### PR TITLE
[FEAT] iOS improvements, new action system, and data layer refactor

### DIFF
--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -1,8 +1,10 @@
 import { eq, and, desc } from "drizzle-orm";
 import pluralize from "pluralize";
 
-import type { DATA_Data, DATA_Flow, DATA_Rows } from "evy-types/data/data";
 import {
+	type DATA_Data,
+	type DATA_Flow,
+	type DATA_Rows,
 	type GetResponse,
 	NAMESPACE_VALUES,
 	RESOURCE_VALUES,

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -4,8 +4,7 @@ import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { PGlite } from "@electric-sql/pglite";
 
-import type { SDUI_Flow } from "evy-types";
-import type { DATA_Flow, DATA_Rows } from "evy-types/data/data";
+import type { SDUI_Flow, DATA_Flow, DATA_Rows } from "evy-types";
 import * as schema from "../../../types/generated/ts/db/schema.generated";
 import {
 	type RowSchema,

--- a/docs/evy/evy_sdui.json
+++ b/docs/evy/evy_sdui.json
@@ -49,23 +49,6 @@
 												"true": "navigate:ca47e6c5-da19-4491-8422-adb40d9e8a27:306ed62c-c2af-4652-a873-26c7a388972d"
 											}
 										]
-									},
-									{
-										"id": "e2ecbf8a-36dc-4d9a-8076-5ab542a0c085",
-										"type": "Button",
-										"view": {
-											"content": {
-												"title": "",
-												"label": "Test"
-											}
-										},
-										"actions": [
-											{
-												"condition": "",
-												"false": "",
-												"true": "navigate:18e988ea-9131-4ee3-a692-77c8f3d36c58:77cb970d-9845-442e-87ef-dfc3d27fcdcd"
-											}
-										]
 									}
 								]
 							}

--- a/docs/services/service_data.json
+++ b/docs/services/service_data.json
@@ -1631,7 +1631,7 @@
 			},
 			"ship": {
 				"postal_code": "",
-				"areas": ""
+				"areas": []
 			}
 		},
 		"description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.",

--- a/docs/services/service_data.json
+++ b/docs/services/service_data.json
@@ -1665,5 +1665,871 @@
 			"cash": false,
 			"app": false
 		}
-	}
+	},
+	"timeslots": [
+		{
+			"id": "91baf759-f221-460b-9afb-b1ae4e8bd59a",
+			"x": 0,
+			"y": 0,
+			"header": "Wed 18",
+			"start_label": "7:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "43f5a5ff-f021-499f-b2be-08f9edcdf9cf",
+			"x": 0,
+			"y": 1,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "9b824515-3ba5-4b21-bf91-93774d14d958",
+			"x": 0,
+			"y": 2,
+			"header": "Wed 18",
+			"start_label": "8:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "41fc1c95-3930-496f-bb20-e072a7f64541",
+			"x": 0,
+			"y": 3,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "f8f2ab5b-6b13-4e84-b4ac-3f95e6e2f2f1",
+			"x": 0,
+			"y": 4,
+			"header": "Wed 18",
+			"start_label": "9:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "b1689ba9-ff44-4dee-af1e-ae513d9ba2d3",
+			"x": 0,
+			"y": 5,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "217a55c3-9a21-44b2-8297-7c862a2ede58",
+			"x": 0,
+			"y": 6,
+			"header": "Wed 18",
+			"start_label": "10:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "900a9ab0-81cc-45af-bb30-e964775324ad",
+			"x": 0,
+			"y": 7,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "9f2c0e17-316a-4ed1-9df7-e7c12aa68405",
+			"x": 0,
+			"y": 8,
+			"header": "Wed 18",
+			"start_label": "11:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "2b6d7ea1-378b-42be-994d-bb6b22f7ea35",
+			"x": 0,
+			"y": 9,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "08d1f27b-7ca5-4e14-8a5f-5daff541d192",
+			"x": 0,
+			"y": 10,
+			"header": "Wed 18",
+			"start_label": "12:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "97b78062-5967-41f7-9184-008155a903b5",
+			"x": 0,
+			"y": 11,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "fa8a3eb4-e298-4bf9-9a5e-0e7355434692",
+			"x": 0,
+			"y": 12,
+			"header": "Wed 18",
+			"start_label": "13:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "4d8483c2-1bad-4d5c-b22c-16c62d4b839f",
+			"x": 0,
+			"y": 14,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "c6990e28-c58d-4207-918a-b6ab519adcb5",
+			"x": 0,
+			"y": 15,
+			"header": "Wed 18",
+			"start_label": "14:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "5372e8bf-3d1f-40b6-b057-b8e1269e8069",
+			"x": 0,
+			"y": 16,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "6aab78e4-a151-4df1-833e-f8589b24fd94",
+			"x": 0,
+			"y": 17,
+			"header": "Wed 18",
+			"start_label": "15:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "ab087807-d6ca-4d6b-8505-7a9b2a0bbb4d",
+			"x": 0,
+			"y": 18,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "3ea89e58-3f2c-4461-b024-b4d1988e6753",
+			"x": 0,
+			"y": 19,
+			"header": "Wed 18",
+			"start_label": "16:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8f7123a8-6a0e-457a-8ed5-7cca82153126",
+			"x": 0,
+			"y": 20,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "6edfc6b4-63ce-419b-8706-43f0f7690f9c",
+			"x": 0,
+			"y": 21,
+			"header": "Wed 18",
+			"start_label": "17:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "f51ab3a5-f092-4e31-afd4-5fcc9a8b84f3",
+			"x": 0,
+			"y": 22,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "5a908396-11f3-44b7-a3de-1a34a59f12ba",
+			"x": 0,
+			"y": 23,
+			"header": "Wed 18",
+			"start_label": "18:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "e719eca1-8477-4d3b-893c-a55c404bf8f1",
+			"x": 0,
+			"y": 24,
+			"header": "Wed 18",
+			"start_label": "",
+			"end_label": "19:00",
+			"selected": false
+		},
+		{
+			"id": "ffe8ebd4-ce38-482d-8a8c-f67b387ae0ed",
+			"x": 1,
+			"y": 0,
+			"header": "Thu 19",
+			"start_label": "7:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "faddac5c-b101-45b0-b373-5401dc71de26",
+			"x": 1,
+			"y": 1,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "7bd67e58-78e2-443e-8a42-41b757291664",
+			"x": 1,
+			"y": 2,
+			"header": "Thu 19",
+			"start_label": "8:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "c095152d-cdbd-4d62-a700-6462219b1174",
+			"x": 1,
+			"y": 3,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "f6f57ea2-f6c2-475f-ad64-6dad66375020",
+			"x": 1,
+			"y": 4,
+			"header": "Thu 19",
+			"start_label": "9:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "15d096b2-97b1-47fb-8149-f01ef8030f22",
+			"x": 1,
+			"y": 5,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "3b676ba9-bcdc-4a90-823b-52c8d61ba2cc",
+			"x": 1,
+			"y": 6,
+			"header": "Thu 19",
+			"start_label": "10:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "d2ba4c0e-30a0-4e78-a13f-2e8c9bf7a115",
+			"x": 1,
+			"y": 7,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "bbb42d66-56ff-498a-beb8-495990c1af28",
+			"x": 1,
+			"y": 8,
+			"header": "Thu 19",
+			"start_label": "11:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "a556deb5-a0e9-4012-a320-472f48a34bcc",
+			"x": 1,
+			"y": 9,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "c6900e07-7588-44d6-80ec-ba8e09ed2fcb",
+			"x": 1,
+			"y": 10,
+			"header": "Thu 19",
+			"start_label": "12:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "faa6e4f1-f878-40a9-8395-3c4b1ca801ca",
+			"x": 1,
+			"y": 11,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "e14c286d-1ab6-4a04-a456-37d931433f3f",
+			"x": 1,
+			"y": 12,
+			"header": "Thu 19",
+			"start_label": "13:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "0beef666-3238-41d8-9c53-2405350ff026",
+			"x": 1,
+			"y": 14,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "bc46725e-6ea7-41ce-b58b-cb6fbb9f2829",
+			"x": 1,
+			"y": 15,
+			"header": "Thu 19",
+			"start_label": "14:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "2d4889e5-cda8-4f48-b8aa-99a99049e048",
+			"x": 1,
+			"y": 16,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8b0d6c69-9cfc-4218-9acf-ef83e7c492de",
+			"x": 1,
+			"y": 17,
+			"header": "Thu 19",
+			"start_label": "15:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "68217fc1-b770-4383-b132-b171c7a9e2d6",
+			"x": 1,
+			"y": 18,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "b71cd94b-e1f9-47b1-ad51-c75d30d29811",
+			"x": 1,
+			"y": 19,
+			"header": "Thu 19",
+			"start_label": "16:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "db16c1fd-cdce-4fc6-916d-271cd5200c1b",
+			"x": 1,
+			"y": 20,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "f72caca0-a553-470c-8eb2-c90528e66367",
+			"x": 1,
+			"y": 21,
+			"header": "Thu 19",
+			"start_label": "17:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "f5f80f39-56dd-4418-acfe-6242531225ac",
+			"x": 1,
+			"y": 22,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8da2bbf7-1ea1-4833-a476-39b57646991e",
+			"x": 1,
+			"y": 23,
+			"header": "Thu 19",
+			"start_label": "18:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "e1639c69-bdcd-46ac-8845-3a5dfc7b449c",
+			"x": 1,
+			"y": 24,
+			"header": "Thu 19",
+			"start_label": "",
+			"end_label": "19:00",
+			"selected": false
+		},
+		{
+			"id": "3b79fdb9-1ccd-4b85-b704-03fc33b424b2",
+			"x": 2,
+			"y": 0,
+			"header": "Fri 20",
+			"start_label": "7:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "c40a5a63-898d-4163-b0e3-d5165e28cd59",
+			"x": 2,
+			"y": 1,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "b1f3f57a-83e5-48b3-b46e-44fbd63bce1f",
+			"x": 2,
+			"y": 2,
+			"header": "Fri 20",
+			"start_label": "8:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "526f771e-65a1-4441-b1ed-b01eda4daacd",
+			"x": 2,
+			"y": 3,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "ef82f1b5-22a6-4f7b-b6db-a6fb4238844a",
+			"x": 2,
+			"y": 4,
+			"header": "Fri 20",
+			"start_label": "9:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "6c5baf15-bf4c-4385-ae7c-4b1aecfbfac6",
+			"x": 2,
+			"y": 5,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8c9f2f08-e675-4555-8d26-c483482eb523",
+			"x": 2,
+			"y": 6,
+			"header": "Fri 20",
+			"start_label": "10:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8f98f106-4fb6-4b16-9bff-7c1791167c7e",
+			"x": 2,
+			"y": 7,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "cde32af0-9bfa-4b11-9d41-f2e97a8318ba",
+			"x": 2,
+			"y": 8,
+			"header": "Fri 20",
+			"start_label": "11:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8ee3c954-3af6-47a5-be32-369e394b2a24",
+			"x": 2,
+			"y": 9,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "bfd64729-3669-4e3e-bb0f-47935539dcb7",
+			"x": 2,
+			"y": 10,
+			"header": "Fri 20",
+			"start_label": "12:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "95332026-e92b-4ce0-8d6c-9481b007e8b8",
+			"x": 2,
+			"y": 11,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "9a244669-2088-4310-97cf-c460b3529b7e",
+			"x": 2,
+			"y": 12,
+			"header": "Fri 20",
+			"start_label": "13:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "f3655a7c-767f-4885-8fc5-7d2af4a36e65",
+			"x": 2,
+			"y": 14,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "d12af099-be07-46be-9a20-eb1f8d72f943",
+			"x": 2,
+			"y": 15,
+			"header": "Fri 20",
+			"start_label": "14:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "812abd5a-5a32-450f-8991-ae6cfc97290b",
+			"x": 2,
+			"y": 16,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "976bb4ae-99de-4143-b6fa-4640efe68752",
+			"x": 2,
+			"y": 17,
+			"header": "Fri 20",
+			"start_label": "15:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "a5163437-e96c-4653-b4d4-8d3aa076899a",
+			"x": 2,
+			"y": 18,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "9c1a41ac-f4ac-483f-b328-870b7f2f212f",
+			"x": 2,
+			"y": 19,
+			"header": "Fri 20",
+			"start_label": "16:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8d02a08c-343b-4035-a05e-a1b5e5d718b5",
+			"x": 2,
+			"y": 20,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "385ea330-ea8e-4ff0-bd91-17e7158ada15",
+			"x": 2,
+			"y": 21,
+			"header": "Fri 20",
+			"start_label": "17:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "4654a3af-4eef-4d1c-a33c-a2392aca43cd",
+			"x": 2,
+			"y": 22,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "5489d3a1-9d6b-44d5-92f6-5de0ee8644ee",
+			"x": 2,
+			"y": 23,
+			"header": "Fri 20",
+			"start_label": "18:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "2eaafb88-f891-4be9-9598-1dfcca13e6b1",
+			"x": 2,
+			"y": 24,
+			"header": "Fri 20",
+			"start_label": "",
+			"end_label": "19:00",
+			"selected": false
+		},
+		{
+			"id": "5f66cb3b-3198-42ca-8d83-a5b0fb7056d3",
+			"x": 3,
+			"y": 0,
+			"header": "Sat 21",
+			"start_label": "7:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "52bc1a42-e44b-43c2-bd13-811149a91d77",
+			"x": 3,
+			"y": 1,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "c44dca09-5e09-49d6-8dac-98985cc3fc97",
+			"x": 3,
+			"y": 2,
+			"header": "Sat 21",
+			"start_label": "8:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "bc9c1912-c97b-4770-9f3d-9ddf7a432fe6",
+			"x": 3,
+			"y": 3,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "e0120281-8acc-40f3-bda6-98a68ee5a8cd",
+			"x": 3,
+			"y": 4,
+			"header": "Sat 21",
+			"start_label": "9:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "d0e5a6fa-2ed7-4df7-819c-23cc68ed5840",
+			"x": 3,
+			"y": 5,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "025568b5-8ef5-4b4b-b218-34684f14c80a",
+			"x": 3,
+			"y": 6,
+			"header": "Sat 21",
+			"start_label": "10:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "d17ac382-5b5e-4f03-a6d7-29f2a5e558c6",
+			"x": 3,
+			"y": 7,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "b14e2cec-6b32-49bb-b85b-b057946a6880",
+			"x": 3,
+			"y": 8,
+			"header": "Sat 21",
+			"start_label": "11:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "27b25590-a656-4b78-94f8-8d82af46d883",
+			"x": 3,
+			"y": 9,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "37f004cb-a498-4d1b-a0c5-0c03402b66b1",
+			"x": 3,
+			"y": 10,
+			"header": "Sat 21",
+			"start_label": "12:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "b062c556-a8e7-4bfd-aaeb-f00b9ada9853",
+			"x": 3,
+			"y": 11,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "1e4e1b89-79ce-4827-9042-f26caf3b1442",
+			"x": 3,
+			"y": 12,
+			"header": "Sat 21",
+			"start_label": "13:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "cc52a17e-c8e5-4242-b92b-58187235ee7c",
+			"x": 3,
+			"y": 14,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "ed97df71-7f49-4944-821c-524cd905ca89",
+			"x": 3,
+			"y": 15,
+			"header": "Sat 21",
+			"start_label": "14:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "8fff8ffc-d840-4bb4-be14-9b6cc0657d95",
+			"x": 3,
+			"y": 16,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "d08093d8-6a4c-4b5b-86f4-0ef227b02fec",
+			"x": 3,
+			"y": 17,
+			"header": "Sat 21",
+			"start_label": "15:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "0f1b0465-7a17-469e-9448-da28d009afff",
+			"x": 3,
+			"y": 18,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "be59bd6d-8fe1-4355-acbb-b160310f1508",
+			"x": 3,
+			"y": 19,
+			"header": "Sat 21",
+			"start_label": "16:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "a46292bd-6ef3-4600-8236-9442ee174eda",
+			"x": 3,
+			"y": 20,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "e5fcbe88-3a1b-41ed-a80d-7e352815a2d3",
+			"x": 3,
+			"y": 21,
+			"header": "Sat 21",
+			"start_label": "17:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "a7fe5951-32c1-454f-9342-202f3e451d08",
+			"x": 3,
+			"y": 22,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "c1e70775-d1ae-41eb-914b-80c465599555",
+			"x": 3,
+			"y": 23,
+			"header": "Sat 21",
+			"start_label": "18:00",
+			"end_label": "",
+			"selected": false
+		},
+		{
+			"id": "b289e9ef-c599-4011-9d70-9ceda562de35",
+			"x": 3,
+			"y": 24,
+			"header": "Sat 21",
+			"start_label": "",
+			"end_label": "19:00",
+			"selected": false
+		}
+	]
 }

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -43,50 +43,6 @@
 		]
 	},
 	{
-		"id": "18e988ea-9131-4ee3-a692-77c8f3d36c58",
-		"name": "Test",
-		"type": "create",
-		"data": "item",
-		"pages": [
-			{
-				"id": "77cb970d-9845-442e-87ef-dfc3d27fcdcd",
-				"title": "Test Item",
-				"rows": [
-					{
-						"id": "9c8da929-4645-4088-b658-f669157b09fd",
-						"type": "Input",
-						"view": {
-							"content": {
-								"title": "test title",
-								"value": "{title}",
-								"placeholder": "test placeholder"
-							}
-						},
-						"destination": "{title}",
-						"actions": []
-					}
-				],
-				"footer": {
-					"id": "422aaaad-8d8d-4f9d-84f2-43f10fc90a2c",
-					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Submit"
-						}
-					},
-					"actions": [
-						{
-							"condition": "{length(title) > 0}",
-							"false": "{highlight_required(title)}",
-							"true": "{create(item)}"
-						}
-					]
-				}
-			}
-		]
-	},
-	{
 		"id": "ca47e6c5-da19-4491-8422-adb40d9e8a27",
 		"name": "Create item",
 		"type": "create",
@@ -220,7 +176,7 @@
 						"type": "SheetContainer",
 						"view": {
 							"content": {
-								"title": "Sheet",
+								"title": "",
 								"child": {
 									"id": "2422c9ec-df63-4fde-9632-0fe159c0b40e",
 									"type": "InputList",
@@ -378,7 +334,7 @@
 														"type": "SheetContainer",
 														"view": {
 															"content": {
-																"title": "Sheet",
+																"title": "",
 																"child": {
 																	"id": "22222222-2222-4222-8222-222222222204",
 																	"type": "TextAction",

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -660,7 +660,7 @@
 						"type": "ListContainer",
 						"view": {
 							"content": {
-								"title": "List",
+								"title": "",
 								"children": [
 									{
 										"id": "33333333-3333-4333-8333-333333333301",
@@ -704,7 +704,7 @@
 					},
 					"actions": [
 						{
-							"condition": "{payment_cash === true || payment_app === true}",
+							"condition": "{payment_cash == true || payment_app == true}",
 							"false": "{highlight_required(payment_app)}",
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,857362ad-856f-465b-85a3-94bc8bb686cd)}"
 						}

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -133,7 +133,7 @@
 								"placeholder": "{formatCurrency(price)}"
 							}
 						},
-						"destination": "{price}",
+						"destination": "{buildCurrency(price)}",
 						"actions": []
 					},
 					{
@@ -267,17 +267,12 @@
 					},
 					"actions": [
 						{
-							"condition": "{count(photos) >= 3}",
-							"false": "{highlight_required(photos)}",
-							"true": ""
-						},
-						{
 							"condition": "{length(title) > 0}",
 							"false": "{highlight_required(title)}",
 							"true": ""
 						},
 						{
-							"condition": "{price >= 1}",
+							"condition": "{price.value >= 1}",
 							"false": "{highlight_required(price)}",
 							"true": ""
 						},

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -255,6 +255,49 @@ final class WebSocketE2ETests: E2ETestBase {
         await emitter.disconnect()
     }
 
+    @MainActor
+    func testConditionalActionEvaluatesLogicalExpression() async throws {
+        let viewItemButton = app.buttons["View"]
+        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 20),
+                      "Home screen not loaded - verify API is running and database is seeded")
+
+        guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
+            XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
+            return
+        }
+
+        let emitter = WSEmitter()
+        let conditionalLabel = "Conditional \(Int(Date().timeIntervalSince1970))"
+
+        do {
+            try await emitter.connect(host: apiHost)
+            try await emitter.login(token: "e2e-test", os: "ios")
+            try await emitter.updateSDUI(
+                flowData: createConditionalFlowData(buttonLabel: conditionalLabel),
+                flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
+            )
+        } catch {
+            XCTFail("Failed to publish conditional flow: \(error.localizedDescription)")
+            return
+        }
+
+        let conditionalButton = app.buttons[conditionalLabel]
+        XCTAssertTrue(conditionalButton.waitForExistence(timeout: 10),
+                      "Conditional button should exist after SDUI update")
+
+        conditionalButton.tap()
+
+        let goHomeButton = app.buttons["Go home"]
+        XCTAssertTrue(goHomeButton.waitForExistence(timeout: 10),
+                      "Tapping the conditional button should navigate when the logical expression is true")
+
+        try? await emitter.updateSDUI(
+            flowData: createHomeFlowData(buttonLabel: "View"),
+            flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
+        )
+        await emitter.disconnect()
+    }
+
     /// Form data editing: navigate to Create, edit title/price/width, verify, return to home.
     func testCreateItemFormEditing() throws {
         let viewItemButton = app.buttons["View"]
@@ -375,5 +418,34 @@ final class WebSocketE2ETests: E2ETestBase {
                 ]
             ]
         ]
+    }
+
+    private func createConditionalFlowData(buttonLabel: String) -> [String: Any] {
+        var flowData = createHomeFlowData(buttonLabel: buttonLabel)
+        guard var pages = flowData["pages"] as? [[String: Any]],
+              var homePage = pages.first,
+              var rows = homePage["rows"] as? [[String: Any]],
+              var firstRow = rows.first,
+              var rowView = firstRow["view"] as? [String: Any],
+              var rowContent = rowView["content"] as? [String: Any],
+              var children = rowContent["children"] as? [[String: Any]],
+              var firstButton = children.first,
+              var actions = firstButton["actions"] as? [[String: Any]],
+              var firstAction = actions.first else {
+            return flowData
+        }
+
+        firstAction["condition"] = "{1 > 0 || (0 > 1 && 2 > 3)}"
+        actions[0] = firstAction
+        firstButton["actions"] = actions
+        children[0] = firstButton
+        rowContent["children"] = children
+        rowView["content"] = rowContent
+        firstRow["view"] = rowView
+        rows[0] = firstRow
+        homePage["rows"] = rows
+        pages[0] = homePage
+        flowData["pages"] = pages
+        return flowData
     }
 }

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		73EDC87D2B8F37E800304DD8 /* EVYButtonRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDC87C2B8F37E800304DD8 /* EVYButtonRow.swift */; };
 		73EDC87F2B8F387500304DD8 /* EVYButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDC87E2B8F387500304DD8 /* EVYButton.swift */; };
 		73F1A0012F30B00100000001 /* e2e.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F1A0002F30B00100000001 /* e2e.swift */; };
