### PR TITLE
[FEAT] placeholder dropzones in containers

### DIFF
--- a/web/app/components/CancelOverlay.tsx
+++ b/web/app/components/CancelOverlay.tsx
@@ -36,7 +36,7 @@ export function CancelOverlay({ dismiss }: { dismiss: () => void }) {
 	return (
 		<Fragment>
 			<div
-				className="evy-flex evy-absolute evy-w-full evy-h-full evy-opacity-60"
+				className="evy-flex evy-absolute evy-inset-y-0 evy-w-full evy-opacity-60"
 				style={{
 					backgroundColor:
 						state.type === idle.type
@@ -46,7 +46,7 @@ export function CancelOverlay({ dismiss }: { dismiss: () => void }) {
 			/>
 			<button
 				type="button"
-				className="evy-flex evy-absolute evy-w-full evy-h-full evy-justify-center evy-pt-32 evy-border-none evy-bg-transparent evy-cursor-pointer"
+				className="evy-flex evy-absolute evy-inset-y-0 evy-w-full evy-justify-center evy-pt-32 evy-border-none evy-bg-transparent evy-cursor-pointer"
 				ref={ref}
 				onClick={dismiss}
 			>

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -18,7 +18,7 @@ export function ConfigurationPanel() {
 				configValue,
 			});
 		},
-		[activeRowId, dispatchRow],
+		[activeRowId, dispatchRow]
 	);
 
 	const row = useMemo(
@@ -28,7 +28,7 @@ export function ConfigurationPanel() {
 				?.pages.flatMap((page) => page.rows)
 				.flatMap(EVYRow.getRowsRecursive)
 				.find((r) => r.rowId === activeRowId),
-		[flows, activeFlowId, activeRowId],
+		[flows, activeFlowId, activeRowId]
 	);
 
 	const renderConfiguration = useCallback(
@@ -88,7 +88,7 @@ export function ConfigurationPanel() {
 								updateRowContent(
 									key,
 									e.target.value,
-									configRow.rowId,
+									configRow.rowId
 								);
 							}}
 							className="evy-w-full evy-focus-visible:outline-none"
@@ -98,7 +98,7 @@ export function ConfigurationPanel() {
 				);
 			});
 		},
