### PR TITLE
Disable no-sloppy-imports lint rule

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -11,7 +11,7 @@ jobs:
             run:
                 working-directory: web
 
-        timeout-minutes: 5
+        timeout-minutes: 6
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/web/deno.json
+++ b/web/deno.json
@@ -8,6 +8,11 @@
 		"moduleResolution": "bundler",
 		"skipLibCheck": true
 	},
+	"lint": {
+		"rules": {
+			"no-sloppy-imports": "off"
+		}
+	},
 	"imports": {
 		"react": "https://esm.sh/react@19.2.0?target=es2022",
 		"react-dom": "https://esm.sh/react-dom@19.2.0?target=es2022",


### PR DESCRIPTION
- Add lint configuration to deno.json to disable no-sloppy-imports rule
- Allows cleaner imports without file extensions in TypeScript files
- Resolves IDE warnings while maintaining functionality