+		74A100012F32000100000001 /* EVYInterpreterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100042F32000100000001 /* EVYInterpreterTests.swift */; };
 		73F2A0012F30B00200000001 /* SDUIEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F2A0112F30B00200000001 /* SDUIEnums.swift */; };
 		73F2A0022F30B00200000001 /* SDUIShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F2A0122F30B00200000001 /* SDUIShapes.swift */; };
 		73F2A0032F30B00200000001 /* SDUIRowPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F2A0132F30B00200000001 /* SDUIRowPayloads.swift */; };
@@ -82,6 +83,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		73F1A0032F30B00100000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 737C6A9A2B2706890093D00C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 737C6AA12B2706890093D00C;
+			remoteInfo = evy;
+		};
+		74A100022F32000100000001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 737C6A9A2B2706890093D00C /* Project object */;
 			proxyType = 1;
@@ -158,6 +166,8 @@
 		73EDC87E2B8F387500304DD8 /* EVYButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYButton.swift; sourceTree = "<group>"; };
 		73F1A0002F30B00100000001 /* e2e.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = e2e.swift; sourceTree = "<group>"; };
 		73F1A0052F30B00100000001 /* evyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = evyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		74A100042F32000100000001 /* EVYInterpreterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYInterpreterTests.swift; sourceTree = "<group>"; };
+		74A100052F32000100000001 /* evyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = evyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73F2A0112F30B00200000001 /* SDUIEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDUIEnums.swift; sourceTree = "<group>"; };
 		73F2A0122F30B00200000001 /* SDUIShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDUIShapes.swift; sourceTree = "<group>"; };
 		73F2A0132F30B00200000001 /* SDUIRowPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDUIRowPayloads.swift; sourceTree = "<group>"; };
@@ -176,6 +186,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		73F1A0062F30B00100000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A100062F32000100000001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -284,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				737C6AA42B2706890093D00C /* evy */,
+				74A100072F32000100000001 /* evyTests */,
 				73F1A0072F30B00100000001 /* e2e */,
 				737C6AA32B2706890093D00C /* Products */,
 			);
@@ -294,6 +312,7 @@
 			children = (
 				737C6AA22B2706890093D00C /* evy.app */,
 				73F1A0052F30B00100000001 /* evyUITests.xctest */,
+				74A100052F32000100000001 /* evyTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -404,6 +423,14 @@
 			path = e2e;
 			sourceTree = "<group>";
 		};
+		74A100072F32000100000001 /* evyTests */ = {
+			isa = PBXGroup;
+			children = (
+				74A100042F32000100000001 /* EVYInterpreterTests.swift */,
+			);
+			path = evyTests;
+			sourceTree = "<group>";
+		};
 		73F2A0102F30B00200000001 /* ../../types/generated/swift */ = {
 			isa = PBXGroup;
 			children = (
@@ -457,6 +484,24 @@
 			productReference = 73F1A0052F30B00100000001 /* evyUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		74A100082F32000100000001 /* evyTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 74A1000D2F32000100000001 /* Build configuration list for PBXNativeTarget "evyTests" */;
+			buildPhases = (
+				74A100092F32000100000001 /* Sources */,
+				74A100062F32000100000001 /* Frameworks */,
+				74A1000A2F32000100000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				74A100032F32000100000001 /* PBXTargetDependency */,
+			);
+			name = evyTests;
+			productName = evyTests;
+			productReference = 74A100052F32000100000001 /* evyTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -471,6 +516,10 @@
 						CreatedOnToolsVersion = 15.0.1;
 					};
 					73F1A0082F30B00100000001 = {
+						CreatedOnToolsVersion = 15.0.1;
+						TestTargetID = 737C6AA12B2706890093D00C;
+					};
+					74A100082F32000100000001 = {
 						CreatedOnToolsVersion = 15.0.1;
 						TestTargetID = 737C6AA12B2706890093D00C;
 					};
@@ -495,6 +544,7 @@
 			targets = (
 				737C6AA12B2706890093D00C /* evy */,
 				73F1A0082F30B00100000001 /* evyUITests */,
+				74A100082F32000100000001 /* evyTests */,
 			);
 		};
 /* End PBXProject section */
@@ -514,6 +564,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		73F1A00A2F30B00100000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		74A1000A2F32000100000001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -600,6 +657,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		74A100092F32000100000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74A100012F32000100000001 /* EVYInterpreterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -607,6 +672,11 @@
 			isa = PBXTargetDependency;
 			target = 737C6AA12B2706890093D00C /* evy */;
 			targetProxy = 73F1A0032F30B00100000001 /* PBXContainerItemProxy */;
+		};
+		74A100032F32000100000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 737C6AA12B2706890093D00C /* evy */;
+			targetProxy = 74A100022F32000100000001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -828,6 +898,56 @@
 			};
 			name = Release;
 		};
