### PR TITLE
[FEAT] Move page title input to top navbar

### DIFF
--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useMemo } from "react";
 
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import type {
@@ -58,6 +58,46 @@ function AppContent() {
 	);
 }
 
+function NavBar() {
+	const { activePageId, activeFlowId, flows, dispatchRow } =
+		useContext(AppContext);
+
+	const activePage = useMemo(
+		() =>
+			flows
+				.find((f) => f.id === activeFlowId)
+				?.pages.find((p) => p.id === activePageId),
+		[flows, activeFlowId, activePageId],
+	);
+
+	return (
+		<div className="evy-border-b evy-border-gray evy-p-2 evy-bg-white evy-flex evy-items-center">
+			<a href="/">
+				<img className="evy-h-4" src="/logo.svg" alt="EVY" />
+			</a>
+			<div className="evy-flex-1 evy-flex evy-justify-center">
+				{activePage && (
+					<input
+						type="text"
+						value={activePage.title}
+						onChange={(e) =>
+							dispatchRow({
+								type: "UPDATE_PAGE_TITLE",
+								pageId: activePage.id,
+								title: e.target.value,
+							})
+						}
+						placeholder="Page title"
+						className="evy-text-center evy-bg-transparent evy-border-none evy-focus-visible:outline-none evy-text-lg evy-font-semibold"
+						aria-label="Page title"
+					/>
+				)}
+			</div>
+			<FlowSelector />
+		</div>
+	);
+}
+
 export function App() {
 	const { flows, loading } = useFlows();
 	const usingInjectedTestFlows = Boolean(window.__TEST_FLOWS__);
@@ -87,12 +127,7 @@ export function App() {
 			syncWithApi={!usingInjectedTestFlows}
 		>
 			<div className="evy-h-screen evy-overflow-hidden evy-flex evy-flex-col">
-				<div className="evy-border-b evy-border-gray evy-p-2 evy-bg-white evy-flex evy-justify-between evy-items-center">
-					<a href="/">
-						<img className="evy-h-4" src="/logo.svg" alt="EVY" />
-					</a>
-					<FlowSelector />
-				</div>
+				<NavBar />
 				<div className="evy-flex evy-flex-1 evy-overflow-hidden evy-bg-gray-light">
 					<AppContent />
 				</div>

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 import { AppContext } from "../state";
 import type { Row } from "../types/row";
@@ -13,18 +13,9 @@ function isRowArray(value: unknown): value is Row[] {
 }
 
 export function ConfigurationPanel() {
-	const { activeRowId, activePageId, flows, activeFlowId, dispatchRow } =
-		useContext(AppContext);
+	const { activeRowId, dispatchRow } = useContext(AppContext);
 	const row = useRowById(activeRowId);
 	const [configStack, setConfigStack] = useState<string[]>([]);
-
-	const activePage = useMemo(
-		() =>
-			flows
-				.find((f) => f.id === activeFlowId)
-				?.pages.find((p) => p.id === activePageId),
-		[flows, activeFlowId, activePageId],
-	);
 	const currentConfigRowId = configStack.at(-1) ?? row?.id;
 	const currentConfigRow = useRowById(currentConfigRowId);
 
@@ -182,27 +173,6 @@ export function ConfigurationPanel() {
 				Configuration
 			</div>
 			<div className="evy-flex evy-flex-col evy-min-h-full evy-p-4 evy-gap-4 evy-overflow-scroll">
-				{activePage && !isDrilledIntoChild && (
-					<>
-						<div className="evy-mb-2">
-							<label htmlFor="page-title">Page title</label>
-							<input
-								id="page-title"
-								type="text"
-								value={activePage.title}
-								onChange={(e) =>
-									dispatchRow({
-										type: "UPDATE_PAGE_TITLE",
-										pageId: activePage.id,
-										title: e.target.value,
-									})
-								}
-								className="evy-w-full evy-focus-visible:outline-none"
-							/>
-						</div>
-						<div className="evy-border-b evy-border-gray" />
-					</>
-				)}
 				{isDrilledIntoChild && currentConfigRow && (
 					<>
 						<button

--- a/web/app/components/FlowSelector.tsx
+++ b/web/app/components/FlowSelector.tsx
@@ -17,7 +17,7 @@ export function FlowSelector() {
 			id="flow-select"
 			value={activeFlowId || "Select a flow"}
 			onChange={handleFlowChange}
-			className="evy-text-sm evy-font-medium evy-p-2"
+			className="evy-text-sm evy-font-medium evy-p-2 evy-pr-8"
 		>
 			{flows.map((flow) => (
 				<option key={flow.id} value={flow.id}>

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -46,7 +46,7 @@ test.describe("Row configuration", () => {
 			.getByText("Configuration", { exact: true })
 			.locator("..");
 
-		await expect(configPanel.getByLabel("Page title")).toHaveValue("Test Page");
+		await expect(page.getByLabel("Page title")).toHaveValue("Test Page");
 		await expect(
 			configPanel.getByRole("button", { name: /^Input$/ }),
 		).toBeVisible();


### PR DESCRIPTION
## Summary

- Moved the page title input from the Configuration panel to the top navbar, centered between the logo and flow selector
- Extracted a new `NavBar` component in `App.tsx` that reads the active page from context and dispatches `UPDATE_PAGE_TITLE` on change
- Cleaned up `ConfigurationPanel.tsx` by removing the page title section and its associated state (`activePage`, `activePageId`, `activeFlowId`, `flows`, `useMemo`)
- Added right padding to `FlowSelector` dropdown to prevent text overlapping with the native dropdown arrow
- Page title input is styled with larger, semibold font and includes a "Page title" placeholder

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] All 46 web tests pass
- [ ] Verify page title input renders centered in the navbar
- [ ] Verify editing the title updates the page title in the phone mockup
- [ ] Verify the flow selector remains right-aligned
- [ ] Verify the Configuration panel no longer shows the page title field


Made with [Cursor](https://cursor.com)