### PR TITLE
[FEAT] New focus mode with animated page transitions

### DIFF
--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from "react";
+import { useContext, useEffect, useMemo, useRef } from "react";
 
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import type {
@@ -16,8 +16,15 @@ import { useFlows } from "./hooks/useFlows";
 import { useActiveFlow } from "./hooks/useActiveFlow";
 
 function AppContent() {
-	const { dispatchRow, dispatchDragging } = useContext(AppContext);
+	const { dispatchRow, dispatchDragging, activePageId, focusMode } =
+		useContext(AppContext);
 	const { pages } = useActiveFlow();
+	const canvasRef = useRef<HTMLDivElement | null>(null);
+	const visiblePages = useMemo(
+		() =>
+			focusMode ? pages.filter((page) => page.id === activePageId) : pages,
+		[pages, focusMode, activePageId],
+	);
 
 	useEffect(() => {
 		return monitorForElements({
@@ -34,13 +41,35 @@ function AppContent() {
 		});
 	}, [pages, dispatchRow, dispatchDragging]);
 
+	useEffect(() => {
+		const element = canvasRef.current;
+		if (!element) {
+			return;
+		}
+
+		const clearSelection = (event: MouseEvent) => {
+			if (event.target === event.currentTarget) {
+				dispatchRow({ type: "CLEAR_ACTIVE_SELECTION" });
+			}
+		};
+
+		element.addEventListener("click", clearSelection);
+
+		return () => {
+			element.removeEventListener("click", clearSelection);
+		};
+	}, [dispatchRow]);
+
 	return (
 		<>
 			<div className="evy-w-300 evy-flex-shrink-0 evy-border-r evy-border-gray evy-bg-white evy-shadow-subtle">
 				<RowsPanel />
 			</div>
-			<div className="evy-flex-1 evy-overflow-auto evy-flex evy-flex-row evy-gap-4 evy-p-4">
-				{pages.map((page) => {
+			<div
+				className="evy-flex-1 evy-overflow-auto evy-flex evy-flex-row evy-gap-4 evy-p-4"
+				ref={canvasRef}
+			>
+				{visiblePages.map((page) => {
 					return (
 						<div
 							key={page.id}
@@ -59,7 +88,7 @@ function AppContent() {
 }
 
 function NavBar() {
-	const { activePageId, activeFlowId, flows, dispatchRow } =
+	const { activePageId, activeFlowId, flows, dispatchRow, focusMode } =
 		useContext(AppContext);
 
 	const activePage = useMemo(
@@ -75,22 +104,34 @@ function NavBar() {
 			<a href="/">
 				<img className="evy-h-4" src="/logo.svg" alt="EVY" />
 			</a>
-			<div className="evy-flex-1 evy-flex evy-justify-center">
+			<div className="evy-flex-1 evy-flex evy-justify-center evy-items-center evy-gap-2">
 				{activePage && (
-					<input
-						type="text"
-						value={activePage.title}
-						onChange={(e) =>
-							dispatchRow({
-								type: "UPDATE_PAGE_TITLE",
-								pageId: activePage.id,
-								title: e.target.value,
-							})
-						}
-						placeholder="Page title"
-						className="evy-text-center evy-bg-transparent evy-border-none evy-focus-visible:outline-none evy-text-lg evy-font-semibold"
-						aria-label="Page title"
-					/>
+					<>
+						<input
+							type="text"
+							value={activePage.title}
+							onChange={(e) =>
+								dispatchRow({
+									type: "UPDATE_PAGE_TITLE",
+									pageId: activePage.id,
+									title: e.target.value,
+								})
+							}
+							placeholder="Page title"
+							className="evy-navbar-page-title evy-text-center evy-bg-transparent evy-border-none evy-focus-visible:outline-none evy-text-lg evy-font-semibold"
+							aria-label="Page title"
+						/>
+						<button
+							type="button"
+							onClick={() => dispatchRow({ type: "TOGGLE_FOCUS_MODE" })}
+							className={`evy-focus-button ${
+								focusMode ? "evy-focus-button--active" : ""
+							}`}
+							aria-pressed={focusMode}
+						>
+							Focus
+						</button>
+					</>
 				)}
 			</div>
 			<FlowSelector />

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -20,8 +20,6 @@ function AppContent() {
 		useContext(AppContext);
 	const { pages } = useActiveFlow();
 	const canvasRef = useRef<HTMLDivElement | null>(null);
-	const previousFocusModeRef = useRef(focusMode);
-	const lastFocusedPageIdRef = useRef<string | null>(null);
 
 	useEffect(() => {
 		return monitorForElements({
@@ -57,68 +55,6 @@ function AppContent() {
 		};
 	}, [dispatchRow]);
 
-	// This is a workaround to prevent the canvas from jumping to the top when the focus mode is toggled
-	useEffect(() => {
-		if (!activePageId) {
-			return;
-		}
-
-		const previousFocusMode = previousFocusModeRef.current;
-		previousFocusModeRef.current = focusMode;
-
-		const isExitingFocus = previousFocusMode && !focusMode;
-		const isReenteringSamePage =
-			!previousFocusMode &&
-			focusMode &&
-			activePageId === lastFocusedPageIdRef.current;
-
-		if (isExitingFocus) {
-			lastFocusedPageIdRef.current = activePageId;
-		}
-
-		if ((!isExitingFocus && !isReenteringSamePage) || !activePageId) {
-			return;
-		}
-
-		const canvasElement = canvasRef.current;
-		if (!canvasElement) {
-			return;
-		}
-
-		const activePageElement = canvasElement.querySelector<HTMLElement>(
-			`[data-page-id="${activePageId}"]`,
-		);
-		if (!activePageElement) {
-			return;
-		}
-
-		const animationDuration = 650;
-		const startTime = performance.now();
-		let frameId: number;
-
-		const keepCentered = () => {
-			const pageRect = activePageElement.getBoundingClientRect();
-			const canvasRect = canvasElement.getBoundingClientRect();
-			const offset =
-				pageRect.left +
-				pageRect.width / 2 -
-				(canvasRect.left + canvasRect.width / 2);
-			canvasElement.scrollLeft += offset;
-
-			if (performance.now() - startTime < animationDuration) {
-				frameId = requestAnimationFrame(keepCentered);
-			} else if (isReenteringSamePage) {
-				lastFocusedPageIdRef.current = null;
-			}
-		};
-
-		frameId = requestAnimationFrame(keepCentered);
-
-		return () => {
-			cancelAnimationFrame(frameId);
-		};
-	}, [focusMode, activePageId]);
-
 	return (
 		<>
 			<div className="evy-w-300 evy-flex-shrink-0 evy-border-r evy-border-gray evy-bg-white evy-shadow-subtle">
@@ -136,7 +72,6 @@ function AppContent() {
 					return (
 						<div
 							key={page.id}
-							data-page-id={page.id}
 							className={`evy-page-wrapper evy-flex-shrink-0 evy-mx-auto evy-bg-phone evy-bg-no-repeat evy-bg-contain evy-w-336 evy-h-662 ${
 								isHidden ? "evy-page-wrapper--hidden" : ""
 							}`}

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -20,11 +20,8 @@ function AppContent() {
 		useContext(AppContext);
 	const { pages } = useActiveFlow();
 	const canvasRef = useRef<HTMLDivElement | null>(null);
-	const visiblePages = useMemo(
-		() =>
-			focusMode ? pages.filter((page) => page.id === activePageId) : pages,
-		[pages, focusMode, activePageId],
-	);
+	const previousFocusModeRef = useRef(focusMode);
+	const lastFocusedPageIdRef = useRef<string | null>(null);
 
 	useEffect(() => {
 		return monitorForElements({
@@ -60,20 +57,89 @@ function AppContent() {
 		};
 	}, [dispatchRow]);
 
+	// This is a workaround to prevent the canvas from jumping to the top when the focus mode is toggled
+	useEffect(() => {
+		if (!activePageId) {
+			return;
+		}
+
+		const previousFocusMode = previousFocusModeRef.current;
+		previousFocusModeRef.current = focusMode;
+
+		const isExitingFocus = previousFocusMode && !focusMode;
+		const isReenteringSamePage =
+			!previousFocusMode &&
+			focusMode &&
+			activePageId === lastFocusedPageIdRef.current;
+
+		if (isExitingFocus) {
+			lastFocusedPageIdRef.current = activePageId;
+		}
+
+		if ((!isExitingFocus && !isReenteringSamePage) || !activePageId) {
+			return;
+		}
+
+		const canvasElement = canvasRef.current;
+		if (!canvasElement) {
+			return;
+		}
+
+		const activePageElement = canvasElement.querySelector<HTMLElement>(
+			`[data-page-id="${activePageId}"]`,
+		);
+		if (!activePageElement) {
+			return;
+		}
+
+		const animationDuration = 650;
+		const startTime = performance.now();
+		let frameId: number;
+
+		const keepCentered = () => {
+			const pageRect = activePageElement.getBoundingClientRect();
+			const canvasRect = canvasElement.getBoundingClientRect();
+			const offset =
+				pageRect.left +
+				pageRect.width / 2 -
+				(canvasRect.left + canvasRect.width / 2);
+			canvasElement.scrollLeft += offset;
+
+			if (performance.now() - startTime < animationDuration) {
+				frameId = requestAnimationFrame(keepCentered);
+			} else if (isReenteringSamePage) {
+				lastFocusedPageIdRef.current = null;
+			}
+		};
+
+		frameId = requestAnimationFrame(keepCentered);
+
+		return () => {
+			cancelAnimationFrame(frameId);
+		};
+	}, [focusMode, activePageId]);
+
 	return (
 		<>
 			<div className="evy-w-300 evy-flex-shrink-0 evy-border-r evy-border-gray evy-bg-white evy-shadow-subtle">
 				<RowsPanel />
 			</div>
 			<div
-				className="evy-flex-1 evy-overflow-auto evy-flex evy-flex-row evy-gap-4 evy-p-4"
+				className={`evy-flex-1 evy-overflow-auto evy-flex evy-flex-row evy-p-4 evy-canvas ${
+					focusMode ? "evy-canvas--focused" : ""
+				}`}
 				ref={canvasRef}
 			>
-				{visiblePages.map((page) => {
+				{pages.map((page) => {
+					const isHidden = focusMode && page.id !== activePageId;
+
 					return (
 						<div
 							key={page.id}
-							className="evy-flex-shrink-0 evy-mx-auto evy-bg-phone evy-bg-no-repeat evy-bg-contain evy-w-336 evy-h-662"
+							data-page-id={page.id}
+							className={`evy-page-wrapper evy-flex-shrink-0 evy-mx-auto evy-bg-phone evy-bg-no-repeat evy-bg-contain evy-w-336 evy-h-662 ${
+								isHidden ? "evy-page-wrapper--hidden" : ""
+							}`}
 						>
 							<AppPage pageId={page.id} />
 						</div>

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useState } from "react";
-import type { MouseEvent } from "react";
 
 import { AppContext } from "../state";
 import type { Row } from "../types/row";
@@ -14,7 +13,7 @@ function isRowArray(value: unknown): value is Row[] {
 }
 
 export function ConfigurationPanel() {
-	const { activeRowId, dispatchRow } = useContext(AppContext);
+	const { activeRowId, focusMode, dispatchRow } = useContext(AppContext);
 	const row = useRowById(activeRowId);
 	const [configStack, setConfigStack] = useState<string[]>([]);
 	const currentConfigRowId = configStack.at(-1) ?? row?.id;
@@ -33,24 +32,26 @@ export function ConfigurationPanel() {
 	}, []);
 
 	const handleOpenChildConfiguration = useCallback(
-		(event: MouseEvent<HTMLButtonElement>, childRowId: string) => {
-			event.stopPropagation();
+		(childRowId: string) => {
 			openChildConfiguration(childRowId);
+			if (!focusMode) {
+				dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
+			}
 		},
-		[openChildConfiguration],
+		[openChildConfiguration, focusMode, dispatchRow],
 	);
 
 	const goBackToParentConfiguration = useCallback(() => {
 		setConfigStack((currentStack) => currentStack.slice(0, -1));
 	}, []);
 
-	const handleGoBackToParentConfiguration = useCallback(
-		(event: MouseEvent<HTMLButtonElement>) => {
-			event.stopPropagation();
-			goBackToParentConfiguration();
-		},
-		[goBackToParentConfiguration],
-	);
+	const handleGoBackToParentConfiguration = useCallback(() => {
+		const willReturnToRoot = configStack.length <= 1;
+		goBackToParentConfiguration();
+		if (willReturnToRoot && focusMode) {
+			dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
+		}
+	}, [configStack.length, goBackToParentConfiguration, focusMode, dispatchRow]);
 
 	const updateRowContent = useCallback(
 		(configId: string, configValue: string, targetRowId?: string) => {
@@ -124,9 +125,7 @@ export function ConfigurationPanel() {
 											type="button"
 											key={child.id}
 											className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
-											onClick={(event) =>
-												handleOpenChildConfiguration(event, child.id)
-											}
+											onClick={() => handleOpenChildConfiguration(child.id)}
 										>
 											<span>{child.config.type}</span>
 											<img
@@ -149,7 +148,7 @@ export function ConfigurationPanel() {
 							type="button"
 							key={uniqueId}
 							className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
-							onClick={(event) => handleOpenChildConfiguration(event, child.id)}
+							onClick={() => handleOpenChildConfiguration(child.id)}
 						>
 							<span>{child.config.type}</span>
 							<img

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -12,6 +12,25 @@ function isRowArray(value: unknown): value is Row[] {
 	return Array.isArray(value) && value.every(isRow);
 }
 
+function ChildRowButton({
+	child,
+	onClick,
+}: {
+	child: Row;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
+			onClick={onClick}
+		>
+			<span>{child.config.type}</span>
+			<img className="evy-h-4 evy-w-4" src="/chevron_right.svg" alt="" />
+		</button>
+	);
+}
+
 export function ConfigurationPanel() {
 	const { activeRowId, focusMode, dispatchRow } = useContext(AppContext);
 	const row = useRowById(activeRowId);
@@ -19,39 +38,28 @@ export function ConfigurationPanel() {
 	const currentConfigRowId = configStack.at(-1) ?? row?.id;
 	const currentConfigRow = useRowById(currentConfigRowId);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset stack when selected row changes
 	useEffect(() => {
-		if (!activeRowId) {
-			setConfigStack([]);
-			return;
-		}
 		setConfigStack([]);
 	}, [activeRowId]);
 
-	const openChildConfiguration = useCallback((childRowId: string) => {
-		setConfigStack((currentStack) => [...currentStack, childRowId]);
-	}, []);
-
-	const handleOpenChildConfiguration = useCallback(
+	const openChildConfiguration = useCallback(
 		(childRowId: string) => {
-			openChildConfiguration(childRowId);
+			setConfigStack((currentStack) => [...currentStack, childRowId]);
 			if (!focusMode) {
 				dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
 			}
 		},
-		[openChildConfiguration, focusMode, dispatchRow],
+		[focusMode, dispatchRow],
 	);
 
 	const goBackToParentConfiguration = useCallback(() => {
-		setConfigStack((currentStack) => currentStack.slice(0, -1));
-	}, []);
-
-	const handleGoBackToParentConfiguration = useCallback(() => {
 		const willReturnToRoot = configStack.length <= 1;
-		goBackToParentConfiguration();
+		setConfigStack((currentStack) => currentStack.slice(0, -1));
 		if (willReturnToRoot && focusMode) {
 			dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
 		}
-	}, [configStack.length, goBackToParentConfiguration, focusMode, dispatchRow]);
+	}, [configStack.length, focusMode, dispatchRow]);
 
 	const updateRowContent = useCallback(
 		(configId: string, configValue: string, targetRowId?: string) => {
@@ -119,23 +127,13 @@ export function ConfigurationPanel() {
 								Children
 							</div>
 							<div className="evy-flex evy-flex-col evy-gap-4">
-								{children.map((child) => {
-									return (
-										<button
-											type="button"
-											key={child.id}
-											className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
-											onClick={() => handleOpenChildConfiguration(child.id)}
-										>
-											<span>{child.config.type}</span>
-											<img
-												className="evy-h-4 evy-w-4"
-												src="/chevron_right.svg"
-												alt=""
-											/>
-										</button>
-									);
-								})}
+								{children.map((child) => (
+									<ChildRowButton
+										key={child.id}
+										child={child}
+										onClick={() => openChildConfiguration(child.id)}
+									/>
+								))}
 							</div>
 						</div>
 					);
@@ -144,19 +142,11 @@ export function ConfigurationPanel() {
 					if (!isRow(value)) return null;
 					const child = value;
 					return (
-						<button
-							type="button"
+						<ChildRowButton
 							key={uniqueId}
-							className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
-							onClick={() => handleOpenChildConfiguration(child.id)}
-						>
-							<span>{child.config.type}</span>
-							<img
-								className="evy-h-4 evy-w-4"
-								src="/chevron_right.svg"
-								alt=""
-							/>
-						</button>
+							child={child}
+							onClick={() => openChildConfiguration(child.id)}
+						/>
 					);
 				}
 				return (
@@ -176,7 +166,7 @@ export function ConfigurationPanel() {
 				);
 			});
 		},
-		[handleOpenChildConfiguration, updateRowContent],
+		[openChildConfiguration, updateRowContent],
 	);
 
 	const configurationElements = currentConfigRow
@@ -196,7 +186,7 @@ export function ConfigurationPanel() {
 						<button
 							type="button"
 							className="evy-flex evy-items-center evy-w-full evy-p-0 evy-bg-transparent evy-border-none evy-text-left evy-cursor-pointer"
-							onClick={handleGoBackToParentConfiguration}
+							onClick={goBackToParentConfiguration}
 							aria-label={`Back to parent configuration from ${currentConfigRow.config.type}`}
 						>
 							<img className="evy-h-4 evy-w-4" src="/chevron_left.svg" alt="" />

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useContext, useEffect, useState } from "react";
+import type { MouseEvent } from "react";
 
 import { AppContext } from "../state";
 import type { Row } from "../types/row";
@@ -31,9 +32,25 @@ export function ConfigurationPanel() {
 		setConfigStack((currentStack) => [...currentStack, childRowId]);
 	}, []);
 
+	const handleOpenChildConfiguration = useCallback(
+		(event: MouseEvent<HTMLButtonElement>, childRowId: string) => {
+			event.stopPropagation();
+			openChildConfiguration(childRowId);
+		},
+		[openChildConfiguration],
+	);
+
 	const goBackToParentConfiguration = useCallback(() => {
 		setConfigStack((currentStack) => currentStack.slice(0, -1));
 	}, []);
+
+	const handleGoBackToParentConfiguration = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			event.stopPropagation();
+			goBackToParentConfiguration();
+		},
+		[goBackToParentConfiguration],
+	);
 
 	const updateRowContent = useCallback(
 		(configId: string, configValue: string, targetRowId?: string) => {
@@ -107,7 +124,9 @@ export function ConfigurationPanel() {
 											type="button"
 											key={child.id}
 											className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
-											onClick={() => openChildConfiguration(child.id)}
+											onClick={(event) =>
+												handleOpenChildConfiguration(event, child.id)
+											}
 										>
 											<span>{child.config.type}</span>
 											<img
@@ -130,7 +149,7 @@ export function ConfigurationPanel() {
 							type="button"
 							key={uniqueId}
 							className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
-							onClick={() => openChildConfiguration(child.id)}
+							onClick={(event) => handleOpenChildConfiguration(event, child.id)}
 						>
 							<span>{child.config.type}</span>
 							<img
@@ -158,7 +177,7 @@ export function ConfigurationPanel() {
 				);
 			});
 		},
-		[openChildConfiguration, updateRowContent],
+		[handleOpenChildConfiguration, updateRowContent],
 	);
 
 	const configurationElements = currentConfigRow
@@ -178,7 +197,7 @@ export function ConfigurationPanel() {
 						<button
 							type="button"
 							className="evy-flex evy-items-center evy-w-full evy-p-0 evy-bg-transparent evy-border-none evy-text-left evy-cursor-pointer"
-							onClick={goBackToParentConfiguration}
+							onClick={handleGoBackToParentConfiguration}
 							aria-label={`Back to parent configuration from ${currentConfigRow.config.type}`}
 						>
 							<img className="evy-h-4 evy-w-4" src="/chevron_left.svg" alt="" />

--- a/web/app/components/FlowSelector.tsx
+++ b/web/app/components/FlowSelector.tsx
@@ -17,7 +17,7 @@ export function FlowSelector() {
 			id="flow-select"
 			value={activeFlowId || "Select a flow"}
 			onChange={handleFlowChange}
-			className="evy-text-sm evy-font-medium evy-p-2 evy-pr-8"
+			className="evy-flow-selector evy-text-sm evy-font-medium evy-p-2 evy-pr-8"
 		>
 			{flows.map((flow) => (
 				<option key={flow.id} value={flow.id}>

--- a/web/app/components/FlowSelector.tsx
+++ b/web/app/components/FlowSelector.tsx
@@ -17,7 +17,7 @@ export function FlowSelector() {
 			id="flow-select"
 			value={activeFlowId || "Select a flow"}
 			onChange={handleFlowChange}
-			className="evy-flow-selector evy-text-sm evy-font-medium evy-p-2 evy-pr-8"
+			className="evy-flow-selector evy-text-sm evy-font-medium evy-p-2"
 		>
 			{flows.map((flow) => (
 				<option key={flow.id} value={flow.id}>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -515,19 +515,19 @@ label {
 }
 
 .evy-focus-button--active {
-	border-color: var(--color-evy-blue);
-	box-shadow: 0 0 8px 2px oklch(60.04% 0.2013 261.37 / 0.5);
+	border-color: var(--color-evy-gray-dark);
+	box-shadow: 0 0 8px 2px oklch(35.84% 0.0103 285.87 / 0.5);
 	animation: focus-glow 2s ease-in-out infinite;
 }
 
 @keyframes focus-glow {
 	0%,
 	100% {
-		box-shadow: 0 0 6px 1px oklch(60.04% 0.2013 261.37 / 0.35);
+		box-shadow: 0 0 6px 1px oklch(35.84% 0.0103 285.87 / 0.35);
 	}
 
 	50% {
-		box-shadow: 0 0 14px 4px oklch(60.04% 0.2013 261.37 / 0.6);
+		box-shadow: 0 0 14px 4px oklch(35.84% 0.0103 285.87 / 0.6);
 	}
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -215,6 +215,9 @@ body {
 .evy-h-4 {
 	height: var(--size-4);
 }
+.evy-h-8 {
+	height: var(--size-8);
+}
 .evy-h-48 {
 	height: var(--size-48);
 }
@@ -336,6 +339,9 @@ body {
 .evy-rounded-md {
 	border-radius: var(--radius-md);
 }
+.evy-rounded-full {
+	border-radius: 999px;
+}
 .evy-rounded-24 {
 	border-top-left-radius: var(--radius-2-4);
 	border-top-right-radius: var(--radius-2-4);
@@ -376,6 +382,9 @@ body {
 }
 
 /* Pointer events */
+.evy-cursor-pointer {
+	cursor: pointer;
+}
 .evy-pointer-events-none {
 	pointer-events: none;
 }
@@ -473,6 +482,53 @@ label {
 	width: 100%;
 	background: none;
 	border: none;
+}
+
+.evy-flow-selector {
+	padding-right: calc(var(--spacing-8) + var(--spacing-4));
+}
+
+.evy-navbar-page-title {
+	height: 34px;
+}
+
+.evy-focus-button {
+	font-size: var(--text-sm);
+	font-weight: var(--font-medium);
+	height: 34px;
+	padding: 0 var(--spacing-4);
+	border: 1px solid var(--color-gray-border);
+	border-radius: var(--radius-md);
+	background-color: var(--color-white);
+	cursor: pointer;
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	transition:
+		border-color var(--transition),
+		box-shadow var(--transition);
+}
+
+.evy-focus-button:hover {
+	border-color: var(--color-evy-gray);
+}
+
+.evy-focus-button--active {
+	border-color: var(--color-evy-blue);
+	box-shadow: 0 0 8px 2px oklch(60.04% 0.2013 261.37 / 0.5);
+	animation: focus-glow 2s ease-in-out infinite;
+}
+
+@keyframes focus-glow {
+	0%,
+	100% {
+		box-shadow: 0 0 6px 1px oklch(60.04% 0.2013 261.37 / 0.35);
+	}
+
+	50% {
+		box-shadow: 0 0 14px 4px oklch(60.04% 0.2013 261.37 / 0.6);
+	}
 }
 
 .evy-v-dropzone {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -529,6 +529,36 @@ label {
 	}
 }
 
+.evy-canvas {
+	gap: var(--spacing-4);
+	transition: gap 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.evy-canvas--focused {
+	gap: 0;
+	transition: gap 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms;
+}
+
+.evy-page-wrapper {
+	overflow: hidden;
+	transition:
+		opacity 350ms cubic-bezier(0.4, 0, 0.2, 1) 300ms,
+		width 300ms cubic-bezier(0.4, 0, 0.2, 1),
+		margin 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.evy-page-wrapper--hidden {
+	opacity: 0;
+	width: 0;
+	margin-left: 0;
+	margin-right: 0;
+	pointer-events: none;
+	transition:
+		opacity 350ms cubic-bezier(0.4, 0, 0.2, 1),
+		width 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms,
+		margin 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms;
+}
+
 .evy-v-dropzone {
 	transition: height 0.2s ease-in-out;
 	background-color: var(--color-evy-blue);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -22,6 +22,7 @@
 	--size-4: 1rem; /* 16px */
 	--size-8: 2rem; /* 32px */
 	--size-48: 12rem; /* 192px */
+	--size-navbar-control: 34px;
 	--size-336: 336px;
 	--size-662: 662px;
 
@@ -214,9 +215,6 @@ body {
 /* Height utilities */
 .evy-h-4 {
 	height: var(--size-4);
-}
-.evy-h-8 {
-	height: var(--size-8);
 }
 .evy-h-48 {
 	height: var(--size-48);
@@ -489,13 +487,13 @@ label {
 }
 
 .evy-navbar-page-title {
-	height: 34px;
+	height: var(--size-navbar-control);
 }
 
 .evy-focus-button {
 	font-size: var(--text-sm);
 	font-weight: var(--font-medium);
-	height: 34px;
+	height: var(--size-navbar-control);
 	padding: 0 var(--spacing-4);
 	border: 1px solid var(--color-gray-border);
 	border-radius: var(--radius-md);

--- a/web/app/rows/design-system/InlineIcon.tsx
+++ b/web/app/rows/design-system/InlineIcon.tsx
@@ -1,13 +1,32 @@
+import iconMap from "../../icons/iconMap";
+
+const ICON_SYNTAX_REGEX = /^::(.+)::$/;
+
+function resolveIconSrc(icon: string): string {
+	const match = icon.match(ICON_SYNTAX_REGEX);
+	if (match) {
+		return iconMap[match[1]] ?? icon;
+	}
+	return icon;
+}
+
 export default function InlineIcon({
 	icon,
 	alt,
+	position = "left",
 }: {
 	icon: string;
 	alt: string;
+	position?: "left" | "right";
 }) {
+	const positionClass =
+		position === "right" ? "evy-end-0 evy-pe-2" : "evy-start-0 evy-ps-2";
+
 	return (
-		<div className="evy-absolute evy-inset-y-0 evy-start-0 evy-flex evy-items-center evy-ps-2 evy-pointer-events-none">
-			<img className="evy-h-4" src={icon} alt={alt} />
+		<div
+			className={`evy-absolute evy-inset-y-0 ${positionClass} evy-flex evy-items-center evy-pointer-events-none`}
+		>
+			<img className="evy-h-4" src={resolveIconSrc(icon)} alt={alt} />
 		</div>
 	);
 }

--- a/web/app/state/AppProvider.tsx
+++ b/web/app/state/AppProvider.tsx
@@ -73,7 +73,7 @@ export function AppProvider({
 				activeFlowId: appState.activeFlowId,
 				activeRowId: appState.activeRowId,
 				activePageId: appState.activePageId,
-				focusMode: appState.focusMode ?? false,
+				focusMode: appState.focusMode,
 				dragging,
 				dropIndicator,
 				dispatchRow,

--- a/web/app/state/AppProvider.tsx
+++ b/web/app/state/AppProvider.tsx
@@ -34,6 +34,7 @@ export function AppProvider({
 	const [appState, dispatchRow] = useReducer(pageReducer, {
 		flows: decodeFlows(flows),
 		activeFlowId: flows[0]?.id,
+		focusMode: false,
 	});
 
 	const [dragging, dispatchDragging] = useReducer(draggingReducer, false);
@@ -72,6 +73,7 @@ export function AppProvider({
 				activeFlowId: appState.activeFlowId,
 				activeRowId: appState.activeRowId,
 				activePageId: appState.activePageId,
+				focusMode: appState.focusMode ?? false,
 				dragging,
 				dropIndicator,
 				dispatchRow,

--- a/web/app/state/context.ts
+++ b/web/app/state/context.ts
@@ -16,6 +16,7 @@ export const AppContext = createContext<{
 	activeFlowId?: string;
 	activeRowId?: string;
 	activePageId?: string;
+	focusMode: boolean;
 	dragging: DraggingState;
 	dropIndicator: DropIndicatorState;
 	dispatchRow: Dispatch<RowAction>;
@@ -24,6 +25,7 @@ export const AppContext = createContext<{
 }>({
 	rows: [],
 	flows: [],
+	focusMode: false,
 	dragging: false,
 	dropIndicator: null,
 	dispatchRow: () => {},

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -258,6 +258,27 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				activeRowId: undefined,
 			};
 		}
+		case "CLEAR_ACTIVE_SELECTION": {
+			return {
+				...state,
+				activePageId: undefined,
+				activeRowId: undefined,
+				focusMode: false,
+			};
+		}
+		case "TOGGLE_FOCUS_MODE": {
+			const nextFocusMode = !state.focusMode;
+			const nextActivePageId =
+				nextFocusMode && !state.activePageId
+					? flow.pages[0]?.id
+					: state.activePageId;
+
+			return {
+				...state,
+				focusMode: nextFocusMode,
+				activePageId: nextActivePageId,
+			};
+		}
 		case "UPDATE_PAGE_TITLE": {
 			const newPages = flow.pages.map((page) =>
 				page.id === action.pageId ? { ...page, title: action.title } : page,

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -50,6 +50,12 @@ export type RowAction =
 			pageId: string;
 	  }
 	| {
+			type: "CLEAR_ACTIVE_SELECTION";
+	  }
+	| {
+			type: "TOGGLE_FOCUS_MODE";
+	  }
+	| {
 			type: "UPDATE_PAGE_TITLE";
 			pageId: string;
 			title: string;
@@ -96,4 +102,5 @@ export type AppState = {
 	activeRowId?: string;
 	activeFlowId?: string;
 	activePageId?: string;
+	focusMode: boolean;
 };


### PR DESCRIPTION
## Summary

- Adds a **Focus Mode** toggle button in the NavBar that isolates the active page by animating non-active pages to zero width/opacity, letting users concentrate on a single page at a time
- Entering a child row configuration automatically activates focus mode; navigating back to root exits it. Clicking the canvas background clears selection and exits focus mode
- Introduces animated CSS transitions for page visibility (opacity + width collapse), a glowing active state for the Focus button, and extracts a reusable `ChildRowButton` component in `ConfigurationPanel`
- Enhances `InlineIcon` with a `position` prop and `::icon::` syntax resolution via the icon map

## Changes

- `App.tsx` — new `focusMode` state consumption, canvas click-to-clear handler, conditional `evy-page-wrapper--hidden` class, Focus button in `NavBar`
- `ConfigurationPanel.tsx` — auto-toggle focus mode on child drill-in/back, extracted `ChildRowButton`
- `globals.css` — focus button styles with glow animation, canvas gap transition, page-wrapper show/hide transitions
- `pageReducer.ts` / `actions.ts` / `context.ts` / `AppProvider.tsx` — `TOGGLE_FOCUS_MODE` and `CLEAR_ACTIVE_SELECTION` actions, `focusMode` state plumbing
- `InlineIcon.tsx` — `position` prop, `::icon::` syntax resolver
- `FlowSelector.tsx` — minor className update

## Test plan

- [ ] Verify focus mode activates/deactivates via the Focus button in the NavBar
- [ ] Verify drilling into child configuration auto-activates focus mode and going back deactivates it
- [ ] Verify clicking the canvas background clears selection and exits focus mode
- [ ] Verify page hide/show animations are smooth and don't jitter
- [ ] Verify inline icons render correctly with the new `::icon::` syntax


Made with [Cursor](https://cursor.com)