+		74A1000B2F32000100000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 995A4BQX6K;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = evy.evyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/evy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/evy";
+				TEST_TARGET_NAME = evy;
+			};
+			name = Debug;
+		};
+		74A1000C2F32000100000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 995A4BQX6K;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = evy.evyTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/evy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/evy";
+				TEST_TARGET_NAME = evy;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -854,6 +974,15 @@
 			buildConfigurations = (
 				73F1A00B2F30B00100000001 /* Debug */,
 				73F1A00C2F30B00100000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		74A1000D2F32000100000001 /* Build configuration list for PBXNativeTarget "evyTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				74A1000B2F32000100000001 /* Debug */,
+				74A1000C2F32000100000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/evy.xcodeproj/xcshareddata/xcschemes/evy.xcscheme
+++ b/ios/evy.xcodeproj/xcshareddata/xcschemes/evy.xcscheme
@@ -44,6 +44,17 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "74A100082F32000100000001"
+               BuildableName = "evyTests.xctest"
+               BlueprintName = "evyTests"
+               ReferencedContainer = "container:evy.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "73F1A0082F30B00100000001"
                BuildableName = "evyUITests.xctest"
                BlueprintName = "evyUITests"

--- a/ios/evy/ContentView.swift
+++ b/ios/evy/ContentView.swift
@@ -93,22 +93,7 @@ struct ContentView: View {
             showingAlert = true
             
         case .close:
-            // If the flow was for creation, delete the draft data
-            if let currentFlow = flows.first(where: { $0.id == currentFlowId }),
-               currentFlow.type == .create {
-                EVY.data.deleteAllDrafts()
-                do {
-                    try EVY.data.delete(key: currentFlow.data)
-                } catch EVYDataError.keyNotFound {
-                    // Draft doesn't exist, continue
-                } catch {
-                    showError(error)
-                }
-            }
-            
-			if let existing = routes.firstIndex(where: { route in
-				route.flowId == currentFlowId
-			}) {
+			if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
                 routes.removeSubrange(existing...)
             } else {
                 routes.removeAll()
@@ -117,35 +102,29 @@ struct ContentView: View {
     }
     
     private func createFlow(currentFlowId: String, key: String) {
-            // Make sure the flow was for creation, otherwise error out
-            guard let currentFlow = flows.first(where: { $0.id == currentFlowId }) else {
-                alertMessage = "Flow not found"
-                showingAlert = true
-                return
-            }
-            if currentFlow.type != .create {
-                alertMessage = "Cannot create - not a create flow"
-                showingAlert = true
-                return
-            }
-			
-            // Create the data
-            do {
-                try EVY.create(key: key)
-            } catch {
-                showError(error)
-                return
-            }
-            
-            // Then, remove the current flow from navigation
-			if let existing = routes.firstIndex(where: { route in
-				route.flowId == currentFlowId
-			}) {
-                routes.removeSubrange(existing...)
-            } else {
-                // But if something is wrong, we exit back home
-                routes.removeAll()
-            }
+        guard let currentFlow = flows.first(where: { $0.id == currentFlowId }) else {
+            alertMessage = "Flow not found"
+            showingAlert = true
+            return
+        }
+        if currentFlow.type != .create {
+            alertMessage = "Cannot create - not a create flow"
+            showingAlert = true
+            return
+        }
+
+        do {
+            try EVY.create(key: key)
+        } catch {
+            showError(error)
+            return
+        }
+
+        if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
+            routes.removeSubrange(existing...)
+        } else {
+            routes.removeAll()
+        }
     }
     
     @ViewBuilder

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -159,12 +159,12 @@ struct EVY {
         return returnText.toString()
     }
     
-    static func ensureDraftExists(variableName: String) {
+    static func ensureDraftExists(variableName: String, initialData: Data? = nil) {
         guard !data.exists(key: variableName),
               !data.hasDraft(variableName: variableName) else {
             return
         }
-        guard let emptyData = "\"\"".data(using: .utf8) else { return }
+        let emptyData = initialData ?? "\"\"".data(using: .utf8)!
         do {
             try data.createDraft(variableName: variableName, data: emptyData)
         } catch {

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -182,6 +182,19 @@ struct EVY {
     }
     
     static func updateValue(_ value: String, at: String) throws {
+        let destinationProps = EVYInterpreter.parsePropsFromText(at)
+        if let (functionName, functionArgs) = EVYInterpreter.parseFunctionCall(destinationProps) {
+            switch functionName {
+            case "buildCurrency":
+                try updateData(try evyBuildCurrency(functionArgs, value), at: functionArgs)
+                return
+            case "buildAddress":
+                try updateData(try evyBuildAddress(functionArgs, value), at: functionArgs)
+                return
+            default:
+                break
+            }
+        }
         try updateData("\"\(value)\"".data(using: .utf8)!, at: at)
     }
     

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -48,8 +48,8 @@ struct EVY {
 		let sellingReasonsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "selling_reasons", filter: nil), expecting: [EVYJson].self)
 		let conditionsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "conditions", filter: nil), expecting: [EVYJson].self)
 		let durationsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "durations", filter: nil), expecting: [EVYJson].self)
+		let areasJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "areas", filter: nil), expecting: [EVYJson].self)
 		let itemsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "items", filter: nil), expecting: [EVYJson].self)
-		let areasJson: [EVYJson] = []
 
 		let serviceData: EVYJson = .dictionary([
 			"selling_reasons": .array(sellingReasonsJson),

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -49,6 +49,7 @@ struct EVY {
 		let conditionsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "conditions", filter: nil), expecting: [EVYJson].self)
 		let durationsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "durations", filter: nil), expecting: [EVYJson].self)
 		let areasJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "areas", filter: nil), expecting: [EVYJson].self)
+		let timeslotsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "timeslots", filter: nil), expecting: [EVYJson].self)
 		let itemsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "items", filter: nil), expecting: [EVYJson].self)
 
 		let serviceData: EVYJson = .dictionary([
@@ -56,6 +57,7 @@ struct EVY {
 			"conditions": .array(conditionsJson),
 			"durations": .array(durationsJson),
 			"areas": .array(areasJson),
+			"timeslots": .array(timeslotsJson),
 			"item": itemsJson.first ?? .dictionary([:]),
 		])
 
@@ -80,6 +82,12 @@ struct EVY {
 		do {
 			let areas = try JSONEncoder().encode(serviceData.parseProp(props: ["areas"]))
 			try EVY.data.create(key: "areas", data: areas)
+		} catch EVYDataError.keyAlreadyExists {
+			// Data already loaded, skip
+		}
+		do {
+			let timeslots = try JSONEncoder().encode(serviceData.parseProp(props: ["timeslots"]))
+			try EVY.data.create(key: "timeslots", data: timeslots)
 		} catch EVYDataError.keyAlreadyExists {
 			// Data already loaded, skip
 		}
@@ -200,14 +208,25 @@ struct EVY {
     
     static func updateData(_ newData: Data, at: String) throws {
         let variableName = EVYInterpreter.parsePropsFromText(at)
+        let splitProps = try EVYInterpreter.splitPropsFromText(variableName)
+        let rootVariable = splitProps.first!
+        let remainingProps = Array(splitProps.dropFirst())
 
-        if let existing = try? data.getDraft(variableName: variableName) {
-            existing.data = newData
-            NotificationCenter.default.post(name: .evyDataUpdated, object: variableName)
-        } else if data.exists(key: variableName) {
-            let dataObj = try data.get(key: variableName)
-            dataObj.data = newData
-            try data.update(props: [variableName], data: newData)
+        if let existing = try? data.getDraft(variableName: rootVariable) {
+            if remainingProps.isEmpty {
+                existing.data = newData
+            } else {
+                try existing.updateDataWithData(newData, props: remainingProps)
+            }
+            NotificationCenter.default.post(name: .evyDataUpdated, object: rootVariable)
+        } else if data.exists(key: rootVariable) {
+            let dataObj = try data.get(key: rootVariable)
+            if remainingProps.isEmpty {
+                dataObj.data = newData
+            } else {
+                try dataObj.updateDataWithData(newData, props: remainingProps)
+            }
+            try data.update(props: splitProps, data: dataObj.data)
         } else {
             try data.createDraft(variableName: variableName, data: newData)
         }

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -32,7 +32,6 @@ struct Filter: Encodable {
 @MainActor
 struct EVY {
     static let data = EVYDataManager()
-    
 	
 	static func getUserData() throws {
 		let userData = try EVYJson.from(localJSON: "user_data")
@@ -44,52 +43,37 @@ struct EVY {
 		}
 	}
 	
+	private static func fetchResource(_ resource: String) async throws -> [EVYJson] {
+		try await EVYAPIManager.shared.fetch(
+			method: "get",
+			params: GetParams(namespace: "evy", resource: resource, filter: nil),
+			expecting: [EVYJson].self
+		)
+	}
+
+	private static func storeIfNew(key: String, from serviceData: EVYJson) {
+		do {
+			let encoded = try JSONEncoder().encode(serviceData.parseProp(props: [key]))
+			try data.create(key: key, data: encoded)
+		} catch EVYDataError.keyAlreadyExists {
+			// Data already loaded, skip
+		} catch {}
+	}
+
 	static func getData() async throws -> Data {
-		let sellingReasonsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "selling_reasons", filter: nil), expecting: [EVYJson].self)
-		let conditionsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "conditions", filter: nil), expecting: [EVYJson].self)
-		let durationsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "durations", filter: nil), expecting: [EVYJson].self)
-		let areasJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "areas", filter: nil), expecting: [EVYJson].self)
-		let timeslotsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "timeslots", filter: nil), expecting: [EVYJson].self)
-		let itemsJson = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(namespace: "evy", resource: "items", filter: nil), expecting: [EVYJson].self)
+		let resources = ["selling_reasons", "conditions", "durations", "areas", "timeslots"]
+		var serviceDict: [String: EVYJson] = [:]
+		for resource in resources {
+			serviceDict[resource] = .array(try await fetchResource(resource))
+		}
 
-		let serviceData: EVYJson = .dictionary([
-			"selling_reasons": .array(sellingReasonsJson),
-			"conditions": .array(conditionsJson),
-			"durations": .array(durationsJson),
-			"areas": .array(areasJson),
-			"timeslots": .array(timeslotsJson),
-			"item": itemsJson.first ?? .dictionary([:]),
-		])
+		let itemsJson = try await fetchResource("items")
+		serviceDict["item"] = itemsJson.first ?? .dictionary([:])
 
-		let sellingReasons = try JSONEncoder().encode(serviceData.parseProp(props: ["selling_reasons"]))
-		do {
-			try EVY.data.create(key: "selling_reasons", data: sellingReasons)
-		} catch EVYDataError.keyAlreadyExists {
-			// Data already loaded, skip
-		}
-		do {
-			let conditions = try JSONEncoder().encode(serviceData.parseProp(props: ["conditions"]))
-			try EVY.data.create(key: "conditions", data: conditions)
-		} catch EVYDataError.keyAlreadyExists {
-			// Data already loaded, skip
-		}
-		do {
-			let durations = try JSONEncoder().encode(serviceData.parseProp(props: ["durations"]))
-			try EVY.data.create(key: "durations", data: durations)
-		} catch EVYDataError.keyAlreadyExists {
-			// Data already loaded, skip
-		}
-		do {
-			let areas = try JSONEncoder().encode(serviceData.parseProp(props: ["areas"]))
-			try EVY.data.create(key: "areas", data: areas)
-		} catch EVYDataError.keyAlreadyExists {
-			// Data already loaded, skip
-		}
-		do {
-			let timeslots = try JSONEncoder().encode(serviceData.parseProp(props: ["timeslots"]))
-			try EVY.data.create(key: "timeslots", data: timeslots)
-		} catch EVYDataError.keyAlreadyExists {
-			// Data already loaded, skip
+		let serviceData: EVYJson = .dictionary(serviceDict)
+
+		for resource in resources {
+			storeIfNew(key: resource, from: serviceData)
 		}
 
 		return try JSONEncoder().encode(serviceData.parseProp(props: ["item"]))

--- a/ios/evy/UI/Atoms/EVYTextView.swift
+++ b/ios/evy/UI/Atoms/EVYTextView.swift
@@ -136,9 +136,9 @@ struct EVYTextView: View {
 			EVYTextView("Title style", style: EVYTextStyle.title)
 			EVYButton(label: "button", action: {})
 			EVYTextView("Action", style: EVYTextStyle.action)
-			EVYTextView("{title} ::star.square.on.square.fill:: and more text")
-			EVYTextView("count: {count(photo_ids)}")
-			EVYTextView("{title} has {count(photo_ids)} photos ::star.square.on.square.fill::")
+			EVYTextView("{item.title} ::star.square.on.square.fill:: and more text")
+			EVYTextView("count: {count(item.photo_ids)}")
+			EVYTextView("{item.title} has {count(item.photo_ids)} photos ::star.square.on.square.fill::")
 		}
 	}
 }