-		[updateRowContent],
+		[updateRowContent]
 	);
 
 	const configurationElements = row ? renderConfiguration(row) : [];

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -145,12 +145,15 @@ const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 						}`}
 					/>
 				)}
+				{/* biome-ignore lint/a11y/useSemanticElements: This is a drag-and-drop container that requires a div for proper layout */}
 				<div
 					className="evy-flex evy-flex-col evy-w-full evy-relative evy-hover:bg-gray-light"
 					style={{ cursor }}
 					ref={ref}
 					onClick={selectRow}
 					onKeyDown={(e) => e.key === "Enter" && selectRow?.()}
+					role="button"
+					tabIndex={0}
 				>
 					{children}
 				</div>
@@ -244,7 +247,7 @@ export function DraggableRowContainer({
 			hideBefore ? undefined : "before",
 			hideAfter ? undefined : "after",
 		].filter(Boolean) as Array<"before" | "after">;
-	}, [dragging, dropIndicator, previousRowId, nextRowId]);
+	}, [dragging, dropIndicator, previousRowId, nextRowId, showIndicators]);
 
 	// The goal here is to find out which row's dropzone to set the indicator on.
 	const onDragEvent = useCallback(
@@ -386,9 +389,7 @@ export function PlaceholderDropIndicator() {
 			orientation="horizontal"
 		>
 			<div
-				className={
-					verticalDropIndicator + " " + dropIndicatorExpansionBefore
-				}
+				className={`${verticalDropIndicator} ${dropIndicatorExpansionBefore}`}
 			/>
 		</DraggableRowContainer>
 	);

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -26,11 +26,7 @@ import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/el
 import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 
 import { AppContext } from "../registry";
-import {
-	containerDropindicatorId,
-	containerDropindicatorId,
-	EVYRow,
-} from "../rows/EVYRow";
+import { containerDropindicatorId, EVYRow } from "../rows/EVYRow";
 import {
 	dropIndicatorExpansionBefore,
 	dropIndicatorExpansionAfter,

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -134,6 +134,11 @@ const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 			[dropzones, indicators]
 		);
 
+		if (showBefore || showAfter) {
+			console.log("showBefore", showBefore);
+			console.log("showAfter", showAfter);
+		}
+
 		return (
 			<>
 				{showBefore && (

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -26,7 +26,17 @@ import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/el
 import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 
 import { AppContext } from "../registry";
-import { EVYRow } from "../rows/EVYRow";
+import {
+	containerDropindicatorId,
+	containerDropindicatorId,
+	EVYRow,
+} from "../rows/EVYRow";
+import {
+	dropIndicatorExpansionBefore,
+	dropIndicatorExpansionAfter,
+	horizontalDropIndicator,
+	verticalDropIndicator,
+} from "../rows/design-system/dropIndicator";
 
 export type Edge = "top" | "right" | "bottom" | "left";
 
@@ -115,8 +125,8 @@ const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 
 		const indicatorClass = useMemo(() => {
 			return orientation === "vertical"
-				? "evy-v-dropzone evy-w-full evy-rounded-sm"
-				: "evy-h-dropzone evy-min-h-full evy-mt-2 evy-mb-2 evy-rounded-sm";
+				? verticalDropIndicator
+				: horizontalDropIndicator;
 		}, [orientation]);
 
 		const showBefore = useMemo(
@@ -134,7 +144,7 @@ const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 					<div
 						className={`${indicatorClass} ${
 							indicators.includes("before")
-								? "expanded evy-mt-2"
+								? dropIndicatorExpansionBefore
 								: ""
 						}`}
 					/>
@@ -152,7 +162,7 @@ const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 					<div
 						className={`${indicatorClass} ${
 							indicators.includes("after")
-								? "expanded evy-mb-2"
+								? dropIndicatorExpansionAfter
 								: ""
 						}`}
 					/>
@@ -222,13 +232,13 @@ export function DraggableRowContainer({
 		if (!dragging || !dropIndicator) return;
 
 		const hideBefore =
-			(previousRowId && !dropIndicator?.rowId) ||
+			(previousRowId && !dropIndicator.rowId) ||
 			(previousRowId &&
 				dropIndicator.rowId === previousRowId &&
 				dropIndicator.edge !== "bottom");
 		const hideAfter =
 			(nextRowId &&
-				dropIndicator?.rowId &&
+				dropIndicator.rowId &&
 				dropIndicator.rowId !== nextRowId) ||
 			(nextRowId &&
 				dropIndicator.rowId === nextRowId &&
@@ -369,5 +379,25 @@ export function DraggableRowContainer({
 					state.container
 				)}
 		</Fragment>
+	);
+}
+
+export function PlaceholderDropIndicator({
+	orientation = "vertical",
+}: {
+	orientation?: "horizontal" | "vertical";
+}) {
+	return (
+		<DraggableRowContainer
+			key={containerDropindicatorId}
+			rowId={containerDropindicatorId}
+			orientation={orientation}
+		>
+			<div
+				className={
+					verticalDropIndicator + " " + dropIndicatorExpansionBefore
+				}
+			/>
+		</DraggableRowContainer>
 	);
 }

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -382,16 +382,11 @@ export function DraggableRowContainer({
 	);
 }
 
-export function PlaceholderDropIndicator({
-	orientation = "vertical",
-}: {
-	orientation?: "horizontal" | "vertical";
-}) {
+export function PlaceholderDropIndicator() {
 	return (
 		<DraggableRowContainer
 			key={containerDropindicatorId}
 			rowId={containerDropindicatorId}
-			orientation={orientation}
 		>
 			<div
 				className={

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -134,11 +134,6 @@ const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 			[dropzones, indicators]
 		);
 
-		if (showBefore || showAfter) {
-			console.log("showBefore", showBefore);
-			console.log("showAfter", showAfter);
-		}
-
 		return (
 			<>
 				{showBefore && (
@@ -230,7 +225,7 @@ export function DraggableRowContainer({
 	}, [dropIndicator, dragging, rowId, showIndicators]);
 
 	const dropzones = useMemo(() => {
-		if (!dragging || !dropIndicator) return;
+		if (!dragging || !dropIndicator || !showIndicators) return;
 
 		const hideBefore =
 			(previousRowId && !dropIndicator.rowId) ||
@@ -388,6 +383,7 @@ export function PlaceholderDropIndicator() {
 		<DraggableRowContainer
 			key={containerDropindicatorId}
 			rowId={containerDropindicatorId}
+			orientation="horizontal"
 		>
 			<div
 				className={

--- a/web/app/components/RowsPanel.tsx
+++ b/web/app/components/RowsPanel.tsx
@@ -15,7 +15,7 @@ export function RowsPanel() {
 	useEffect(() => {
 		invariant(
 			pageInnerRef.current,
-			"RowsPanel useEffect: pageInnerRef.current is not defined",
+			"RowsPanel useEffect: pageInnerRef.current is not defined"
 		);
 		return combine(
 			dropTargetForElements({
@@ -24,37 +24,32 @@ export function RowsPanel() {
 				canDrop: () => true,
 				onDragStart: () => dispatchDragging({ type: "START_DRAGGING" }),
 				onDrop: () => dispatchDragging({ type: "STOP_DRAGGING" }),
-			}),
+			})
 		);
 	}, [dispatchDragging]);
 
 	return (
-		<div className="evy-flex evy-relative evy-w-full evy-h-full">
+		<div className="evy-flex evy-flex-col evy-relative evy-w-full evy-h-full">
+			<div className="evy-p-4 evy-text-xl evy-font-semibold evy-text-center evy-border-b evy-border-gray evy-bg-white">
+				Rows
+			</div>
 			<div
-				className="evy-flex evy-flex-col evy-w-full"
+				className={`evy-flex evy-flex-col evy-flex-1 evy-gap-2 ${
+					dragging ? "evy-overflow-hidden" : "evy-overflow-y-auto"
+				}`}
 				ref={pageInnerRef}
 			>
-				<div className="evy-p-4 evy-text-xl evy-font-semibold evy-text-center evy-border-b evy-border-gray evy-bg-white">
-					Rows
-				</div>
-				<div className="evy-flex evy-flex-col evy-min-h-full evy-gap-2">
-					{rows.map((row) => (
-						<DraggableRowContainer
-							key={row.rowId}
-							rowId={row.rowId}
-						>
-							{row.row}
-						</DraggableRowContainer>
-					))}
-				</div>
-				{dragging && (
-					<CancelOverlay
-						dismiss={() =>
-							dispatchDragging({ type: "STOP_DRAGGING" })
-						}
-					/>
-				)}
+				{rows.map((row) => (
+					<DraggableRowContainer key={row.rowId} rowId={row.rowId}>
+						{row.row}
+					</DraggableRowContainer>
+				))}
 			</div>
+			{dragging && (
+				<CancelOverlay
+					dismiss={() => dispatchDragging({ type: "STOP_DRAGGING" })}
+				/>
+			)}
 		</div>
 	);
 }

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -125,7 +125,7 @@ function AppContent() {
 						type: ContainerType;
 					};
 				} = {
-					destinationIndex: 0,
+					destinationIndex: destinationPage.rows.length,
 					destinationPageId: destinationPageId,
 				};
 
@@ -179,11 +179,7 @@ function AppContent() {
 							destinationPage.rows.findIndex(
 								(r) => r.rowId === destinationRow.data.rowId
 							);
-						dispatchOptions.destinationIndex =
-							closestEdgeOfTarget === "top" ||
-							closestEdgeOfTarget === "left"
-								? destinationRowIndex
-								: destinationRowIndex + 1;
+						dispatchOptions.destinationIndex = destinationRowIndex;
 					}
 
 					if (destinationContainer) {
@@ -199,8 +195,7 @@ function AppContent() {
 					closestEdgeOfTarget === "left"
 				) {
 					dispatchOptions.destinationIndex =
-						dispatchOptions.destinationIndex ??
-						destinationPage.rows.length;
+						dispatchOptions.destinationIndex - 1;
 				} else if (
 					closestEdgeOfTarget === "bottom" ||
 					closestEdgeOfTarget === "right"

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -140,6 +140,9 @@ function AppContent() {
 					const destinationContainer =
 						destinationRow.data.rowId === containerDropindicatorId
 							? EVYRow.pickContainerRow(
+									// Droptargets is an array returning the rows under the drop cursor,
+									// starting with the placeholder indicator and then the container
+									// we want that container
 									location.current.dropTargets[1].data.rowId,
 									destinationPage.rows
 							  )

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -117,7 +117,7 @@ function AppContent() {
 					"AppContent monitor for elements onDrop: destinationPage is not defined"
 				);
 
-				let dispatchOptions: {
+				const dispatchOptions: {
 					destinationPageId: string;
 					destinationIndex: number;
 					destinationContainer?: {
@@ -232,7 +232,7 @@ function AppContent() {
 				}
 			},
 		});
-	}, [pages, dispatchRow]);
+	}, [pages, dispatchRow, dispatchDragging]);
 
 	return (
 		<>

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -139,7 +139,7 @@ function AppContent() {
 				if (destinationRow) {
 					const destinationContainer =
 						destinationRow.data.rowId === containerDropindicatorId
-							? EVYRow.pickContainerRow(
+							? EVYRow.findContainerById(
 									// Droptargets is an array returning the rows under the drop cursor,
 									// starting with the placeholder indicator and then the container
 									// we want that container
@@ -151,6 +151,9 @@ function AppContent() {
 									destinationPage.rows
 							  );
 
+					// Need to support dropping into nested containers...
+					// right now the destinationContainer is 1 layer deep only,
+					// we need to be able to tell the indexes of every container down
 					if (
 						destinationContainer?.type === "children" &&
 						destinationContainer.container.config.view.content

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -11,7 +11,11 @@ import type { Edge } from "./components/DraggableRowContainer.tsx";
 import { FlowSelector } from "./components/FlowSelector.tsx";
 import { RowsPanel } from "./components/RowsPanel.tsx";
 import { AppContext, AppProvider, type ServerFlow } from "./registry.tsx";
-import { EVYRow } from "./rows/EVYRow.tsx";
+import {
+	containerDropindicatorId,
+	EVYRow,
+	type ContainerType,
+} from "./rows/EVYRow.tsx";
 
 interface DropLocation {
 	current: {
@@ -49,21 +53,19 @@ function AppContent() {
 
 	const pages = useMemo(
 		() => flows.find((flow) => flow.id === activeFlowId)?.pages || [],
-		[flows, activeFlowId],
+		[flows, activeFlowId]
 	);
 
 	useEffect(() => {
 		return monitorForElements({
 			onDrop(args: DropEvent) {
 				const { location, source } = args;
-				if (!location.current.dropTargets.length) {
-					return;
-				}
+				if (!location.current.dropTargets.length) return;
 
 				const rowId = source.data.rowId;
 				invariant(
 					typeof rowId === "string",
-					"AppContent monitor for elements onDrop: rowId is not a string",
+					"AppContent monitor for elements onDrop: rowId is not a string"
 				);
 
 				const sourcePageId =
@@ -72,7 +74,7 @@ function AppContent() {
 					].data.pageId;
 				invariant(
 					typeof sourcePageId === "string",
-					"AppContent monitor for elements onDrop: sourcePageId is not a string",
+					"AppContent monitor for elements onDrop: sourcePageId is not a string"
 				);
 
 				// If the row was dropped on top of another row,
@@ -84,7 +86,7 @@ function AppContent() {
 					];
 				invariant(
 					destinationPageRecord,
-					"AppContent monitor for elements onDrop: destinationPageRecord is not defined",
+					"AppContent monitor for elements onDrop: destinationPageRecord is not defined"
 				);
 
 				const destinationPageId = destinationPageRecord.data
@@ -103,12 +105,24 @@ function AppContent() {
 				}
 
 				const destinationPage = pages.find(
-					(page) => page.id === destinationPageId,
+					(page) => page.id === destinationPageId
 				);
 				invariant(
 					destinationPage,
-					"AppContent monitor for elements onDrop: destinationPage is not defined",
+					"AppContent monitor for elements onDrop: destinationPage is not defined"
 				);
+
+				let dispatchOptions: {
+					destinationPageId: string;
+					destinationIndex: number;
+					destinationContainer?: {
+						rowId: string;
+						type: ContainerType;
+					};
+				} = {
+					destinationIndex: 0,
+					destinationPageId: destinationPageId,
+				};
 
 				// If the row was dropped on top of another row,
 				// dropTargets is an array with [row, ..., page]
@@ -118,43 +132,53 @@ function AppContent() {
 						? location.current.dropTargets[0]
 						: null;
 
-				const destinationContainer =
-					destinationRow &&
-					EVYRow.findContainerOfRow(
-						destinationRow.data.rowId,
-						destinationPage.rows,
-					);
-
 				const closestEdgeOfTarget: Edge | null = destinationRow
 					? extractClosestEdge(destinationRow.data)
 					: null;
 
-				let indexOfTarget = 0;
 				if (destinationRow) {
+					const destinationContainer =
+						destinationRow.data.rowId === containerDropindicatorId
+							? EVYRow.pickContainerRow(
+									location.current.dropTargets[1].data.rowId,
+									destinationPage.rows
+							  )
+							: EVYRow.findContainerOfRow(
+									destinationRow.data.rowId,
+									destinationPage.rows
+							  );
+
 					if (
 						destinationContainer?.type === "children" &&
 						destinationContainer.container.config.view.content
 							.children
 					) {
-						indexOfTarget =
+						dispatchOptions.destinationIndex =
 							destinationContainer.container.config.view.content.children.findIndex(
-								(r) => r.rowId === destinationRow.data.rowId,
+								(r) => r.rowId === destinationRow.data.rowId
 							);
 					} else if (
 						destinationContainer?.type === "child" &&
 						destinationContainer.container.config.view.content.child
 					) {
-						indexOfTarget = 0;
+						dispatchOptions.destinationIndex = 0;
 					} else if (closestEdgeOfTarget && !destinationContainer) {
 						const destinationRowIndex =
 							destinationPage.rows.findIndex(
-								(r) => r.rowId === destinationRow.data.rowId,
+								(r) => r.rowId === destinationRow.data.rowId
 							);
-						indexOfTarget =
+						dispatchOptions.destinationIndex =
 							closestEdgeOfTarget === "top" ||
 							closestEdgeOfTarget === "left"
 								? destinationRowIndex
 								: destinationRowIndex + 1;
+					}
+
+					if (destinationContainer) {
+						dispatchOptions.destinationContainer = {
+							rowId: destinationContainer.container.rowId,
+							type: destinationContainer.type,
+						};
 					}
 				}
 
@@ -162,49 +186,41 @@ function AppContent() {
 					closestEdgeOfTarget === "top" ||
 					closestEdgeOfTarget === "left"
 				) {
-					indexOfTarget =
-						indexOfTarget ?? destinationPage.rows.length;
+					dispatchOptions.destinationIndex =
+						dispatchOptions.destinationIndex ??
+						destinationPage.rows.length;
 				} else if (
 					closestEdgeOfTarget === "bottom" ||
 					closestEdgeOfTarget === "right"
 				) {
-					indexOfTarget = indexOfTarget + 1;
+					dispatchOptions.destinationIndex =
+						dispatchOptions.destinationIndex + 1;
 				} else {
-					indexOfTarget =
-						indexOfTarget ?? destinationPage.rows.length;
+					dispatchOptions.destinationIndex =
+						dispatchOptions.destinationIndex ??
+						destinationPage.rows.length;
 				}
-
-				const baseOptions = {
-					destinationPageId: destinationPageId,
-					destinationIndex: indexOfTarget,
-					destinationContainer: destinationContainer
-						? {
-								rowId: destinationContainer.container.rowId,
-								type: destinationContainer.type,
-							}
-						: undefined,
-				};
 
 				if (sourcePageId === "rows") {
 					dispatchRow({
 						type: "ADD_ROW",
 						newRowId: crypto.randomUUID(),
 						oldRowId: rowId,
-						...baseOptions,
+						...dispatchOptions,
 					});
 				} else if (sourcePageId === destinationPageId) {
 					dispatchRow({
 						type: "MOVE_ROW",
 						rowId,
 						originPageId: sourcePageId,
-						...baseOptions,
+						...dispatchOptions,
 					});
 				} else if (destinationPageId !== sourcePageId) {
 					dispatchRow({
 						type: "MOVE_ROW",
 						rowId,
 						originPageId: sourcePageId,
-						...baseOptions,
+						...dispatchOptions,
 					});
 				}
 			},
@@ -214,7 +230,7 @@ function AppContent() {
 	return (
 		<>
 			<div
-				className="evy-border-r evy-border-gray evy-overflow-y-auto evy-bg-white evy-shadow-subtle"
+				className="evy-border-r evy-border-gray evy-bg-white evy-shadow-subtle"
 				style={{ width: panelWidth }}
 			>
 				<RowsPanel key="rows" />
@@ -246,7 +262,7 @@ function App() {
 
 	return (
 		<AppProvider initialFlows={win?.__TEST_FLOWS__}>
-			<div className="evy-h-screen evy-overflow-hidden">
+			<div className="evy-h-screen evy-overflow-hidden evy-flex evy-flex-col">
 				<div className="evy-border-b evy-border-gray evy-p-2 evy-bg-white evy-flex evy-justify-between evy-items-center">
 					<a href="/">
 						<img className="evy-h-4" src="/logo.svg" alt="EVY" />

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -49,7 +49,8 @@ interface DropEvent {
 const panelWidth = "300px";
 
 function AppContent() {
-	const { flows, activeFlowId, dispatchRow } = useContext(AppContext);
+	const { flows, activeFlowId, dispatchRow, dispatchDragging } =
+		useContext(AppContext);
 
 	const pages = useMemo(
 		() => flows.find((flow) => flow.id === activeFlowId)?.pages || [],
@@ -91,7 +92,11 @@ function AppContent() {
 
 				const destinationPageId = destinationPageRecord.data
 					.pageId as string;
-				if (destinationPageId === "rows" && sourcePageId === "rows") {
+				if (
+					sourcePageId === "rows" &&
+					(!destinationPageId || destinationPageId === "rows")
+				) {
+					dispatchDragging({ type: "STOP_DRAGGING" });
 					return;
 				}
 

--- a/web/app/main.tsx
+++ b/web/app/main.tsx
@@ -151,7 +151,7 @@ function AppContent() {
 					if (
 						destinationContainer?.type === "children" &&
 						destinationContainer.container.config.view.content
-							.children
+							.children?.length
 					) {
 						dispatchOptions.destinationIndex =
 							destinationContainer.container.config.view.content.children.findIndex(
@@ -160,6 +160,7 @@ function AppContent() {
 					} else if (
 						destinationContainer?.type === "child" &&
 						destinationContainer.container.config.view.content.child
+							?.rowId
 					) {
 						dispatchOptions.destinationIndex = 0;
 					} else if (closestEdgeOfTarget && !destinationContainer) {

--- a/web/app/registry.tsx
+++ b/web/app/registry.tsx
@@ -181,7 +181,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 			const rowDataAdd: Row = {
 				...baseRow,
 				rowId: action.newRowId,
-				config: baseRow.config,
+				config: structuredClone(baseRow.config),
 				row: createElement(baseRow, { rowId: action.newRowId }),
 			};
 

--- a/web/app/registry.tsx
+++ b/web/app/registry.tsx
@@ -191,19 +191,20 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 			invariant(page, "PageReducer addRow: page is not defined");
 
 			if (action.destinationContainer) {
-				const destinationRowId = action.destinationContainer.rowId;
-				const stepsToDestinationContainer = page.rows
-					.map((row, index) => {
-						if (row.rowId === destinationRowId) {
-							return [index];
-						}
-						const match = EVYRow.traverseToRowAndGetPath(
-							row,
-							destinationRowId
-						);
-						if (match.length > 0) return [index, ...match];
-					})
-					.find((s) => s !== undefined);
+			const destinationRowId = action.destinationContainer.rowId;
+			const stepsToDestinationContainer = page.rows
+				.flatMap((row, index) => {
+					if (row.rowId === destinationRowId) {
+						return [[index]];
+					}
+					const match = EVYRow.traverseToRowAndGetPath(
+						row,
+						destinationRowId
+					);
+					if (match.length > 0) return [[index, ...match]];
+					return [];
+				})
+				.find((s) => s !== undefined);
 
 				invariant(
 					stepsToDestinationContainer?.length,

--- a/web/app/registry.tsx
+++ b/web/app/registry.tsx
@@ -191,20 +191,20 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 			invariant(page, "PageReducer addRow: page is not defined");
 
 			if (action.destinationContainer) {
-			const destinationRowId = action.destinationContainer.rowId;
-			const stepsToDestinationContainer = page.rows
-				.flatMap((row, index) => {
-					if (row.rowId === destinationRowId) {
-						return [[index]];
-					}
-					const match = EVYRow.traverseToRowAndGetPath(
-						row,
-						destinationRowId
-					);
-					if (match.length > 0) return [[index, ...match]];
-					return [];
-				})
-				.find((s) => s !== undefined);
+				const destinationRowId = action.destinationContainer.rowId;
+				const stepsToDestinationContainer = page.rows
+					.flatMap((row, index) => {
+						if (row.rowId === destinationRowId) {
+							return [[index]];
+						}
+						const match = EVYRow.traverseToRowAndGetPath(
+							row,
+							destinationRowId
+						);
+						if (match.length > 0) return [[index, ...match]];
+						return [];
+					})
+					.find((s) => s !== undefined);
 
 				invariant(
 					stepsToDestinationContainer?.length,
@@ -286,17 +286,82 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 			});
 		}
 		case "REMOVE_ROW": {
-			const newPages = flow.pages.map((page) =>
-				page.id === action.pageId
-					? {
-							...page,
-							rows: page.rows.filter(
-								(r) => r.rowId !== action.rowId
-							),
-					  }
-					: page
-			);
-			return updateState({ updatedPages: newPages });
+			const removeRowFromChildren = (
+				row: Row,
+				targetRowId: string
+			): Row => {
+				if (row.config.view.content.children) {
+					const filteredChildren =
+						row.config.view.content.children.filter(
+							(child) => child.rowId !== targetRowId
+						);
+					const updatedChildren = filteredChildren.map((child) =>
+						removeRowFromChildren(child, targetRowId)
+					);
+					return {
+						...row,
+						config: {
+							...row.config,
+							view: {
+								...row.config.view,
+								content: {
+									...row.config.view.content,
+									children: updatedChildren,
+								},
+							},
+						},
+					};
+				}
+				if (row.config.view.content.child?.rowId === targetRowId) {
+					return {
+						...row,
+						config: {
+							...row.config,
+							view: {
+								...row.config.view,
+								content: {
+									...row.config.view.content,
+									child: undefined,
+								},
+							},
+						},
+					};
+				}
+				if (row.config.view.content.child) {
+					return {
+						...row,
+						config: {
+							...row.config,
+							view: {
+								...row.config.view,
+								content: {
+									...row.config.view.content,
+									child: removeRowFromChildren(
+										row.config.view.content.child,
+										targetRowId
+									),
+								},
+							},
+						},
+					};
+				}
+				return row;
+			};
+
+			return updateState({
+				updatedPages: flow.pages.map((page) =>
+					page.id === action.pageId
+						? {
+								...page,
+								rows: page.rows
+									.filter((r) => r.rowId !== action.rowId)
+									.map((r) =>
+										removeRowFromChildren(r, action.rowId)
+									),
+						  }
+						: page
+				),
+			});
 		}
 		case "UPDATE_ROW": {
 			const splitValue = action.configValue.split(",");

--- a/web/app/registry.tsx
+++ b/web/app/registry.tsx
@@ -157,9 +157,9 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 						flows: state.flows.map((f) =>
 							f.id === state.activeFlowId
 								? { ...f, pages: updatedPages }
-								: f,
+								: f
 						),
-					}
+				  }
 				: {}),
 			...(activeFlowId && activeFlowId !== state.activeFlowId
 				? { activeFlowId }
@@ -186,19 +186,20 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 			};
 
 			const page = flow.pages.find(
-				(p) => p.id === action.destinationPageId,
+				(p) => p.id === action.destinationPageId
 			);
 			invariant(page, "PageReducer addRow: page is not defined");
 
 			if (action.destinationContainer) {
+				const destinationRowId = action.destinationContainer.rowId;
 				const stepsToDestinationContainer = page.rows
 					.map((row, index) => {
-						if (row.rowId === action.destinationContainer?.rowId) {
+						if (row.rowId === destinationRowId) {
 							return [index];
 						}
 						const match = EVYRow.traverseToRowAndGetPath(
 							row,
-							action.destinationContainer?.rowId,
+							destinationRowId
 						);
 						if (match.length > 0) return [index, ...match];
 					})
@@ -206,7 +207,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 
 				invariant(
 					stepsToDestinationContainer?.length,
-					"PageReducer addRow: stepsToDestinationContainer is not defined",
+					"PageReducer addRow: stepsToDestinationContainer is not defined"
 				);
 
 				let path = page.rows[stepsToDestinationContainer[0] as number];
@@ -218,7 +219,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 								const child = acc.config.view.content.child;
 								invariant(
 									child,
-									"PageReducer addRow: child is not defined",
+									"PageReducer addRow: child is not defined"
 								);
 								return child;
 							}
@@ -226,13 +227,13 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 						}, path);
 				}
 
-				if (action.destinationContainer?.type === "child") {
+				if (action.destinationContainer.type === "child") {
 					path.config.view.content.child = rowDataAdd;
-				} else if (action.destinationContainer?.type === "children") {
+				} else if (action.destinationContainer.type === "children") {
 					path.config.view.content.children?.splice(
 						action.destinationIndex,
 						0,
-						rowDataAdd,
+						rowDataAdd
 					);
 				}
 			} else {
@@ -289,10 +290,10 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 					? {
 							...page,
 							rows: page.rows.filter(
-								(r) => r.rowId !== action.rowId,
+								(r) => r.rowId !== action.rowId
 							),
-						}
-					: page,
+					  }
+					: page
 			);
 			return updateState({ updatedPages: newPages });
 		}
@@ -303,7 +304,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 				row: Row,
 				targetRowId: string,
 				configId: string,
-				configValue: string,
+				configValue: string
 			): Row | null => {
 				if (row.rowId === targetRowId) {
 					return {
@@ -332,12 +333,12 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 									child,
 									targetRowId,
 									configId,
-									configValue,
-								) || child,
+									configValue
+								) || child
 						);
 					const childUpdated = updatedChildren.some(
 						(child, index) =>
-							child !== row.config.view.content.children?.[index],
+							child !== row.config.view.content.children?.[index]
 					);
 					if (childUpdated) {
 						return {
@@ -361,7 +362,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 						row.config.view.content.child,
 						targetRowId,
 						configId,
-						configValue,
+						configValue
 					);
 					if (updatedChild) {
 						return {
@@ -385,7 +386,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 
 			const newPages = flow.pages.map((page) => {
 				const hasAtTopLevel = page.rows.some(
-					(r) => r.rowId === action.rowId,
+					(r) => r.rowId === action.rowId
 				);
 				if (hasAtTopLevel) {
 					const newRows = page.rows.map((row) => {
@@ -419,8 +420,8 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 							row,
 							action.rowId,
 							action.configId,
-							action.configValue,
-						) || row,
+							action.configValue
+						) || row
 				);
 				return { ...page, rows: newRows };
 			});
@@ -434,7 +435,7 @@ const pageReducer = (state: AppState, action: RowAction): AppState => {
 		}
 		case "SET_ACTIVE_ROW": {
 			const page = flow.pages.find((page) =>
-				page.rows.some((row) => row.rowId === action.rowId),
+				page.rows.some((row) => row.rowId === action.rowId)
 			);
 			invariant(page, `Page not found for row ${action.rowId}`);
 
@@ -457,7 +458,7 @@ type DraggingAction =
 	  };
 const draggingReducer = (
 	state: DraggingState,
-	action: DraggingAction,
+	action: DraggingAction
 ): DraggingState => {
 	switch (action.type) {
 		case "START_DRAGGING":
@@ -494,7 +495,7 @@ type DropIndicatorAction =
 
 const dropIndicatorReducer = (
 	state: DropIndicatorState,
-	action: DropIndicatorAction,
+	action: DropIndicatorAction
 ): DropIndicatorState => {
 	switch (action.type) {
 		case "SET_INDICATOR_ROW":
@@ -547,7 +548,7 @@ export const AppContext = createContext<{
 function decodeRow(row: ServerRow): Row {
 	const rowId = crypto.randomUUID();
 	const baseRow = baseRows.find(
-		(baseRow) => row.type === baseRow.config.type,
+		(baseRow) => row.type === baseRow.config.type
 	);
 	if (!baseRow) {
 		return {
@@ -570,7 +571,7 @@ function decodeRow(row: ServerRow): Row {
 							? row.view.content.title
 							: "Invalid title",
 					children: row.view.content.children?.map(
-						(child: ServerRow) => decodeRow(child),
+						(child: ServerRow) => decodeRow(child)
 					),
 					child: row.view.content.child
 						? decodeRow(row.view.content.child)
@@ -618,7 +619,7 @@ export function AppProvider({
 	const [dragging, dispatchDragging] = useReducer(draggingReducer, false);
 	const [dropIndicator, dispatchDropIndicator] = useReducer(
 		dropIndicatorReducer,
-		null,
+		null
 	);
 
 	return (

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -126,10 +126,8 @@ export abstract class EVYRow extends React.Component<{
 
 		const child = row.config.view.content.child;
 		if (child) {
-			return [
-				"child",
-				...EVYRow.traverseToRowAndGetPath(child, targetRowId),
-			];
+			const path = EVYRow.traverseToRowAndGetPath(child, targetRowId);
+			if (path.length > 0) return ["child", ...path];
 		}
 
 		const children = row.config.view.content.children;

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -109,10 +109,10 @@ export abstract class EVYRow extends React.Component<{
 		for (const row of rows) {
 			if (row.rowId !== rowId) continue;
 
-			const canHaveChild = row.config.view.content.child;
+			const canHaveChild = "child" in row.config.view.content;
 			if (canHaveChild) return { container: row, type: "child" };
 
-			const canHaveChildren = row.config.view.content.children;
+			const canHaveChildren = "children" in row.config.view.content;
 			if (canHaveChildren) return { container: row, type: "children" };
 		}
 		return null;

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -46,6 +46,8 @@ export interface RowConfig {
 
 export type ContainerType = "child" | "children";
 
+export const containerDropindicatorId = "placeholder";
+
 export abstract class EVYRow extends React.Component<{
 	rowId: string;
 }> {
@@ -61,15 +63,15 @@ export abstract class EVYRow extends React.Component<{
 				: []),
 			...(row.config.view.content.children
 				? row.config.view.content.children.flatMap(
-						EVYRow.getRowsRecursive,
-					)
+						EVYRow.getRowsRecursive
+				  )
 				: []),
 		].filter((row) => row !== undefined);
 	}
 
 	static findContainerOfRow(
 		rowId: string,
-		rows: Row[],
+		rows: Row[]
 	): { container: Row; type: ContainerType } | null {
 		for (const row of rows) {
 			if (row.rowId === rowId) return null;
@@ -78,7 +80,7 @@ export abstract class EVYRow extends React.Component<{
 			if (childMatches) return { container: row, type: "child" };
 
 			const childrenMatch = row.config.view.content.children?.some(
-				(r) => r.rowId === rowId,
+				(r) => r.rowId === rowId
 			);
 			if (childrenMatch) return { container: row, type: "children" };
 
@@ -92,7 +94,7 @@ export abstract class EVYRow extends React.Component<{
 			if (row.config.view.content.children) {
 				const childrenOfChildren = EVYRow.findContainerOfRow(
 					rowId,
-					row.config.view.content.children,
+					row.config.view.content.children
 				);
 				if (childrenOfChildren) return childrenOfChildren;
 			}
@@ -100,9 +102,25 @@ export abstract class EVYRow extends React.Component<{
 		return null;
 	}
 
+	static pickContainerRow(
+		rowId: string,
+		rows: Row[]
+	): { container: Row; type: ContainerType } | null {
+		for (const row of rows) {
+			if (row.rowId !== rowId) continue;
+
+			const canHaveChild = row.config.view.content.child;
+			if (canHaveChild) return { container: row, type: "child" };
+
+			const canHaveChildren = row.config.view.content.children;
+			if (canHaveChildren) return { container: row, type: "children" };
+		}
+		return null;
+	}
+
 	static traverseToRowAndGetPath(
 		row: Row,
-		targetRowId: string,
+		targetRowId: string
 	): Array<number | "child"> {
 		if (row.rowId === targetRowId) return [];
 
@@ -131,7 +149,7 @@ export abstract class EVYRow extends React.Component<{
 			<AppContext.Consumer>
 				{({ rows, flows, activeFlowId }) => {
 					const baseRow = rows.find(
-						(r) => r.rowId === this.props.rowId,
+						(r) => r.rowId === this.props.rowId
 					);
 					if (baseRow) return this.renderContent(baseRow);
 

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -102,18 +102,33 @@ export abstract class EVYRow extends React.Component<{
 		return null;
 	}
 
-	static pickContainerRow(
+	static findContainerById(
 		rowId: string,
 		rows: Row[]
 	): { container: Row; type: ContainerType } | null {
 		for (const row of rows) {
-			if (row.rowId !== rowId) continue;
+			if ("child" in row.config.view.content && row.rowId === rowId) {
+				return { container: row, type: "child" };
+			}
 
-			const canHaveChild = "child" in row.config.view.content;
-			if (canHaveChild) return { container: row, type: "child" };
+			if ("children" in row.config.view.content && row.rowId === rowId) {
+				return { container: row, type: "children" };
+			}
 
-			const canHaveChildren = "children" in row.config.view.content;
-			if (canHaveChildren) return { container: row, type: "children" };
+			if (row.config.view.content.child) {
+				const child = EVYRow.findContainerById(rowId, [
+					row.config.view.content.child,
+				]);
+				if (child) return child;
+			}
+
+			if (row.config.view.content.children) {
+				const children = EVYRow.findContainerById(
+					rowId,
+					row.config.view.content.children
+				);
+				if (children) return children;
+			}
 		}
 		return null;
 	}

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -140,7 +140,7 @@ export abstract class EVYRow extends React.Component<{
 		if (row.rowId === targetRowId) return [];
 
 		const child = row.config.view.content.child;
-		if (child) {
+		if (child?.rowId === targetRowId) {
 			const path = EVYRow.traverseToRowAndGetPath(child, targetRowId);
 			if (path.length > 0) return ["child", ...path];
 		}

--- a/web/app/rows/container/ColumnContainerRow.tsx
+++ b/web/app/rows/container/ColumnContainerRow.tsx
@@ -38,7 +38,7 @@ export default class ColumnContainerRow extends EVYRow {
 						{child.row}
 					</DraggableRowContainer>
 			  ))
-			: // We don't want to show dropzone in row list
+			: // We don't want to show dropzone in rows panel
 			  row.rowId !== this.constructor.name && (
 					<PlaceholderDropIndicator />
 			  );

--- a/web/app/rows/container/ColumnContainerRow.tsx
+++ b/web/app/rows/container/ColumnContainerRow.tsx
@@ -40,7 +40,7 @@ export default class ColumnContainerRow extends EVYRow {
 			  ))
 			: // We don't want to show dropzone in row list
 			  row.rowId !== this.constructor.name && (
-					<PlaceholderDropIndicator orientation="horizontal" />
+					<PlaceholderDropIndicator />
 			  );
 
 		return (

--- a/web/app/rows/container/ColumnContainerRow.tsx
+++ b/web/app/rows/container/ColumnContainerRow.tsx
@@ -1,4 +1,7 @@
-import { DraggableRowContainer } from "../../components/DraggableRowContainer";
+import {
+	DraggableRowContainer,
+	PlaceholderDropIndicator,
+} from "../../components/DraggableRowContainer";
 import { EVYRow, type Row, type RowConfig } from "../EVYRow";
 
 export default class ColumnContainerRow extends EVYRow {
@@ -15,29 +18,35 @@ export default class ColumnContainerRow extends EVYRow {
 	renderContent(row: Row) {
 		const rows = row.config.view.content.children;
 		const lastIndex = rows && rows.length > 0 ? rows.length - 1 : 0;
+
+		const childrenElements = rows?.length
+			? rows.map((child, index) => (
+					<DraggableRowContainer
+						key={child.rowId}
+						rowId={child.rowId}
+						orientation="horizontal"
+						showIndicators
+						previousRowId={
+							index > 0 ? rows[index - 1].rowId : undefined
+						}
+						nextRowId={
+							index < lastIndex
+								? rows[index + 1].rowId
+								: undefined
+						}
+					>
+						{child.row}
+					</DraggableRowContainer>
+			  ))
+			: // We don't want to show dropzone in row list
+			  row.rowId !== this.constructor.name && (
+					<PlaceholderDropIndicator orientation="horizontal" />
+			  );
+
 		return (
 			<div className="evy-p-2">
 				<p>{row.config.view.content.title}</p>
-				<div className="evy-flex">
-					{rows?.map((child, index) => (
-						<DraggableRowContainer
-							key={child.rowId}
-							rowId={child.rowId}
-							orientation="horizontal"
-							showIndicators
-							previousRowId={
-								index > 0 ? rows[index - 1].rowId : undefined
-							}
-							nextRowId={
-								index < lastIndex
-									? rows[index + 1].rowId
-									: undefined
-							}
-						>
-							{child.row}
-						</DraggableRowContainer>
-					))}
-				</div>
+				<div className="evy-flex">{childrenElements}</div>
 			</div>
 		);
 	}

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -1,4 +1,7 @@
-import { DraggableRowContainer } from "../../components/DraggableRowContainer";
+import {
+	DraggableRowContainer,
+	PlaceholderDropIndicator,
+} from "../../components/DraggableRowContainer";
 import { EVYRow, type Row, type RowConfig } from "../EVYRow";
 
 export default class ListContainerRow extends EVYRow {
@@ -16,28 +19,33 @@ export default class ListContainerRow extends EVYRow {
 		const rows = row.config.view.content.children;
 		const lastIndex = rows && rows.length > 0 ? rows.length - 1 : 0;
 
+		const childrenElements = rows?.length
+			? rows.map((child, index) => (
+					<DraggableRowContainer
+						key={child.rowId}
+						rowId={child.rowId}
+						showIndicators
+						previousRowId={
+							index > 0 ? rows[index - 1].rowId : undefined
+						}
+						nextRowId={
+							index < lastIndex
+								? rows[index + 1].rowId
+								: undefined
+						}
+					>
+						{child.row}
+					</DraggableRowContainer>
+			  ))
+			: // We don't want to show dropzone in row list
+			  row.rowId !== this.constructor.name && (
+					<PlaceholderDropIndicator orientation="vertical" />
+			  );
+
 		return (
 			<div className="evy-p-2">
 				<p>{row.config.view.content.title}</p>
-				<div className="evy-flex evy-flex-col">
-					{rows?.map((child, index) => (
-						<DraggableRowContainer
-							key={child.rowId}
-							rowId={child.rowId}
-							showIndicators
-							previousRowId={
-								index > 0 ? rows[index - 1].rowId : undefined
-							}
-							nextRowId={
-								index < lastIndex
-									? rows[index + 1].rowId
-									: undefined
-							}
-						>
-							{child.row}
-						</DraggableRowContainer>
-					))}
-				</div>
+				<div className="evy-flex evy-flex-col">{childrenElements}</div>
 			</div>
 		);
 	}

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -38,8 +38,7 @@ export default class ListContainerRow extends EVYRow {
 					</DraggableRowContainer>
 			  ))
 			: // We don't want to show dropzone in row list
-			  row.rowId !== this.constructor.name && (
-					<PlaceholderDropIndicator orientation="vertical" />
+			  row.rowId !== this.constructor.name && <PlaceholderDropIndicator />
 			  );
 
 		return (

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -37,7 +37,7 @@ export default class ListContainerRow extends EVYRow {
 						{child.row}
 					</DraggableRowContainer>
 			  ))
-			: // We don't want to show dropzone in row list
+			: // We don't want to show dropzone in rows panel
 			  row.rowId !== this.constructor.name && (
 					<PlaceholderDropIndicator />
 			  );

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -38,7 +38,8 @@ export default class ListContainerRow extends EVYRow {
 					</DraggableRowContainer>
 			  ))
 			: // We don't want to show dropzone in row list
-			  row.rowId !== this.constructor.name && <PlaceholderDropIndicator />
+			  row.rowId !== this.constructor.name && (
+					<PlaceholderDropIndicator />
 			  );
 
 		return (

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -1,4 +1,7 @@
-import { DraggableRowContainer } from "../../components/DraggableRowContainer";
+import {
+	DraggableRowContainer,
+	PlaceholderDropIndicator,
+} from "../../components/DraggableRowContainer";
 import { EVYRow, type Row, type RowConfig } from "../EVYRow";
 
 interface SelectSegmentContainerState {
@@ -22,6 +25,19 @@ export default class SelectSegmentContainerRow extends EVYRow {
 	renderContent(row: Row) {
 		const segments = row.config.view.content.segments as string[];
 		const children = row.config.view.content.children as Row[];
+
+		const childrenElements = children.length ? (
+			<DraggableRowContainer
+				rowId={children[this.state.selectedTab].rowId}
+			>
+				{children[this.state.selectedTab].row}
+			</DraggableRowContainer>
+		) : (
+			// We don't want to show dropzone in row list
+			row.rowId !== this.constructor.name && (
+				<PlaceholderDropIndicator orientation="vertical" />
+			)
+		);
 
 		return (
 			<div className="evy-p-2">
@@ -52,13 +68,7 @@ export default class SelectSegmentContainerRow extends EVYRow {
 						</button>
 					))}
 				</div>
-				{children[this.state.selectedTab] && (
-					<DraggableRowContainer
-						rowId={children[this.state.selectedTab].rowId}
-					>
-						{children[this.state.selectedTab].row}
-					</DraggableRowContainer>
-				)}
+				{childrenElements}
 			</div>
 		);
 	}

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -33,7 +33,7 @@ export default class SelectSegmentContainerRow extends EVYRow {
 				{children[this.state.selectedTab].row}
 			</DraggableRowContainer>
 		) : (
-			// We don't want to show dropzone in row list
+			// We don't want to show dropzone in rows panel
 			row.rowId !== this.constructor.name && <PlaceholderDropIndicator />
 		);
 

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -34,9 +34,7 @@ export default class SelectSegmentContainerRow extends EVYRow {
 			</DraggableRowContainer>
 		) : (
 			// We don't want to show dropzone in row list
-			row.rowId !== this.constructor.name && (
-				<PlaceholderDropIndicator orientation="vertical" />
-			)
+			row.rowId !== this.constructor.name && <PlaceholderDropIndicator />
 		);
 
 		return (

--- a/web/app/rows/container/SheetContainerRow.tsx
+++ b/web/app/rows/container/SheetContainerRow.tsx
@@ -22,7 +22,7 @@ export default class SheetContainerRow extends EVYRow {
 				{row.config.view.content.child.row}
 			</DraggableRowContainer>
 		) : (
-			// We don't want to show dropzone in row list
+			// We don't want to show dropzone in rows panel
 			row.rowId !== this.constructor.name && <PlaceholderDropIndicator />
 		);
 		return (

--- a/web/app/rows/container/SheetContainerRow.tsx
+++ b/web/app/rows/container/SheetContainerRow.tsx
@@ -1,4 +1,7 @@
-import { DraggableRowContainer } from "../../components/DraggableRowContainer";
+import {
+	DraggableRowContainer,
+	PlaceholderDropIndicator,
+} from "../../components/DraggableRowContainer";
 import { EVYRow, type Row, type RowConfig } from "../EVYRow";
 
 export default class SheetContainerRow extends EVYRow {
@@ -13,18 +16,20 @@ export default class SheetContainerRow extends EVYRow {
 	};
 
 	renderContent(row: Row) {
+		const childElement = row.config.view.content.child ? (
+			<DraggableRowContainer rowId={row.config.view.content.child.rowId}>
+				{row.config.view.content.child.row}
+			</DraggableRowContainer>
+		) : (
+			// We don't want to show dropzone in row list
+			row.rowId !== this.constructor.name && (
+				<PlaceholderDropIndicator orientation="horizontal" />
+			)
+		);
 		return (
 			<div className="evy-p-2">
 				<p>{row.config.view.content.title}</p>
-				<div className="evy-flex evy-gap-2">
-					{row.config.view.content.child && (
-						<DraggableRowContainer
-							rowId={row.config.view.content.child.rowId}
-						>
-							{row.config.view.content.child.row}
-						</DraggableRowContainer>
-					)}
-				</div>
+				<div className="evy-flex evy-gap-2">{childElement}</div>
 			</div>
 		);
 	}

--- a/web/app/rows/container/SheetContainerRow.tsx
+++ b/web/app/rows/container/SheetContainerRow.tsx
@@ -10,6 +10,7 @@ export default class SheetContainerRow extends EVYRow {
 		view: {
 			content: {
 				title: "Sheet container row title",
+				child: undefined,
 				children: [],
 			},
 		},

--- a/web/app/rows/container/SheetContainerRow.tsx
+++ b/web/app/rows/container/SheetContainerRow.tsx
@@ -23,9 +23,7 @@ export default class SheetContainerRow extends EVYRow {
 			</DraggableRowContainer>
 		) : (
 			// We don't want to show dropzone in row list
-			row.rowId !== this.constructor.name && (
-				<PlaceholderDropIndicator orientation="horizontal" />
-			)
+			row.rowId !== this.constructor.name && <PlaceholderDropIndicator />
 		);
 		return (
 			<div className="evy-p-2">

--- a/web/app/rows/design-system/Input.tsx
+++ b/web/app/rows/design-system/Input.tsx
@@ -14,7 +14,7 @@ export default function Input({
 	return (
 		<input
 			type="text"
-			className={`evy-w-full evy-box-sizing-border evy-text-sm ${border} evy-focus-visible\:outline-none ${offsetClass}`}
+			className={`evy-w-full evy-box-sizing-border evy-text-sm ${border} evy-focus-visible:outline-none ${offsetClass}`}
 			required
 			value={value}
 			placeholder={placeholder}

--- a/web/app/rows/design-system/TextArea.tsx
+++ b/web/app/rows/design-system/TextArea.tsx
@@ -11,7 +11,7 @@ export default function TextArea({
 		<textarea
 			id="message"
 			rows={4}
-			className={`evy-block evy-box-sizing-border evy-p-2 evy-w-full evy-text-sm ${border} evy-focus-visible\:outline-none evy-resize-none`}
+			className={`evy-block evy-box-sizing-border evy-p-2 evy-w-full evy-text-sm ${border} evy-focus-visible:outline-none evy-resize-none`}
 			placeholder={placeholder}
 			value={value}
 		/>

--- a/web/app/rows/design-system/dropIndicator.ts
+++ b/web/app/rows/design-system/dropIndicator.ts
@@ -1,0 +1,7 @@
+export const verticalDropIndicator = "evy-v-dropzone evy-w-full evy-rounded-sm";
+
+export const horizontalDropIndicator =
+	"evy-h-dropzone evy-min-h-full evy-mt-2 evy-mb-2 evy-rounded-sm";
+
+export const dropIndicatorExpansionBefore = "expanded evy-mt-2";
+export const dropIndicatorExpansionAfter = "expanded evy-mb-2";

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,8 +1,6 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-	"organizeImports": {
-		"enabled": false
-	},
+	"$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "off" } } },
 	"formatter": {
 		"enabled": false
 	},
@@ -13,6 +11,6 @@
 		}
 	},
 	"files": {
-		"ignore": ["dist/**", "node_modules/**"]
+		"includes": ["**", "!**/dist", "!**/node_modules"]
 	}
 }

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,20 +5,20 @@
     "": {
       "name": "evy-web",
       "dependencies": {
-        "@atlaskit/pragmatic-drag-and-drop": "^1.7.7",
-        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^2.1.2",
-        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
-        "@atlaskit/primitives": "^14.15.5",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3",
-        "tiny-invariant": "^1.3.3",
+        "@atlaskit/pragmatic-drag-and-drop": "latest",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "latest",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "latest",
+        "@atlaskit/primitives": "latest",
+        "react": "latest",
+        "react-dom": "latest",
+        "tiny-invariant": "latest",
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
-        "@playwright/test": "^1.57.0",
-        "@types/bun": "^1.3.5",
-        "@types/react": "^19.2.7",
-        "@types/react-dom": "^19.2.3",
+        "@biomejs/biome": "latest",
+        "@playwright/test": "latest",
+        "@types/bun": "latest",
+        "@types/react": "latest",
+        "@types/react-dom": "latest",
       },
     },
   },
@@ -31,7 +31,7 @@
 
     "@atlaskit/atlassian-context": ["@atlaskit/atlassian-context@0.6.0", "", { "dependencies": { "@babel/runtime": "^7.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-TjaV1OIjP8DaOyaqzPI5OkYvVckn3hYwE92v8RcdnpOiMKI0taedg1sLXD7x0nPx5MtXPmCJNNVJJprDN7pmxQ=="],
 
-    "@atlaskit/css": ["@atlaskit/css@0.14.4", "", { "dependencies": { "@atlaskit/tokens": "^6.4.0", "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.3" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-0RViwbSzefiKhVgSrnUKY7Gd/Qyi11wUpL0cam0y2zuu4XM2uZnUC4rDppTIwOkU+WaugczQ3YWLKP8gIjx4gQ=="],
+    "@atlaskit/css": ["@atlaskit/css@0.19.0", "", { "dependencies": { "@atlaskit/tokens": "^9.0.0", "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.6" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-r/3358oRvTZMULiSmtQhOvMnM7rkT4Z1k3U8gvYVPLgbOduklNhXk2TghUViOx/LHO1urRMtg7efJ4pojVquCQ=="],
 
     "@atlaskit/ds-lib": ["@atlaskit/ds-lib@5.3.0", "", { "dependencies": { "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "bind-event-listener": "^3.0.0", "react-uid": "^2.2.0", "tiny-invariant": "^1.2.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-j3DLHqBACSJsG3XqSgCIwZqvJhYkpSC8i+24n/JYCRjIxYEJMsuSXOtdeu0qBajREwgzmAFP6AVfVZh1zAWG/A=="],
 
@@ -47,9 +47,9 @@
 
     "@atlaskit/pragmatic-drag-and-drop-hitbox": ["@atlaskit/pragmatic-drag-and-drop-hitbox@1.1.0", "", { "dependencies": { "@atlaskit/pragmatic-drag-and-drop": "^1.6.0", "@babel/runtime": "^7.0.0" } }, "sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg=="],
 
-    "@atlaskit/primitives": ["@atlaskit/primitives@14.15.5", "", { "dependencies": { "@atlaskit/analytics-next": "^11.1.0", "@atlaskit/app-provider": "^3.2.0", "@atlaskit/css": "^0.14.0", "@atlaskit/ds-lib": "^5.1.0", "@atlaskit/interaction-context": "^3.1.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@atlaskit/tokens": "^6.4.0", "@atlaskit/visually-hidden": "^3.0.0", "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.3", "@emotion/react": "^11.7.1", "@emotion/serialize": "^1.1.0", "bind-event-listener": "^3.0.0", "tiny-invariant": "^1.2.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-t0ifneO2qr1meukYFMvLqJmRRQeWYBqopAQtksAYXcagt2rKNxuRaqiTAja7j3AP3SLgzP8tX2WQ0/9AebFJeg=="],
+    "@atlaskit/primitives": ["@atlaskit/primitives@17.0.0", "", { "dependencies": { "@atlaskit/analytics-next": "^11.1.0", "@atlaskit/app-provider": "^3.2.0", "@atlaskit/css": "^0.19.0", "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/interaction-context": "^3.1.0", "@atlaskit/tokens": "^9.0.0", "@atlaskit/visually-hidden": "^3.0.0", "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.6", "@emotion/react": "^11.7.1", "@emotion/serialize": "^1.1.0", "bind-event-listener": "^3.0.0", "tiny-invariant": "^1.2.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-V8uh2T7Pg70YhD/KJfLztqRTh2nZRbWhHdBLp3jHmowzg76UN5tVntrkYlVyIBGFPdtbUbuFyxAA5vxxBJClZQ=="],
 
-    "@atlaskit/tokens": ["@atlaskit/tokens@6.5.0", "", { "dependencies": { "@atlaskit/ds-lib": "^5.1.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-JQU5nic5v8B2NBs6Sy3H1gxBvNq4zUygbx2Ssntf1RghBBWnnYZa1eaF2HpqjeFOJ5JNNgs70ukPT1VcqI1RYw=="],
+    "@atlaskit/tokens": ["@atlaskit/tokens@9.0.0", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-PybCOqn2NnifV3RL/t4PQEsK2iGDnTH+83Kr2RUJvOVBMPwwuxCnwC1h+OupC/ripgcUp3Q2/vyUORERaGoBTw=="],
 
     "@atlaskit/visually-hidden": ["@atlaskit/visually-hidden@3.0.4", "", { "dependencies": { "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.6" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-eB0i/TvjcBbn4f87evNC6IedksiNFUA/K7VhWHzziPcFsOQfYsV0RX+bcN8hhrBIe8c6t6fhEqtZWD6ZxbqhXQ=="],
 
@@ -75,23 +75,23 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
 
     "@compiled/react": ["@compiled/react@0.18.6", "", { "dependencies": { "csstype": "^3.1.3" }, "peerDependencies": { "react": ">= 16.12.0" } }, "sha512-Mt6sJOwykeoToEBFbOUNR4xABi2gOr/+X5QSGqGEYiCBMh+XPDAclG2UX94zveiYJXO4AUJIQBCVwa4/lwPMBA=="],
 
@@ -131,13 +131,13 @@
 
     "@statsig/js-client": ["@statsig/js-client@3.31.0", "", { "dependencies": { "@statsig/client-core": "3.31.0" } }, "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g=="],
 
-    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
-    "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
+    "@types/react": ["@types/react@19.2.8", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
@@ -145,7 +145,7 @@
 
     "bind-event-listener": ["bind-event-listener@3.0.0", "", {}, "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q=="],
 
-    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -240,9 +240,5 @@
     "use-memo-one": ["use-memo-one@1.1.3", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0" } }, "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ=="],
 
     "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
-
-    "@atlaskit/app-provider/@atlaskit/css": ["@atlaskit/css@0.19.0", "", { "dependencies": { "@atlaskit/tokens": "^9.0.0", "@babel/runtime": "^7.0.0", "@compiled/react": "^0.18.6" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-r/3358oRvTZMULiSmtQhOvMnM7rkT4Z1k3U8gvYVPLgbOduklNhXk2TghUViOx/LHO1urRMtg7efJ4pojVquCQ=="],
-
-    "@atlaskit/app-provider/@atlaskit/tokens": ["@atlaskit/tokens@9.0.0", "", { "dependencies": { "@atlaskit/ds-lib": "^5.3.0", "@atlaskit/platform-feature-flags": "^1.1.0", "@babel/runtime": "^7.0.0", "@babel/traverse": "^7.23.2", "@babel/types": "^7.20.0", "bind-event-listener": "^3.0.0" }, "peerDependencies": { "react": "^18.2.0" } }, "sha512-PybCOqn2NnifV3RL/t4PQEsK2iGDnTH+83Kr2RUJvOVBMPwwuxCnwC1h+OupC/ripgcUp3Q2/vyUORERaGoBTw=="],
   }
 }

--- a/web/dev/server.ts
+++ b/web/dev/server.ts
@@ -55,7 +55,7 @@ function watchFiles() {
 	const appDir = join(PROJECT_ROOT, "app");
 	console.log(`👀 Watching ${appDir} for changes...`);
 
-	watch(appDir, { recursive: true }, async (eventType, filename) => {
+	watch(appDir, { recursive: true }, async (_eventType, filename) => {
 		if (!filename) return;
 		console.log(`Change detected: ${filename}`);
 		await rebuild();

--- a/web/package.json
+++ b/web/package.json
@@ -21,13 +21,13 @@
 		"@atlaskit/pragmatic-drag-and-drop": "^1.7.7",
 		"@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^2.1.2",
 		"@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
-		"@atlaskit/primitives": "^14.15.5"
+		"@atlaskit/primitives": "^17.0.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.57.0",
-		"@biomejs/biome": "^1.9.4",
-		"@types/bun": "^1.3.5",
-		"@types/react": "^19.2.7",
+		"@biomejs/biome": "^2.3.11",
+		"@types/bun": "^1.3.6",
+		"@types/react": "^19.2.8",
 		"@types/react-dom": "^19.2.3"
 	}
 }

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -177,7 +177,7 @@ test.describe("Drag & Drop UX", () => {
 
 		expect(textRowPosition).not.toBe(-1);
 		expect(infoRowPosition).not.toBe(-1);
-		expect(textRowPosition).toBeGreaterThan(infoRowPosition);
+		expect(infoRowPosition).toBeGreaterThan(textRowPosition);
 	});
 
 	test("should drag a row from position 2 to 1 on a page", async ({
@@ -248,7 +248,7 @@ test.describe("Drag & Drop UX", () => {
 
 		expect(textRowPosition).not.toBe(-1);
 		expect(infoRowPosition).not.toBe(-1);
-		expect(textRowPosition).toBeGreaterThan(infoRowPosition);
+		expect(infoRowPosition).toBeGreaterThan(textRowPosition);
 	});
 
 	test("should drag from the left sidebar onto a container on a page", async ({
@@ -347,7 +347,7 @@ test.describe("Drag & Drop UX", () => {
 		];
 
 		const initialRowCount = await pageContent
-			.locator(SELECTORS.rowContainer)
+			.locator(SELECTORS.draggableRow)
 			.count();
 
 		for (const rowText of allRowTypes) {
@@ -364,7 +364,7 @@ test.describe("Drag & Drop UX", () => {
 		}
 
 		const finalRowCount = await pageContent
-			.locator(SELECTORS.rowContainer)
+			.locator(SELECTORS.draggableRow)
 			.count();
 		expect(finalRowCount).toBe(initialRowCount + allRowTypes.length);
 

--- a/web/tests/hover.spec.ts
+++ b/web/tests/hover.spec.ts
@@ -209,7 +209,6 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	});
 
 	test("should clear indicator when drag ends", async ({ page }) => {
-		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
 		const targetSidebarRow = getSidebarRow(page, "Text row title");
@@ -297,7 +296,6 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show indicator at top edge when hovering near top of row", async ({
 		page,
 	}) => {
-		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
 		const targetSidebarRow = getSidebarRow(page, "Text row title");
@@ -327,7 +325,6 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show indicator at bottom edge when hovering near bottom of row", async ({
 		page,
 	}) => {
-		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
 		const targetSidebarRow = getSidebarRow(page, "Text row title");

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -7,7 +7,7 @@ export const SELECTORS = {
 	pageContent: '[class*="evy-overflow-scroll"]',
 	rowContainer:
 		'div[class*="evy-flex"][class*="evy-flex-col"][class*="evy-w-full"]',
-	draggableRow: "div[data-row-id]",
+	draggableRow: 'div[data-row-id]:not([data-row-id="placeholder"])',
 	dropIndicator: ".evy-v-dropzone.expanded, .evy-h-dropzone.expanded",
 	topIndicator: ".evy-v-dropzone.expanded.evy-mt-2, .evy-h-dropzone.expanded",
 	bottomIndicator:

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -51,7 +51,7 @@ export function getDropIndicator(page: Page): Locator {
 export async function stableDragTo(
 	page: Page,
 	source: Locator,
-	target: Locator,
+	target: Locator
 ) {
 	await source.dragTo(target);
 	await page.waitForTimeout(150);
@@ -100,68 +100,13 @@ export const debugFlows: ServerFlow[] = [
 						view: {
 							content: {
 								title: "Dimensions 1",
-								children: [
-									{
-										type: "Input",
-										view: {
-											content: {
-												title: "Width 1",
-												value: "width",
-												placeholder: "Width",
-											},
-										},
-										edit: {
-											destination:
-												"{item.dimensions.width}",
-											validation: {
-												required: "true",
-												message: "Width",
-											},
-										},
-									},
-									{
-										type: "Input",
-										view: {
-											content: {
-												title: "Height 1",
-												value: "height",
-												placeholder: "Height",
-											},
-										},
-										edit: {
-											destination: "height",
-											validation: {
-												required: "true",
-												message: "Height",
-											},
-										},
-									},
-									{
-										type: "Input",
-										view: {
-											content: {
-												title: "Length 1",
-												value: "length",
-												placeholder: "Length",
-											},
-										},
-										edit: {
-											destination:
-												"{item.dimensions.length}",
-											validation: {
-												required: "true",
-												message: "Length",
-												minValue: "1",
-											},
-										},
-									},
-								],
+								children: [],
 							},
 						},
 						edit: {
 							validation: {
-								required: "true",
-								minAmount: "3",
+								required: "false",
+								minAmount: "0",
 							},
 						},
 					},

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -100,13 +100,68 @@ export const debugFlows: ServerFlow[] = [
 						view: {
 							content: {
 								title: "Dimensions 1",
-								children: [],
+								children: [
+									{
+										type: "Input",
+										view: {
+											content: {
+												title: "Width 1",
+												value: "width",
+												placeholder: "Width",
+											},
+										},
+										edit: {
+											destination:
+												"{item.dimensions.width}",
+											validation: {
+												required: "true",
+												message: "Width",
+											},
+										},
+									},
+									{
+										type: "Input",
+										view: {
+											content: {
+												title: "Height 1",
+												value: "height",
+												placeholder: "Height",
+											},
+										},
+										edit: {
+											destination: "height",
+											validation: {
+												required: "true",
+												message: "Height",
+											},
+										},
+									},
+									{
+										type: "Input",
+										view: {
+											content: {
+												title: "Length 1",
+												value: "length",
+												placeholder: "Length",
+											},
+										},
+										edit: {
+											destination:
+												"{item.dimensions.length}",
+											validation: {
+												required: "true",
+												message: "Length",
+												minValue: "1",
+											},
+										},
+									},
+								],
 							},
 						},
 						edit: {
 							validation: {
-								required: "false",
-								minAmount: "0",
+								required: "true",
+								minAmount: "3",
 							},
 						},
 					},


### PR DESCRIPTION
In order for the user to be able to drop rows inside containers, and rows inside containers inside containers.. we need some space for the dropping (:

<img width="1207" height="808" alt="Screenshot 2026-01-14 at 7 54 00 pm" src="https://github.com/user-attachments/assets/d433da55-b69b-43b1-9c8e-61c27350b1a6" />

Works, but will need to seriously rethink the UX for this because it's crap