--- a/ios/evy/UI/EVYActionRunner.swift
+++ b/ios/evy/UI/EVYActionRunner.swift
@@ -7,52 +7,6 @@
 
 import Foundation
 
-public enum SDUI_ActionTarget: Codable {
-    case navigate(Route)
-    case create(String)
-    case close
-
-    private enum EVYActionError: Error {
-        case invalid
-        case missingKeywords
-        case tooManyKeywords
-    }
-
-    /// Parse target string for use in row behaviour.
-    public static func parse(_ value: String) throws -> SDUI_ActionTarget {
-        let valueSplit = value.split(separator: ":")
-        if valueSplit.count < 1 {
-            throw EVYActionError.missingKeywords
-        }
-        if valueSplit.count > 3 {
-            throw EVYActionError.tooManyKeywords
-        }
-        switch valueSplit.first {
-        case "navigate":
-            guard valueSplit.count >= 3 else { throw EVYActionError.invalid }
-            return .navigate(Route(
-                flowId: String(valueSplit[1]),
-                pageId: String(valueSplit[2])
-            ))
-        case "create":
-            guard valueSplit.count == 2 else { throw EVYActionError.invalid }
-            return .create(String(valueSplit[1]))
-        case "close":
-            return .close
-        default:
-            throw EVYActionError.invalid
-        }
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        guard let value = try? container.decode(String.self) else {
-            throw EVYActionError.invalid
-        }
-        self = try SDUI_ActionTarget.parse(value)
-    }
-}
-
 @MainActor
 enum EVYActionRunner {
     static func run(actions: [SDUI_RowAction],
@@ -96,57 +50,59 @@ enum EVYActionRunner {
     private static func execute(branch: String,
                                 navigate: @escaping (NavOperation) -> Void) throws
     {
-		let unwrappedBranch = unwrapActionBranch(branch)
-		
-        if let target = try? SDUI_ActionTarget.parse(branch) {
-            perform(target: target, navigate: navigate)
+        let unwrappedBranch = unwrapActionBranch(branch)
+
+        if let operation = parseColonFormat(unwrappedBranch) ?? parseColonFormat(branch) {
+            navigate(operation)
             return
         }
-        else if let target = try? SDUI_ActionTarget.parse(unwrappedBranch) {
-            perform(target: target, navigate: navigate)
-            return
-		} else if let (functionName, functionArgs) = EVYInterpreter.parseFunctionCall(unwrappedBranch) {
-			switch functionName {
-			case "navigate":
-				let args = splitArguments(functionArgs)
-				guard args.count == 2 else {
-					throw EVYError.invalidData(context: "navigate requires flowId and pageId")
-				}
-				navigate(.navigate(Route(flowId: args[0], pageId: args[1])))
-			case "create":
-				let args = splitArguments(functionArgs)
-				guard let key = args.first, !key.isEmpty else {
-					throw EVYError.invalidData(context: "create requires a key")
-				}
-				navigate(.create(key))
-			case "close":
-				navigate(.close)
-			case "highlight_required":
-				let args = splitArguments(functionArgs)
-				let alias = args.first ?? "field"
-				let fieldName = alias
-					.replacingOccurrences(of: "_", with: " ")
-					.trimmingCharacters(in: .whitespacesAndNewlines)
-				let readableField = fieldName.isEmpty ? "Field" : fieldName.capitalized
-				navigate(.highlightRequired(readableField))
-			default:
-				throw EVYError.invalidData(context: "Unsupported action function: \(functionName)")
-			}
-		} else {
-			throw EVYError.invalidData(context: "Unknown action branch: \(branch)")
-		}
+
+        if let (functionName, functionArgs) = EVYInterpreter.parseFunctionCall(unwrappedBranch) {
+            switch functionName {
+            case "navigate":
+                let args = splitArguments(functionArgs)
+                guard args.count == 2 else {
+                    throw EVYError.invalidData(context: "navigate requires flowId and pageId")
+                }
+                navigate(.navigate(Route(flowId: args[0], pageId: args[1])))
+            case "create":
+                let args = splitArguments(functionArgs)
+                guard let key = args.first, !key.isEmpty else {
+                    throw EVYError.invalidData(context: "create requires a key")
+                }
+                navigate(.create(key))
+            case "close":
+                navigate(.close)
+            case "highlight_required":
+                let args = splitArguments(functionArgs)
+                let alias = args.first ?? "field"
+                let fieldName = alias
+                    .replacingOccurrences(of: "_", with: " ")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let readableField = fieldName.isEmpty ? "Field" : fieldName.capitalized
+                navigate(.highlightRequired(readableField))
+            default:
+                throw EVYError.invalidData(context: "Unsupported action function: \(functionName)")
+            }
+        } else {
+            throw EVYError.invalidData(context: "Unknown action branch: \(branch)")
+        }
     }
-    
-    private static func perform(target: SDUI_ActionTarget,
-                                navigate: @escaping (NavOperation) -> Void)
-    {
-        switch target {
-        case let .navigate(route):
-            navigate(.navigate(route))
-        case let .create(key):
-            navigate(.create(key))
-        case .close:
-            navigate(.close)
+
+    private static func parseColonFormat(_ value: String) -> NavOperation? {
+        let parts = value.split(separator: ":")
+        guard let keyword = parts.first else { return nil }
+        switch keyword {
+        case "navigate":
+            guard parts.count >= 3 else { return nil }
+            return .navigate(Route(flowId: String(parts[1]), pageId: String(parts[2])))
+        case "create":
+            guard parts.count == 2 else { return nil }
+            return .create(String(parts[1]))
+        case "close":
+            return .close
+        default:
+            return nil
         }
     }
     

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 extension SDUI_Page: View {
 	public var body: some View {
@@ -33,6 +34,14 @@ extension SDUI_Page: View {
 		.onAppear {
 			bootstrapDrafts()
 		}
+		.simultaneousGesture(TapGesture().onEnded {
+			UIApplication.shared.sendAction(
+				#selector(UIResponder.resignFirstResponder),
+				to: nil,
+				from: nil,
+				for: nil
+			)
+		})
 	}
 
 	@MainActor private func bootstrapDrafts() {

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -61,6 +61,8 @@ extension SDUI_Page: View {
 				let initialData: Data?
 				if row.type == .inlinePicker {
 					initialData = "[]".data(using: .utf8)
+				} else if row.type == .calendar {
+					initialData = try? EVY.data.get(key: "timeslots").data
 				} else {
 					initialData = nil
 				}

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -45,32 +45,35 @@ extension SDUI_Page: View {
 	}
 
 	@MainActor private func bootstrapDrafts() {
-		var destinations: Set<String> = []
 		for row in rows {
-			Self.collectDestinations(from: row, into: &destinations)
+			Self.bootstrapDrafts(for: row)
 		}
 		if let footer = footer {
-			Self.collectDestinations(from: footer, into: &destinations)
-		}
-		for destination in destinations {
-			let variableName = EVYInterpreter.parsePropsFromText(destination)
-			if !variableName.isEmpty {
-				EVY.ensureDraftExists(variableName: variableName)
-			}
+			Self.bootstrapDrafts(for: footer)
 		}
 	}
 
-	private static func collectDestinations(from row: SDUI_Row, into destinations: inout Set<String>) {
+	@MainActor
+	private static func bootstrapDrafts(for row: SDUI_Row) {
 		if let destination = row.destination, !destination.isEmpty {
-			destinations.insert(destination)
+			let variableName = EVYInterpreter.parsePropsFromText(destination)
+			if !variableName.isEmpty {
+				let initialData: Data?
+				if row.type == .inlinePicker {
+					initialData = "[]".data(using: .utf8)
+				} else {
+					initialData = nil
+				}
+				EVY.ensureDraftExists(variableName: variableName, initialData: initialData)
+			}
 		}
 		if let children = row.view.content.children {
 			for child in children {
-				collectDestinations(from: child, into: &destinations)
+				bootstrapDrafts(for: child)
 			}
 		}
 		if let child = row.view.content.child {
-			collectDestinations(from: child, into: &destinations)
+			bootstrapDrafts(for: child)
 		}
 	}
 }

--- a/ios/evy/UI/Rows/Action/EVYButtonRow.swift
+++ b/ios/evy/UI/Rows/Action/EVYButtonRow.swift
@@ -36,6 +36,6 @@ struct EVYButtonRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "1", "footer"])
+		try! await EVY.getRow(["1", "pages", "0", "footer"])
 	}
 }

--- a/ios/evy/UI/Rows/Action/EVYTextActionRow.swift
+++ b/ios/evy/UI/Rows/Action/EVYTextActionRow.swift
@@ -39,6 +39,6 @@ struct EVYTextActionRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "2", "rows", "0", "view", "content", "children", "0", "child", "view", "content", "children", "1", "child"])
+		try! await EVY.getRow(["2", "pages", "2", "rows", "0", "view", "content", "children", "0", "child", "view", "content", "children", "1", "child"])
 	}
 }

--- a/ios/evy/UI/Rows/Container/EVYColumnContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYColumnContainerRow.swift
@@ -35,6 +35,6 @@ struct EVYColumnContainerRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "5"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "5"])
 	}
 }

--- a/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
@@ -33,6 +33,6 @@ struct EVYListContainerRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "2", "rows", "0", "view", "content", "children", "0"])
+		try! await EVY.getRow(["3", "pages", "3", "rows", "1"])
 	}
 }

--- a/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
@@ -33,6 +33,6 @@ struct EVYListContainerRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["3", "pages", "3", "rows", "1"])
+		try! await EVY.getRow(["2", "pages", "3", "rows", "1"])
 	}
 }

--- a/ios/evy/UI/Rows/Container/EVYSelectSegmentContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYSelectSegmentContainerRow.swift
@@ -41,6 +41,6 @@ struct EVYSelectSegmentContainerRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "2", "rows", "0"])
+		try! await EVY.getRow(["2", "pages", "2", "rows", "0"])
 	}
 }

--- a/ios/evy/UI/Rows/Container/EVYSheetContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYSheetContainerRow.swift
@@ -46,6 +46,6 @@ struct EVYSheetContainerRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "6"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "6"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
@@ -29,6 +29,6 @@ struct EVYCalendarRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "2", "rows", "0", "view", "content", "children", "0", "view", "content", "children", "4"])
+		try! await EVY.getRow(["2", "pages", "2", "rows", "0", "view", "content", "children", "0", "view", "content", "children", "4"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
@@ -41,6 +41,6 @@ struct EVYDropdownRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "3"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "3"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
@@ -40,6 +40,6 @@ struct EVYInlinePickerRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "2", "rows", "0", "view", "content", "children", "1", "view", "content", "children", "3"])
+		try! await EVY.getRow(["2", "pages", "2", "rows", "0", "view", "content", "children", "1", "view", "content", "children", "3"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYInputRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInputRow.swift
@@ -39,6 +39,6 @@ struct EVYInputRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "1"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "1"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
@@ -41,6 +41,6 @@ struct EVYSearchRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "6", "view", "content", "children", "0", "child"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "6", "view", "content", "children", "0"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
@@ -40,6 +40,6 @@ struct EVYSelectPhotoRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "0"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "0"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
@@ -40,6 +40,6 @@ struct EVYTextAreaRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "1", "rows", "0"])
+		try! await EVY.getRow(["2", "pages", "1", "rows", "0"])
 	}
 }

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -33,7 +33,7 @@ struct EVYTextSelectRow: View, EVYRowProtocol {
 		})
 		let temporaryId = UUID().uuidString
 		guard (try? EVY.updateValue(view.content.text, at: temporaryId)) != nil,
-		      let data = try? EVY.data.get(key: temporaryId),
+		      let data = try? EVY.data.getDraft(variableName: temporaryId),
 		      let decoded = try? data.decoded() else { return nil }
 		self.value = decoded
 	}

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -61,6 +61,6 @@ struct EVYTextSelectRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "3", "rows", "1", "view", "content", "children", "0", "child"])
+		try! await EVY.getRow(["2", "pages", "3", "rows", "1", "view", "content", "children", "0"])
 	}
 }

--- a/ios/evy/UI/Rows/View/EVYInfoRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInfoRow.swift
@@ -35,6 +35,6 @@ struct EVYInfoRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "4", "rows", "0"])
+		try! await EVY.getRow(["2", "pages", "4", "rows", "0"])
 	}
 }

--- a/ios/evy/UI/Rows/View/EVYInputListRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInputListRow.swift
@@ -35,6 +35,6 @@ struct EVYInputListRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "6", "view", "content", "child"])
+		try! await EVY.getRow(["2", "pages", "0", "rows", "6", "view", "content", "child"])
 	}
 }

--- a/ios/evy/UI/Rows/View/EVYTextRow.swift
+++ b/ios/evy/UI/Rows/View/EVYTextRow.swift
@@ -59,6 +59,6 @@ struct EVYTextRow: View, EVYRowProtocol {
 	AsyncPreview { asyncView in
 		EVYRow(row: asyncView)
 	} view: {
-		try! await EVY.getRow(["0", "pages", "0", "rows", "0"])
+		try! await EVY.getRow(["1", "pages", "0", "rows", "0"])
 	}
 }

--- a/ios/evy/UI/Views/EVYCalendar.swift
+++ b/ios/evy/UI/Views/EVYCalendar.swift
@@ -171,36 +171,47 @@ struct ViewOffsetKey: PreferenceKey {
 }
 
 struct EVYCalendar: View {
-    private var yLabels: [EVYCalendarLabel]
-    private var xLabels: [EVYCalendarLabel]
-    
     private let primarySource: String
-    private let secondaryTimeslotsData: [EVYCalendarTimeslotData]
+    private let secondarySource: String
     
+    @State private var yLabels: [EVYCalendarLabel]
+    @State private var xLabels: [EVYCalendarLabel]
     @State private var scrollOffset = CGPoint.zero
     @State private var calendarTimeslots: EVYCalendarTimeslots
     
     init(primary: String, secondary: String) {
         primarySource = primary
-        secondaryTimeslotsData = getTimeslotsData(secondary)
+        secondarySource = secondary
 
-        let primaryTimeslotsData = getTimeslotsData(primary)
+        let (xl, yl, timeslots) = Self.buildCalendarData(
+            primarySource: primary,
+            secondarySource: secondary
+        )
+        _xLabels = State(initialValue: xl)
+        _yLabels = State(initialValue: yl)
+        _calendarTimeslots = State(initialValue: timeslots)
+    }
+    
+    private static func buildCalendarData(
+        primarySource: String,
+        secondarySource: String
+    ) -> ([EVYCalendarLabel], [EVYCalendarLabel], EVYCalendarTimeslots) {
+        let primaryTimeslotsData = getTimeslotsData(primarySource)
+        let secondaryTimeslotsData = getTimeslotsData(secondarySource)
         
-        // Build the initial axis labels
-        xLabels = primaryTimeslotsData
+        var xLabels = primaryTimeslotsData
             .filter { $0.y == 0 }
-			.map {
-				EVYCalendarLabel(value: String($0.header),
-								 full: false)
-			}
-        yLabels = primaryTimeslotsData
+            .map {
+                EVYCalendarLabel(value: String($0.header),
+                                 full: false)
+            }
+        var yLabels = primaryTimeslotsData
             .filter { $0.x == 0 }
-			.map {
-				EVYCalendarLabel(value: String($0.start_label),
-								 full: false)
-			}
+            .map {
+                EVYCalendarLabel(value: String($0.start_label),
+                                 full: false)
+            }
         
-        // Mark the axis labels as full if needed
         for x in 0..<xLabels.count {
             let selectedInColumn = primaryTimeslotsData
                 .filter { $0.x == x && $0.selected }
@@ -218,7 +229,6 @@ struct EVYCalendar: View {
             yLabels[y].full = true
         }
         
-        // Append a label to yaxis to denote the end
         if !primaryTimeslotsData.isEmpty {
             yLabels.append(
                 EVYCalendarLabel(value: primaryTimeslotsData.last!.end_label,
@@ -226,11 +236,32 @@ struct EVYCalendar: View {
             )
         }
         
-        // Build the initial calendar timeslots to display
-        calendarTimeslots = EVYCalendarTimeslots(rows: yLabels.count-1,
-                                                      columns: xLabels.count,
-                                                      primaryTimeslotsData: primaryTimeslotsData,
-                                                      secondaryTimeslotsData: secondaryTimeslotsData)
+        let timeslots = EVYCalendarTimeslots(
+            rows: max(yLabels.count - 1, 0),
+            columns: xLabels.count,
+            primaryTimeslotsData: primaryTimeslotsData,
+            secondaryTimeslotsData: secondaryTimeslotsData
+        )
+        
+        return (xLabels, yLabels, timeslots)
+    }
+    
+    private func reloadData(animated: Bool = false) {
+        let (xl, yl, timeslots) = Self.buildCalendarData(
+            primarySource: primarySource,
+            secondarySource: secondarySource
+        )
+        if animated {
+            withAnimation(.linear(duration: animationDuration)) {
+                xLabels = xl
+                yLabels = yl
+                calendarTimeslots = timeslots
+            }
+        } else {
+            xLabels = xl
+            yLabels = yl
+            calendarTimeslots = timeslots
+        }
     }
     
     private func handleOperation(_ operation: EVYCalendarOperation) {
@@ -272,12 +303,7 @@ struct EVYCalendar: View {
             }
         }
         
-        withAnimation(.linear(duration: animationDuration)) {
-            calendarTimeslots = EVYCalendarTimeslots(rows: yLabels.count-1,
-                                                     columns: xLabels.count,
-                                                     primaryTimeslotsData: getTimeslotsData(primarySource),
-                                                     secondaryTimeslotsData: secondaryTimeslotsData)
-        }
+        reloadData(animated: true)
     }
     
     var body: some View {
@@ -299,8 +325,12 @@ struct EVYCalendar: View {
                     }.scrollIndicators(.hidden)
                 }.coordinateSpace(name: "scroll")
             }
-        }.environment(\.operate) { calendarOperation in
+        }
+        .environment(\.operate) { calendarOperation in
             handleOperation(calendarOperation)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .evyDataUpdated)) { _ in
+            reloadData()
         }
     }
 }
@@ -327,8 +357,12 @@ private func getTimeslotsData(_ source: String) -> [EVYCalendarTimeslotData] {
 		asyncView
 	} view: {
 		try! await EVY.createItem()
-		
-	return EVYCalendar(primary: "{pickup_timeslots}",
+
+		let timeslotsData = (try? EVY.data.get(key: "timeslots"))?.data
+		EVY.ensureDraftExists(variableName: "pickup_timeslots", initialData: timeslotsData)
+		EVY.ensureDraftExists(variableName: "delivery_timeslots", initialData: timeslotsData)
+
+		return EVYCalendar(primary: "{pickup_timeslots}",
 					   secondary: "{delivery_timeslots}")
 	}
 }

--- a/ios/evy/UI/Views/EVYDropdown.swift
+++ b/ios/evy/UI/Views/EVYDropdown.swift
@@ -28,20 +28,29 @@ struct EVYDropdown: View {
         self.format = format
         self.placeholder = placeholder
         
+        var loadedOptions: [EVYJson] = []
+        
         do {
             let data = try EVY.getDataFromText(data)
             if case let .array(arrayValue) = data {
-                options = arrayValue
+                loadedOptions = arrayValue
             }
         } catch {
             #if DEBUG
             print("[EVYDropdown] Error loading options: \(error)")
             #endif
         }
+        options = loadedOptions
         
         selection = EVYState(watch: destination, setter: {
             do {
                 let value = try EVY.getDataFromText($0)
+                if case let .string(identifier) = value {
+                    if identifier.isEmpty { return "" }
+                    if let matchingOption = loadedOptions.first(where: { $0.identifierValue() == identifier }) {
+                        return try EVY.formatData(json: matchingOption, format: format)
+                    }
+                }
                 return try EVY.formatData(json: value, format: format)
             } catch {
                 #if DEBUG

--- a/ios/evy/UI/Views/EVYInlinePicker.swift
+++ b/ios/evy/UI/Views/EVYInlinePicker.swift
@@ -13,54 +13,69 @@ struct EVYInlinePicker: View {
     let destination: String
     
     private var options: [EVYJson] = []
+    private var selectedIdentifiers: EVYState<[String]>
     
-    @State private var selection: EVYJson
-    
-    init(title: String, data: String, format: String, destination: String) {
+    init(title: String,
+         data: String,
+         format: String,
+         destination: String)
+    {
         self.title = title
         self.format = format
         self.destination = destination
         
+        var loadedOptions: [EVYJson] = []
         do {
             let data = try EVY.getDataFromText(data)
             if case let .array(arrayValue) = data {
-                options.append(contentsOf: arrayValue)
+                loadedOptions.append(contentsOf: arrayValue)
             }
         } catch {
             #if DEBUG
             print("[EVYInlinePicker] Error loading options: \(error)")
             #endif
         }
+        options = loadedOptions
         
-        _selection = State(initialValue: options.first!)
-        
-        do {
-            let selected = try EVY.getDataFromText(destination)
-            if case let .string(stringValue) = selected {
-                let matching = options.first { option in
-                    option.identifierValue() == stringValue
+        selectedIdentifiers = EVYState(watch: destination, setter: {
+            do {
+                let selected = try EVY.getDataFromText($0)
+                guard case let .array(arrayValue) = selected else {
+                    throw EVYError.invalidData(context: "InlinePicker destination '\($0)' must be an array.")
                 }
-                if matching != nil {
-                    _selection = State(initialValue: matching!)
-                }
+                return arrayValue.map { $0.identifierValue() }
+            } catch {
+                NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
+                #if DEBUG
+                print("[EVYInlinePicker] Error loading selection: \(error)")
+                #endif
             }
-        } catch {
-            #if DEBUG
-            print("[EVYInlinePicker] Error loading selection: \(error)")
-            #endif
-        }
+            return []
+        })
     }
     
     private func performAction(option: EVYJson) {
-        selection = option
-        
-        try! EVY.updateValue(option.identifierValue(), at: destination)
+        let optionIdentifier = option.identifierValue()
+        do {
+            var updatedIdentifiers = selectedIdentifiers.value.filter {
+                $0 != optionIdentifier
+            }
+            if updatedIdentifiers.count == selectedIdentifiers.value.count {
+                updatedIdentifiers.append(optionIdentifier)
+            }
+            let encoded = try JSONEncoder().encode(updatedIdentifiers)
+            try EVY.updateData(encoded, at: destination)
+        } catch {
+            #if DEBUG
+            print("[EVYInlinePicker] Error updating selection: \(error)")
+            #endif
+        }
     }
     
     var body: some View {
         HStack {
             ForEach(Array(options.enumerated()), id: \.offset) { _, option in
-                let isSelected = option.identifierValue() == selection.identifierValue()
+                let isSelected = selectedIdentifiers.value.contains(option.identifierValue())
                 Button(action: {
                     performAction(option: option)
                 }) {

--- a/ios/evy/UI/Views/EVYSelectItem.swift
+++ b/ios/evy/UI/Views/EVYSelectItem.swift
@@ -24,6 +24,7 @@ struct EVYSelectItem: View {
     let selectionStyle: EVYRadioStyle
     let target: EVYSelectItemTarget
     let textStyle: EVYTextStyle
+    let onSelect: (() -> Void)?
     
     private var selected: EVYState<Bool>
     
@@ -32,7 +33,8 @@ struct EVYSelectItem: View {
          format: String,
          selectionStyle: EVYRadioStyle,
          target: EVYSelectItemTarget,
-         textStyle: EVYTextStyle = .body)
+         textStyle: EVYTextStyle = .body,
+         onSelect: (() -> Void)? = nil)
     {
         self.destination = destination
         self.value = value
@@ -40,6 +42,7 @@ struct EVYSelectItem: View {
         self.selectionStyle = selectionStyle
         self.target = target
         self.textStyle = textStyle
+        self.onSelect = onSelect
         
         selected = EVYState(watch: destination, setter: {
             do {
@@ -157,7 +160,7 @@ struct EVYSelectItem: View {
                         try EVY.updateData(encoded, at: destination)
                     }
                 }
-                
+                onSelect?()
             } catch {
                 #if DEBUG
                 print("[EVYSelectItem] Error updating selection: \(error)")

--- a/ios/evy/UI/Views/EVYSelectList.swift
+++ b/ios/evy/UI/Views/EVYSelectList.swift
@@ -11,6 +11,7 @@ struct EVYSelectList: View {
     let options: [EVYJson]
     let format: String
     let destination: String
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         List {
@@ -19,7 +20,8 @@ struct EVYSelectList: View {
                               value: value,
                               format: format,
                               selectionStyle: .single,
-                              target: .single_identifier)
+                              target: .single_identifier,
+                              onSelect: { dismiss() })
 				.frame(height: Constants.listRowHeight)
             }
             .listRowSeparator(.hidden)

--- a/ios/evy/UI/Views/EVYTextField.swift
+++ b/ios/evy/UI/Views/EVYTextField.swift
@@ -13,7 +13,9 @@ struct EVYTextField: View {
     let multiLine: Bool
     let input: String
     
+    @Bindable private var displayValue: EVYState<EVYValue>
     @Bindable private var editableValue: EVYState<EVYValue>
+    @Bindable private var placeholderValue: EVYState<EVYValue>
     
     @FocusState private var focused: Bool
     @State private var editing: Bool = false
@@ -24,8 +26,14 @@ struct EVYTextField: View {
         self.destination = destination
         self.multiLine = multiLine
         
+        self.displayValue = EVYState(watch: input, setter: {
+            Self.resolveValue(from: $0)
+        })
         self.editableValue = EVYState(watch: input, setter: {
-            (try? EVY.getValueFromText($0, editing: true)) ?? EVYValue($0, nil, nil)
+            Self.resolveValue(from: $0, editing: true)
+        })
+        self.placeholderValue = EVYState(watch: placeholder, setter: {
+            Self.resolveValue(from: $0)
         })
     }
     
@@ -36,11 +44,21 @@ struct EVYTextField: View {
                   multiLine: false)
     }
     
+    private static func resolveValue(from text: String, editing: Bool = false) -> EVYValue {
+        if let resolvedValue = try? EVY.getValueFromText(text, editing: editing) {
+            return resolvedValue
+        }
+        if EVY.parsePropsFromText(text) == text {
+            return EVYValue(text, nil, nil)
+        }
+        return EVYValue("", nil, nil)
+    }
+    
     var body: some View {
         Group {
             if !editing || destination.isEmpty {
-                let display = EVYTextView(input)
-                let placeholder = EVYTextView(placeholder, style: .info)
+                let display = EVYTextView(displayValue.value.toString())
+                let placeholder = EVYTextView(placeholderValue.value.toString(), style: .info)
                 
                 if display.text.value.value.count > 0 {
                     display.frame(maxWidth: .infinity, alignment: .leading)
@@ -49,7 +67,7 @@ struct EVYTextField: View {
                 }
             } else {
                 TextField(text: $editableValue.value.value,
-                          prompt: EVYTextView(placeholder).toText(),
+                          prompt: EVYTextView(placeholderValue.value.toString()).toText(),
                           axis: multiLine ? .vertical : .horizontal,
                           label: {})
                 .font(.evy)

--- a/ios/evy/UI/Views/EVYTextField.swift
+++ b/ios/evy/UI/Views/EVYTextField.swift
@@ -26,14 +26,17 @@ struct EVYTextField: View {
         self.destination = destination
         self.multiLine = multiLine
         
-        self.displayValue = EVYState(watch: input, setter: {
-            Self.resolveValue(from: $0)
+        let inputWatchTarget = Self.watchTarget(for: input)
+        let placeholderWatchTarget = Self.watchTarget(for: placeholder)
+        
+        self.displayValue = EVYState(watch: inputWatchTarget, setter: { _ in
+            Self.resolveValue(from: input)
         })
-        self.editableValue = EVYState(watch: input, setter: {
-            Self.resolveValue(from: $0, editing: true)
+        self.editableValue = EVYState(watch: inputWatchTarget, setter: { _ in
+            Self.resolveValue(from: input, editing: true)
         })
-        self.placeholderValue = EVYState(watch: placeholder, setter: {
-            Self.resolveValue(from: $0)
+        self.placeholderValue = EVYState(watch: placeholderWatchTarget, setter: { _ in
+            Self.resolveValue(from: placeholder)
         })
     }
     
@@ -52,6 +55,17 @@ struct EVYTextField: View {
             return EVYValue(text, nil, nil)
         }
         return EVYValue("", nil, nil)
+    }
+    
+    private static func watchTarget(for text: String) -> String {
+        let parsedProps = EVY.parsePropsFromText(text)
+        if parsedProps == text {
+            return text
+        }
+        if let functionCall = EVYInterpreter.parseFunctionCall(parsedProps) {
+            return functionCall.functionArgs
+        }
+        return parsedProps
     }
     
     var body: some View {

--- a/ios/evy/UI/Views/EVYTextField.swift
+++ b/ios/evy/UI/Views/EVYTextField.swift
@@ -112,8 +112,10 @@ struct EVYTextField: View {
         )
         .contentShape(Rectangle())
         .onTapGesture {
-            editing.toggle()
-            focused.toggle()
+            if !editing {
+                editing = true
+                focused = true
+            }
         }
         .accessibilityIdentifier("textField_\(destination)")
     }

--- a/ios/evy/UI/Views/EVYTextField.swift
+++ b/ios/evy/UI/Views/EVYTextField.swift
@@ -128,22 +128,22 @@ struct EVYTextField: View {
 		try! await EVY.createItem()
 		
 		return VStack {
-		EVYTextField(input: "{formatDimension(width)}",
-					 destination: "{width}",
+		EVYTextField(input: "{formatDimension(item.dimensions.width)}",
+					 destination: "{item.dimensions.width}",
 					 placeholder: "10",
 					 multiLine: true)
 		
-		EVYTextField(input: "{formatCurrency(price)}",
-					 destination: "{price}",
+		EVYTextField(input: "{formatCurrency(item.price)}",
+					 destination: "{item.price}",
 					 placeholder: "10")
 					 
-		EVYTextField(input: "{title}",
-					 destination: "{title}",
+		EVYTextField(input: "{item.title}",
+					 destination: "{item.title}",
 					 placeholder: "Sample placeholder",
 					 multiLine: true)
 		
-		EVYTextField(input: "{title}",
-					 destination: "{title}",
+		EVYTextField(input: "{item.title}",
+					 destination: "{item.title}",
 					 placeholder: "Sample placeholder")
 			
 			EVYTextField(input: "",

--- a/ios/evy/Utils/EVYFunctions.swift
+++ b/ios/evy/Utils/EVYFunctions.swift
@@ -46,57 +46,84 @@ func evyLength(_ args: String) throws -> EVYFunctionOutput {
 func evyFormatCurrency(_ args: String,
                        _ editing: Bool = false) throws -> EVYFunctionOutput {
     let res = try EVY.getDataFromProps(args)
+    
+    let rawValue: String
     switch res {
     case let .dictionary(dictValue):
         guard let value = dictValue["value"] else {
             throw EVYError.formatFailed(type: "currency", reason: "missing 'value' field")
         }
-        if editing {
-            return EVYFunctionOutput(value: "\(value.toString())", prefix: nil, suffix: nil)
-        }
-        guard let number = NumberFormatter().number(from: value.toString()) else {
-            throw EVYError.formatFailed(type: "currency", reason: "could not parse number from '\(value.toString())'")
-        }
-        return EVYFunctionOutput(value: String(format: "%.2f", CGFloat(truncating: number)), prefix: "$", suffix: nil)
+        rawValue = value.toString()
+    case let .string(stringValue):
+        rawValue = stringValue
+    case let .int(intValue):
+        rawValue = String(intValue)
+    case let .decimal(decimalValue):
+        rawValue = "\(decimalValue)"
     default:
         throw EVYError.formatFailed(type: "currency", reason: "expected dictionary, got \(res)")
     }
+    
+    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedValue.isEmpty {
+        return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
+    }
+    if editing {
+        return EVYFunctionOutput(value: trimmedValue, prefix: nil, suffix: nil)
+    }
+    guard let number = NumberFormatter().number(from: trimmedValue) else {
+        throw EVYError.formatFailed(type: "currency", reason: "could not parse number from '\(trimmedValue)'")
+    }
+    return EVYFunctionOutput(value: String(format: "%.2f", CGFloat(truncating: number)), prefix: "$", suffix: nil)
 }
 
 @MainActor
 func evyFormatDimension(_ args: String,
                         _ editing: Bool = false) throws -> EVYFunctionOutput {
     let res = try EVY.getDataFromProps(args)
+    
+    let mm: Int
     switch res {
-	case let .int(mm):
-        if editing {
-            return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+    case let .int(intValue):
+        mm = intValue
+    case let .string(stringValue):
+        let trimmedValue = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedValue.isEmpty {
+            return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
         }
-        if mm > 1000 {
-            let meters = Decimal(mm/1000)
-            let truncatedMeters = NSDecimalNumber(decimal: meters).intValue
-            if meters == Decimal(integerLiteral: truncatedMeters) {
-                return EVYFunctionOutput(value: "\(truncatedMeters)", prefix: nil, suffix: "m")
-            }
-            return EVYFunctionOutput(value: "\(meters)", prefix: nil, suffix: "m")
+        guard let parsedValue = Int(trimmedValue) else {
+            throw EVYError.formatFailed(type: "dimension", reason: "could not parse integer from '\(trimmedValue)'")
         }
-        if mm > 100 {
-            let cm = Decimal(mm/10)
-            let truncatedCM = NSDecimalNumber(decimal: cm).intValue
-            if cm == Decimal(integerLiteral: truncatedCM) {
-                return EVYFunctionOutput(value: "\(truncatedCM)", prefix: nil, suffix: "cm")
-            }
-            return EVYFunctionOutput(value: "\(cm)", prefix: nil, suffix: "cm")
-        }
-        
-		let truncatedMM = NSDecimalNumber(integerLiteral: mm).intValue
-        if mm == truncatedMM {
-            return EVYFunctionOutput(value: "\(truncatedMM)", prefix: nil, suffix: "mm")
-        }
-        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: "mm")
+        mm = parsedValue
     default:
         throw EVYError.formatFailed(type: "dimension", reason: "expected integer, got \(res)")
     }
+    
+    if editing {
+        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+    }
+    if mm > 1000 {
+        let meters = Decimal(mm/1000)
+        let truncatedMeters = NSDecimalNumber(decimal: meters).intValue
+        if meters == Decimal(integerLiteral: truncatedMeters) {
+            return EVYFunctionOutput(value: "\(truncatedMeters)", prefix: nil, suffix: "m")
+        }
+        return EVYFunctionOutput(value: "\(meters)", prefix: nil, suffix: "m")
+    }
+    if mm > 100 {
+        let cm = Decimal(mm/10)
+        let truncatedCM = NSDecimalNumber(decimal: cm).intValue
+        if cm == Decimal(integerLiteral: truncatedCM) {
+            return EVYFunctionOutput(value: "\(truncatedCM)", prefix: nil, suffix: "cm")
+        }
+        return EVYFunctionOutput(value: "\(cm)", prefix: nil, suffix: "cm")
+    }
+    
+    let truncatedMM = NSDecimalNumber(integerLiteral: mm).intValue
+    if mm == truncatedMM {
+        return EVYFunctionOutput(value: "\(truncatedMM)", prefix: nil, suffix: "mm")
+    }
+    return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: "mm")
 }
 
 @MainActor
@@ -166,8 +193,188 @@ func evyFormatAddress(_ args: String) throws -> EVYFunctionOutput {
     }
 }
 
+@MainActor
+func evyBuildCurrency(_ args: String,
+                      _ value: String) throws -> Data {
+    let existingCurrency = evyExistingCurrency(for: args) ?? "AUD"
+    let builtCurrency = EVYJson.dictionary([
+        "currency": .string(existingCurrency),
+        "value": evyJsonValue(from: value)
+    ])
+    return try JSONEncoder().encode(builtCurrency)
+}
+
+@MainActor
+func evyBuildAddress(_ args: String,
+                     _ value: String) throws -> Data {
+    let existingData = try? EVY.getDataFromProps(args)
+    let existingAddress: [String: EVYJson]
+    if case let .dictionary(dictValue) = existingData {
+        existingAddress = dictValue
+    } else {
+        existingAddress = [:]
+    }
+    
+    let builtAddress = EVYJson.dictionary(
+        evyAddressFields(from: value, existingAddress: existingAddress)
+    )
+    return try JSONEncoder().encode(builtAddress)
+}
+
 private func evyNumericValue(_ value: String) -> Decimal? {
     Decimal(string: value.trimmingCharacters(in: .whitespacesAndNewlines))
+}
+
+private func evyJsonValue(from value: String) -> EVYJson {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedValue.isEmpty {
+        return .string("")
+    }
+    if let intValue = Int(trimmedValue) {
+        return .int(intValue)
+    }
+    if let decimalValue = Decimal(string: trimmedValue) {
+        return .decimal(decimalValue)
+    }
+    return .string(trimmedValue)
+}
+
+@MainActor
+private func evyExistingCurrency(for props: String) -> String? {
+    guard let existingData = try? EVY.getDataFromProps(props),
+          case let .dictionary(dictValue) = existingData,
+          let currencyValue = dictValue["currency"]
+    else {
+        return nil
+    }
+    return currencyValue.toString()
+}
+
+private func evyAddressFields(from value: String,
+                              existingAddress: [String: EVYJson]) -> [String: EVYJson] {
+    let requiredKeys = ["unit", "street", "city", "postcode", "state"]
+    var addressFields = existingAddress
+    
+    for key in requiredKeys where addressFields[key] == nil {
+        addressFields[key] = .string("")
+    }
+    
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedValue.isEmpty {
+        return addressFields
+    }
+    
+    let parsedFields = evyParsedAddressFields(from: trimmedValue, existingAddress: addressFields)
+    for (key, parsedValue) in parsedFields {
+        addressFields[key] = .string(parsedValue)
+    }
+    
+    return addressFields
+}
+
+private func evyParsedAddressFields(from value: String,
+                                    existingAddress: [String: EVYJson]) -> [String: String] {
+    let normalizedValue = value.replacingOccurrences(of: "\r\n", with: "\n")
+    let lines = normalizedValue
+        .split(separator: "\n", omittingEmptySubsequences: true)
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+    
+    if lines.count >= 2 {
+        return evyParsedTwoLineAddress(
+            firstLine: lines[0],
+            secondLine: lines[1],
+            existingAddress: existingAddress
+        )
+    }
+    
+    let commaSeparatedParts = normalizedValue
+        .split(separator: ",", omittingEmptySubsequences: true)
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+    
+    if commaSeparatedParts.count >= 2 {
+        return evyParsedSingleLineAddress(
+            firstPart: commaSeparatedParts[0],
+            secondPart: commaSeparatedParts[1],
+            existingAddress: existingAddress
+        )
+    }
+    
+    return [
+        "unit": existingAddress["unit"]?.toString() ?? "",
+        "street": normalizedValue,
+        "city": existingAddress["city"]?.toString() ?? "",
+        "postcode": existingAddress["postcode"]?.toString() ?? "",
+        "state": existingAddress["state"]?.toString() ?? ""
+    ]
+}
+
+private func evyParsedTwoLineAddress(firstLine: String,
+                                     secondLine: String,
+                                     existingAddress: [String: EVYJson]) -> [String: String] {
+    let firstLineParts = firstLine
+        .split(separator: ",", omittingEmptySubsequences: true)
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+    let secondLineParts = secondLine
+        .split(separator: ",", omittingEmptySubsequences: true)
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+    
+    let unitAndStreet = evyAddressUnitAndStreet(
+        from: firstLineParts.first ?? firstLine,
+        existingAddress: existingAddress
+    )
+    
+    return [
+        "unit": unitAndStreet.unit,
+        "street": unitAndStreet.street,
+        "city": secondLineParts.first ?? "",
+        "postcode": firstLineParts.count > 1 ? firstLineParts[1] : "",
+        "state": secondLineParts.count > 1 ? secondLineParts[1] : ""
+    ]
+}
+
+private func evyParsedSingleLineAddress(firstPart: String,
+                                        secondPart: String,
+                                        existingAddress: [String: EVYJson]) -> [String: String] {
+    let unitAndStreet = evyAddressUnitAndStreet(
+        from: firstPart,
+        existingAddress: existingAddress
+    )
+    let locationParts = secondPart
+        .split(separator: " ", omittingEmptySubsequences: true)
+        .map(String.init)
+    
+    let postcode = locationParts.last ?? ""
+    let state = locationParts.count > 1 ? locationParts[locationParts.count - 2] : ""
+    let city = locationParts.count > 2
+        ? locationParts.dropLast(2).joined(separator: " ")
+        : ""
+    
+    return [
+        "unit": unitAndStreet.unit,
+        "street": unitAndStreet.street,
+        "city": city,
+        "postcode": postcode,
+        "state": state
+    ]
+}
+
+private func evyAddressUnitAndStreet(from input: String,
+                                     existingAddress: [String: EVYJson]) -> (unit: String, street: String) {
+    let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    let existingStreet = existingAddress["street"]?.toString() ?? ""
+    
+    if !existingStreet.isEmpty, trimmedInput.hasSuffix(existingStreet) {
+        let unit = String(trimmedInput.dropLast(existingStreet.count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (unit, existingStreet)
+    }
+    
+    let parts = trimmedInput.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+    if parts.count == 2 {
+        return (String(parts[0]), String(parts[1]))
+    }
+    
+    return ("", trimmedInput)
 }
 
 private func evyCompareValues<T: Comparable>(_ comparisonOperator: String,

--- a/ios/evy/Utils/EVYFunctions.swift
+++ b/ios/evy/Utils/EVYFunctions.swift
@@ -130,38 +130,50 @@ func evyFormatDimension(_ args: String,
 func evyFormatWeight(_ args: String,
                      _ editing: Bool = false) throws -> EVYFunctionOutput {
     let res = try EVY.getDataFromProps(args)
+    
+    let rawValue: String
     switch res {
     case let .string(stringValue):
-        if editing {
-            return EVYFunctionOutput(value: stringValue, prefix: nil, suffix: nil)
-        }
-        guard let mg = Decimal(string: stringValue) else {
-            throw EVYError.formatFailed(type: "weight", reason: "could not parse decimal from '\(stringValue)'")
-        }
-        if mg > 1000000 {
-            let kg = mg/1000000
-            let truncatedKG = NSDecimalNumber(decimal: kg).intValue
-            if kg == Decimal(integerLiteral: truncatedKG) {
-                return EVYFunctionOutput(value: "\(truncatedKG)", prefix: nil, suffix: "kg")
-            }
-            return EVYFunctionOutput(value: "\(kg)", prefix: nil, suffix: "kg")
-        }
-        if mg > 1000 {
-            let gram = mg/1000
-            let truncatedGram = NSDecimalNumber(decimal: gram).intValue
-            if gram == Decimal(integerLiteral: truncatedGram) {
-                return EVYFunctionOutput(value: "\(truncatedGram)", prefix: nil, suffix: "g")
-            }
-            return EVYFunctionOutput(value: "\(gram)", prefix: nil, suffix: "g")
-        }
-        let truncatedMG = NSDecimalNumber(decimal: mg).intValue
-        if mg == Decimal(integerLiteral: truncatedMG) {
-            return EVYFunctionOutput(value: "\(truncatedMG)", prefix: nil, suffix: "mg")
-        }
-        return EVYFunctionOutput(value: "\(mg)", prefix: nil, suffix: "mg")
+        rawValue = stringValue
+    case let .int(intValue):
+        rawValue = String(intValue)
+    case let .decimal(decimalValue):
+        rawValue = "\(decimalValue)"
     default:
-        throw EVYError.formatFailed(type: "weight", reason: "expected string, got \(res)")
+        throw EVYError.formatFailed(type: "weight", reason: "expected string or number, got \(res)")
     }
+    
+    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedValue.isEmpty {
+        return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
+    }
+    if editing {
+        return EVYFunctionOutput(value: trimmedValue, prefix: nil, suffix: nil)
+    }
+    guard let mg = Decimal(string: trimmedValue) else {
+        throw EVYError.formatFailed(type: "weight", reason: "could not parse decimal from '\(trimmedValue)'")
+    }
+    if mg > 1000000 {
+        let kg = mg/1000000
+        let truncatedKG = NSDecimalNumber(decimal: kg).intValue
+        if kg == Decimal(integerLiteral: truncatedKG) {
+            return EVYFunctionOutput(value: "\(truncatedKG)", prefix: nil, suffix: "kg")
+        }
+        return EVYFunctionOutput(value: "\(kg)", prefix: nil, suffix: "kg")
+    }
+    if mg > 1000 {
+        let gram = mg/1000
+        let truncatedGram = NSDecimalNumber(decimal: gram).intValue
+        if gram == Decimal(integerLiteral: truncatedGram) {
+            return EVYFunctionOutput(value: "\(truncatedGram)", prefix: nil, suffix: "g")
+        }
+        return EVYFunctionOutput(value: "\(gram)", prefix: nil, suffix: "g")
+    }
+    let truncatedMG = NSDecimalNumber(decimal: mg).intValue
+    if mg == Decimal(integerLiteral: truncatedMG) {
+        return EVYFunctionOutput(value: "\(truncatedMG)", prefix: nil, suffix: "mg")
+    }
+    return EVYFunctionOutput(value: "\(mg)", prefix: nil, suffix: "mg")
 }
 
 @MainActor
@@ -411,22 +423,23 @@ func evyComparison(_ comparisonOperator: String, left: String, right: String) ->
 	AsyncPreview { asyncView in
 		asyncView
 	} view: {
+		try! EVY.getUserData()
 		try! await EVY.createItem()
 		
 		return VStack {
-		EVYTextView("{formatDimension(width)}")
+		EVYTextView("{formatDimension(item.dimensions.width)}")
 		EVYTextView("a == a: {a == a}")
 		EVYTextView("a == b: {a == b}")
 		EVYTextView("1 == 2: {1 == 2}")
 		EVYTextView("1 == 1: {1 == 1}")
 		EVYTextView("1 != 1: {1 != 1}")
-		EVYTextView("title == Amazing: {{title} == Amazing}")
-		EVYTextView("title == Amazing Fridge: {{title} == Amazing Fridge}")
-		EVYTextView("Amazing Fridge == title: {Amazing Fridge == {title}}")
-		EVYTextView("count (title) == 13: {{count(title)} == 13}")
-		EVYTextView("count (title) == 14: {{count(title)} == 14}")
-		EVYTextView("count (title) > 0: {{count(title)} > 0}")
-		EVYTextView("{formatAddress(pickup_address)}")
+		EVYTextView("title == Amazing: {{item.title} == Amazing}")
+		EVYTextView("title == Amazing Fridge: {{item.title} == Amazing Fridge}")
+		EVYTextView("Amazing Fridge == title: {Amazing Fridge == {item.title}}")
+		EVYTextView("count (title) == 13: {{count(item.title)} == 13}")
+		EVYTextView("count (title) == 14: {{count(item.title)} == 14}")
+		EVYTextView("count (title) > 0: {{count(item.title)} > 0}")
+		EVYTextView("{formatAddress(user.address)}")
 		}
 	}
 }

--- a/ios/evy/Utils/EVYInterpreter.swift
+++ b/ios/evy/Utils/EVYInterpreter.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 private let comparisonBlockPattern = "\\{[^{}\"]+\\}"
-private let comparisonOperatorPattern = "(>=|<=|==|!=|>|<)"
 private let comparisonOperators = [">=", "<=", "==", "!=", ">", "<"]
 private let propsPattern = "\\{(?!\")[^}^\"]*(?!\")\\}"
 private let functionParamsPattern = "\\(([^)]*)\\)"
@@ -168,14 +167,6 @@ private func parseProps(_ input: String) -> (Regex<AnyRegexOutput>.Match, String
     if let match = try? firstMatch(input, pattern: propsPattern) {
         // Remove leading and trailing curly braces
         return (match, String(match.0.dropFirst().dropLast()))
-    }
-    return nil
-}
-
-private func parseArrayFromProps(_ input: String) -> (Regex<AnyRegexOutput>.Match, String)? {
-    if let match = try? firstMatch(input, pattern: arrayPattern) {
-        // Remove leading and trailing curly braces
-        return (match, String(match.0))
     }
     return nil
 }

--- a/ios/evy/Utils/EVYInterpreter.swift
+++ b/ios/evy/Utils/EVYInterpreter.swift
@@ -123,6 +123,8 @@ struct EVYInterpreter {
                 value = try evyFormatWeight(funcArgs, editing)
             case "formatAddress":
                 value = try evyFormatAddress(funcArgs)
+            case "buildCurrency", "buildAddress":
+                value = nil
             default:
                 value = nil
             }

--- a/ios/evy/Utils/EVYInterpreter.swift
+++ b/ios/evy/Utils/EVYInterpreter.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-private let comparisonBasePattern = "[a-zA-Z0-9_.\\(\\){} ]+"
+private let comparisonBlockPattern = "\\{[^{}\"]+\\}"
 private let comparisonOperatorPattern = "(>=|<=|==|!=|>|<)"
+private let comparisonOperators = [">=", "<=", "==", "!=", ">", "<"]
 private let propsPattern = "\\{(?!\")[^}^\"]*(?!\")\\}"
 private let functionParamsPattern = "\\(([^)]*)\\)"
 private let functionPattern = "[a-zA-Z_]+\(functionParamsPattern)"
@@ -83,17 +84,22 @@ struct EVYInterpreter {
             return input
         }
         
-        if let (match, comparisonOperator, left, right) = parseComparisonFromText(input.value)
+        if let (fullMatch, comparison) = parseComparisonFromText(input.value)
         {
-            let parsedLeft = try parseText(EVYValue(left, input.prefix, input.suffix),
-                                           editing)
-            let parsedRight = try parseText(EVYValue(right, input.prefix, input.suffix),
-                                            editing)
-            let comparisonResult = evyComparison(comparisonOperator,
-                                                 left: parsedLeft.value,
-                                                 right: parsedRight.value)
+            let comparisonResult = try evaluateBooleanExpression(comparison) { operand in
+                let trimmedOperand = operand.trimmingCharacters(in: .whitespacesAndNewlines)
+                let parsedOperand = try parseText(EVYValue(trimmedOperand, nil, nil),
+                                                  editing)
+                if parsedOperand.value != trimmedOperand {
+                    return parsedOperand.value
+                }
+                if let propsValue = try? EVY.getDataFromText("{\(trimmedOperand)}") {
+                    return propsValue.toString()
+                }
+                return parsedOperand.value
+            }
             let parsedInput = input.value.replacingOccurrences(
-                of: match.0.description,
+                of: fullMatch,
                 with: comparisonResult ? "true" : "false"
             )
             return try parseText(EVYValue(parsedInput, input.prefix, input.suffix),
@@ -174,35 +180,180 @@ private func parseArrayFromProps(_ input: String) -> (Regex<AnyRegexOutput>.Matc
     return nil
 }
 
-private func parseComparisonFromText(_ input: String) -> (match: Regex<AnyRegexOutput>.Match,
-                                                          comparisonOperator: String,
-                                                          left: String,
-                                                          right: String)?
+private func parseComparisonFromText(_ input: String) -> (fullMatch: String, content: String)?
 {
-    guard let match = try? firstMatch(input,
-                                      pattern: "\\{\(comparisonBasePattern) \(comparisonOperatorPattern) \(comparisonBasePattern)\\}") else {
+    guard let regex = try? Regex(comparisonBlockPattern) else {
         return nil
+    }
+    for match in input.matches(of: regex) {
+        let block = String(match.0)
+        let comparison = String(block.dropFirst().dropLast())
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if containsTopLevelComparisonOperator(comparison) {
+            return (block, comparison)
+        }
+    }
+    return nil
+}
+
+private func evaluateBooleanExpression(_ input: String,
+                                       resolver: (String) throws -> String) throws -> Bool
+{
+    let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+    let orTerms = splitRespectingParens(trimmedInput, separator: "||")
+    if orTerms.count > 1 {
+        for term in orTerms {
+            if try evaluateBooleanExpression(term, resolver: resolver) {
+                return true
+            }
+        }
+        return false
     }
 
-    // Remove opening { from match
-    let comparison = String(match.0.description)
-    guard let leftMatch = try? firstMatch(comparison, pattern: "\\{\(comparisonBasePattern)") else {
-        return nil
-    }
-    guard let rightMatch = try? lastMatch(comparison, pattern: "\(comparisonBasePattern)\\}") else {
-        return nil
-    }
-    guard let operatorMatch = try? firstMatch(comparison, pattern: comparisonOperatorPattern) else {
-        return nil
+    let andTerms = splitRespectingParens(trimmedInput, separator: "&&")
+    if andTerms.count > 1 {
+        for term in andTerms {
+            if try !evaluateBooleanExpression(term, resolver: resolver) {
+                return false
+            }
+        }
+        return true
     }
 
-    let leftMatchWithBracket = leftMatch.0.description.trimmingCharacters(in: .whitespacesAndNewlines)
-    let left = leftMatchWithBracket.dropFirst()
-    let rightMatchWithBracket = rightMatch.0.description.trimmingCharacters(in: .whitespacesAndNewlines)
-    let right = rightMatchWithBracket.dropLast()
-    let comparisonOperator = operatorMatch.0.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    if isWrappedInParentheses(trimmedInput) {
+        let innerExpression = String(trimmedInput.dropFirst().dropLast())
+        return try evaluateBooleanExpression(innerExpression, resolver: resolver)
+    }
 
-    return (match, comparisonOperator, String(left), String(right))
+    if trimmedInput == "true" {
+        return true
+    }
+    if trimmedInput == "false" {
+        return false
+    }
+
+    guard let (left, comparisonOperator, right) = parseAtomicComparison(trimmedInput) else {
+        throw EVYError.invalidData(context: "Invalid comparison expression: \(trimmedInput)")
+    }
+
+    let resolvedLeft = try resolver(left)
+    let resolvedRight = try resolver(right)
+    return evyComparison(comparisonOperator, left: resolvedLeft, right: resolvedRight)
+}
+
+private func splitRespectingParens(_ input: String, separator: String) -> [String] {
+    guard !input.isEmpty else {
+        return [input]
+    }
+
+    var parts: [String] = []
+    var depth = 0
+    var currentStart = input.startIndex
+    var index = input.startIndex
+
+    while index < input.endIndex {
+        let character = input[index]
+        if character == "(" {
+            depth += 1
+        } else if character == ")" && depth > 0 {
+            depth -= 1
+        }
+
+        if depth == 0, input[index...].hasPrefix(separator) {
+            parts.append(String(input[currentStart..<index])
+                .trimmingCharacters(in: .whitespacesAndNewlines))
+            currentStart = input.index(index, offsetBy: separator.count)
+            index = currentStart
+            continue
+        }
+
+        index = input.index(after: index)
+    }
+
+    parts.append(String(input[currentStart...]).trimmingCharacters(in: .whitespacesAndNewlines))
+    return parts
+}
+
+private func parseAtomicComparison(_ input: String) -> (left: String,
+                                                        comparisonOperator: String,
+                                                        right: String)?
+{
+    var depth = 0
+    var index = input.startIndex
+
+    while index < input.endIndex {
+        let character = input[index]
+        if character == "(" {
+            depth += 1
+        } else if character == ")" && depth > 0 {
+            depth -= 1
+        }
+
+        if depth == 0 {
+            for comparisonOperator in comparisonOperators {
+                if input[index...].hasPrefix(comparisonOperator) {
+                    let left = String(input[..<index]).trimmingCharacters(in: .whitespacesAndNewlines)
+                    let rightStart = input.index(index, offsetBy: comparisonOperator.count)
+                    let right = String(input[rightStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !left.isEmpty, !right.isEmpty else {
+                        return nil
+                    }
+                    return (left, comparisonOperator, right)
+                }
+            }
+        }
+
+        index = input.index(after: index)
+    }
+
+    return nil
+}
+
+private func containsTopLevelComparisonOperator(_ input: String) -> Bool {
+    var depth = 0
+    var index = input.startIndex
+
+    while index < input.endIndex {
+        let character = input[index]
+        if character == "(" {
+            depth += 1
+        } else if character == ")" && depth > 0 {
+            depth -= 1
+        }
+
+        if depth == 0 {
+            for comparisonOperator in comparisonOperators {
+                if input[index...].hasPrefix(comparisonOperator) {
+                    return true
+                }
+            }
+        }
+
+        index = input.index(after: index)
+    }
+
+    return false
+}
+
+private func isWrappedInParentheses(_ input: String) -> Bool {
+    guard input.first == "(", input.last == ")" else {
+        return false
+    }
+
+    var depth = 0
+    for index in input.indices {
+        let character = input[index]
+        if character == "(" {
+            depth += 1
+        } else if character == ")" {
+            depth -= 1
+            if depth == 0 {
+                return index == input.index(before: input.endIndex)
+            }
+        }
+    }
+
+    return false
 }
 
 private func parseFunctionFromText(_ input: String) -> (match: Regex<AnyRegexOutput>.Match,
@@ -279,6 +430,9 @@ private func lastMatch(_ input: String, pattern: String) throws -> Regex<AnyRege
 	let withComparison = try! EVYInterpreter.parseTextFromText(
 		"{count(title) == count(selling_reasons)} v {count(title) == count(title)}"
 	)
+    let withMultiComparison = try! EVYInterpreter.parseTextFromText(
+        "{count(title) > 0 || (1 > 2 && count(selling_reasons) > 0)}"
+    )
 	
 	let weight = try! EVYInterpreter.parseTextFromText(
 		"{formatWeight(weight)}"
@@ -294,6 +448,7 @@ private func lastMatch(_ input: String, pattern: String) throws -> Regex<AnyRege
 			Text(withSuffix.toString())
 			Text(WithSuffixAndRight.toString())
 			Text(withComparison.toString())
+            Text(withMultiComparison.toString())
 			Text(weight.toString())
 			Text(firstSellingReason.toString())
 			

--- a/ios/evy/Utils/EVYInterpreter.swift
+++ b/ios/evy/Utils/EVYInterpreter.swift
@@ -415,27 +415,27 @@ private func lastMatch(_ input: String, pattern: String) throws -> Regex<AnyRege
 		try! await EVY.createItem()
 		
 	let bare = "test"
-	let data = "{title}"
+	let data = "{item.title}"
 	
 	let parsedData = try! EVYInterpreter.parseTextFromText(data)
 	let withPrefix = try! EVYInterpreter.parseTextFromText(
-		"{formatCurrency(price)}"
+		"{formatCurrency(item.price)}"
 	)
 	let withSuffix = try! EVYInterpreter.parseTextFromText(
-		"{formatDimension(width)}"
+		"{formatDimension(item.dimensions.width)}"
 	)
 	let WithSuffixAndRight = try! EVYInterpreter.parseTextFromText(
-		"{formatDimension(width)} - {title}"
+		"{formatDimension(item.dimensions.width)} - {item.title}"
 	)
 	let withComparison = try! EVYInterpreter.parseTextFromText(
-		"{count(title) == count(selling_reasons)} v {count(title) == count(title)}"
+		"{count(item.title) == count(selling_reasons)} v {count(item.title) == count(item.title)}"
 	)
     let withMultiComparison = try! EVYInterpreter.parseTextFromText(
-        "{count(title) > 0 || (1 > 2 && count(selling_reasons) > 0)}"
+        "{count(item.title) > 0 || (1 > 2 && count(selling_reasons) > 0)}"
     )
 	
 	let weight = try! EVYInterpreter.parseTextFromText(
-		"{formatWeight(weight)}"
+		"{formatWeight(item.dimensions.weight)}"
 	)
 		
 		let firstSellingReason = try! EVY.getDataFromText("{selling_reasons[0]}")
@@ -452,8 +452,8 @@ private func lastMatch(_ input: String, pattern: String) throws -> Regex<AnyRege
 			Text(weight.toString())
 			Text(firstSellingReason.toString())
 			
-		EVYTextField(input: "{formatCurrency(price)}",
-					 destination: "{price}",
+		EVYTextField(input: "{formatCurrency(item.price)}",
+					 destination: "{item.price}",
 					 placeholder: "Editing price")
 		}
 	}

--- a/ios/evyTests/EVYInterpreterTests.swift
+++ b/ios/evyTests/EVYInterpreterTests.swift
@@ -1,0 +1,70 @@
+//
+//  EVYInterpreterTests.swift
+//  evyTests
+//
+//  Created by Cursor on 13/3/2026.
+//
+
+import XCTest
+@testable import evy
+
+@MainActor
+final class EVYInterpreterTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try EVY.getUserData()
+    }
+
+    func testEvaluatesLogicalOperatorsWithLiterals() throws {
+        XCTAssertTrue(try EVY.evaluateFromText("{0 > 1 || 1 > 0}"))
+        XCTAssertFalse(try EVY.evaluateFromText("{0 > 1 || 0 > 2}"))
+        XCTAssertTrue(try EVY.evaluateFromText("{1 > 0 && 2 > 1}"))
+        XCTAssertFalse(try EVY.evaluateFromText("{1 > 0 && 0 > 1}"))
+    }
+
+    func testEvaluatesGroupedLogicalOperators() throws {
+        XCTAssertTrue(try EVY.evaluateFromText("{0 > 1 || (1 > 0 && 2 > 1)}"))
+        XCTAssertFalse(try EVY.evaluateFromText("{(0 > 1 || 1 > 2) && 2 > 3}"))
+        XCTAssertTrue(try EVY.evaluateFromText("{0 > 1 || 0 > 2 || 1 > 0}"))
+    }
+
+    func testEvaluatesFunctionOperands() throws {
+        let titleKey = uniqueKey("title")
+        let reasonsKey = uniqueKey("reasons")
+
+        try store(.string("Hello"), at: titleKey)
+        try store(.array([.string("One"), .string("Two")]), at: reasonsKey)
+
+        XCTAssertTrue(try EVY.evaluateFromText("{count(\(titleKey)) > 0 || count(\(reasonsKey)) > 3}"))
+        XCTAssertFalse(try EVY.evaluateFromText("{count(\(titleKey)) > 10 && count(\(reasonsKey)) > 3}"))
+    }
+
+    func testEvaluatesBarePropsInsideComparison() throws {
+        let paymentCashKey = uniqueKey("payment_cash")
+        let paymentAppKey = uniqueKey("payment_app")
+
+        try store(.bool(false), at: paymentCashKey)
+        try store(.bool(true), at: paymentAppKey)
+
+        XCTAssertTrue(try EVY.evaluateFromText("{\(paymentCashKey) == true || \(paymentAppKey) == true}"))
+        XCTAssertFalse(try EVY.evaluateFromText("{\(paymentCashKey) == true && \(paymentAppKey) == false}"))
+    }
+
+    func testReplacesComparisonInsideText() throws {
+        let result = try EVYInterpreter.parseTextFromText("result: {1 > 0 || 2 > 0}")
+        XCTAssertEqual(result.value, "result: true")
+    }
+
+    private func store(_ value: EVYJson, at key: String) throws {
+        if EVY.data.exists(key: key) {
+            try EVY.data.delete(key: key)
+        }
+        let encodedValue = try JSONEncoder().encode(value)
+        try EVY.data.create(key: key, data: encodedValue)
+    }
+
+    private func uniqueKey(_ suffix: String) -> String {
+        let randomId = UUID().uuidString.replacingOccurrences(of: "-", with: "_")
+        return "evy_interpreter_tests_\(suffix)_\(randomId)"
+    }
+}

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -31,7 +31,7 @@ echo -e "${YELLOW}========================================${NC}"
 
 cleanup() {
     echo -e "\n${YELLOW}Cleaning up...${NC}"
-    # docker compose down -v --remove-orphans 2>/dev/null || true
+    docker compose down -v --remove-orphans 2>/dev/null || true
 }
 
 wait_for_http_service() {

--- a/types/schema/rpc/get.request.schema.json
+++ b/types/schema/rpc/get.request.schema.json
@@ -20,6 +20,7 @@
 				"conditions",
 				"durations",
 				"areas",
+				"timeslots",
 				"items"
 			]
 		},

--- a/types/schema/rpc/upsert.request.schema.json
+++ b/types/schema/rpc/upsert.request.schema.json
@@ -20,6 +20,7 @@
 				"conditions",
 				"durations",
 				"areas",
+				"timeslots",
 				"items"
 			]
 		},

--- a/web/app/utils/dropHandler.ts
+++ b/web/app/utils/dropHandler.ts
@@ -163,14 +163,7 @@ export function handleDrop(
 			oldRowId: rowId,
 			...dispatchOptions,
 		});
-	} else if (sourcePageId === destinationPageId) {
-		dispatchRow({
-			type: "MOVE_ROW",
-			rowId,
-			originPageId: sourcePageId,
-			...dispatchOptions,
-		});
-	} else if (destinationPageId !== sourcePageId) {
+	} else {
 		dispatchRow({
 			type: "MOVE_ROW",
 			rowId,


### PR DESCRIPTION
## Summary

- **New action/condition system**: Replaces the old `edit`/`validation`/`action.target` row model with a flexible `destination` + `actions[]` array where each action has `condition`, `true`, and `false` branches, enabling conditional navigation, creation, and validation
- **Data layer overhaul**: Moves from a single monolithic namespaced-data row to individual per-resource rows with `namespace` and `resource` columns, adds pluralize-based resource normalization, and introduces a draft system for in-progress entity creation on iOS
- **Schema & type generation improvements**: Adds recursive `$defs` inlining with cycle guards, barrel exports from `evy-types`, Swift codegen for `true`/`false` reserved-word fields, and seed validation with UUID enforcement
- **iOS interpreter enhancements**: Supports compound boolean expressions (`&&`, `||`, parentheses), adds `length()`, `buildCurrency()`, `buildAddress()` functions, and handles mixed data types in formatters
- **Infrastructure hardening**: Docker healthchecks for API readiness, seeded-data verification, deterministic e2e startup sequencing, and robust cleanup
- **Web configuration panel**: Rebuilt to support the new actions model with per-action condition/true/false editing, dragging source tracking, and simplified drop handler
- **Cleanup & refactoring**: Removed redundant `SDUI_ActionTarget` enum, duplicate cleanup logic, unused functions/patterns, repetitive data loading code, and inconsistent import paths

## Test plan

- [x] API e2e tests pass (`bun run test:e2e`)
- [x] Web e2e tests pass (`bun run test:e2e`)
- [x] Full e2e suite passes (`./run-e2e.sh --skip-ios`)
- [x] iOS build succeeds in Xcode (iPhone Air iOS 26.2)
- [x] iOS e2e tests pass


Made with [Cursor](https://cursor.com)