### PR TITLE
[FEAT] URL routing for flows and pages

### DIFF
--- a/web/app/hooks/useUrlSync.ts
+++ b/web/app/hooks/useUrlSync.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, type Dispatch } from "react";
+
+import type { RowAction } from "../types/actions";
+import type { SDUI_Flow } from "../types/flow";
+import { buildUrlPath, parseUrlPath, resolveUrlIds } from "../utils/urlUtils";
+
+export function useUrlSync(
+	activeFlowId: string | undefined,
+	activePageId: string | undefined,
+	flows: SDUI_Flow[],
+	dispatchRow: Dispatch<RowAction>,
+) {
+	const isInitialMount = useRef(true);
+	const isPopStateNavigation = useRef(false);
+
+	useEffect(() => {
+		if (isInitialMount.current) {
+			isInitialMount.current = false;
+			const url = buildUrlPath(activeFlowId, activePageId);
+			window.history.replaceState(null, "", url);
+			return;
+		}
+
+		if (isPopStateNavigation.current) {
+			isPopStateNavigation.current = false;
+			return;
+		}
+
+		const url = buildUrlPath(activeFlowId, activePageId);
+		if (window.location.pathname !== url) {
+			window.history.pushState(null, "", url);
+		}
+	}, [activeFlowId, activePageId]);
+
+	useEffect(() => {
+		const handlePopState = () => {
+			const { flowId: urlFlowId, pageId: urlPageId } = parseUrlPath();
+			const { flowId, pageId } = resolveUrlIds(urlFlowId, urlPageId, flows);
+			isPopStateNavigation.current = true;
+
+			if (flowId && flowId !== activeFlowId) {
+				dispatchRow({ type: "SET_ACTIVE_FLOW", flowId });
+			}
+			if (pageId) {
+				dispatchRow({ type: "SET_ACTIVE_PAGE", pageId });
+			}
+		};
+
+		window.addEventListener("popstate", handlePopState);
+		return () => window.removeEventListener("popstate", handlePopState);
+	}, [flows, activeFlowId, dispatchRow]);
+}

--- a/web/app/state/AppProvider.tsx
+++ b/web/app/state/AppProvider.tsx
@@ -4,6 +4,7 @@ import {
 	useReducer,
 	useRef,
 	useEffect,
+	useMemo,
 } from "react";
 import type { SDUI_Flow as ServerFlow } from "evy-types";
 
@@ -13,6 +14,8 @@ import { pageReducer, draggingReducer, dropIndicatorReducer } from "./reducers";
 import { decodeFlows, encodeFlow } from "../utils/decodeFlow";
 import { baseRows } from "../rows/baseRows";
 import { wsClient } from "../api/wsClient";
+import { useUrlSync } from "../hooks/useUrlSync";
+import { parseUrlPath, resolveUrlIds } from "../utils/urlUtils";
 
 export function AppProvider({
 	children,
@@ -31,11 +34,23 @@ export function AppProvider({
 
 	const flows: ServerFlow[] = initialFlows;
 
-	const [appState, dispatchRow] = useReducer(pageReducer, {
-		flows: decodeFlows(flows),
-		activeFlowId: flows[0]?.id,
-		focusMode: false,
-	});
+	const initialState = useMemo(() => {
+		const { flowId: urlFlowId, pageId: urlPageId } = parseUrlPath();
+		const { flowId: activeFlowId, pageId: activePageId } = resolveUrlIds(
+			urlFlowId,
+			urlPageId,
+			flows,
+		);
+
+		return {
+			flows: decodeFlows(flows),
+			activeFlowId,
+			activePageId,
+			focusMode: false,
+		};
+	}, [flows]);
+
+	const [appState, dispatchRow] = useReducer(pageReducer, initialState);
 
 	const [dragging, dispatchDragging] = useReducer(draggingReducer, false);
 	const [dropIndicator, dispatchDropIndicator] = useReducer(
@@ -64,6 +79,13 @@ export function AppProvider({
 
 		previousFlowsRef.current = appState.flows;
 	}, [appState.flows, appState.activeFlowId, syncWithApi]);
+
+	useUrlSync(
+		appState.activeFlowId,
+		appState.activePageId,
+		appState.flows,
+		dispatchRow,
+	);
 
 	return (
 		<AppContext.Provider

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -230,10 +230,13 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			return updateState({ updatedPages: newPages });
 		}
 		case "SET_ACTIVE_FLOW": {
-			return updateState({
+			return {
+				...state,
 				activeFlowId: action.flowId,
 				activeRowId: undefined,
-			});
+				activePageId: undefined,
+				focusMode: false,
+			};
 		}
 		case "SET_ACTIVE_ROW": {
 			const page = flow.pages.find(

--- a/web/app/utils/urlUtils.ts
+++ b/web/app/utils/urlUtils.ts
@@ -1,0 +1,43 @@
+export function parseUrlPath(): { flowId?: string; pageId?: string } {
+	const parts = window.location.pathname.split("/").filter(Boolean);
+	return {
+		flowId: parts[0] || undefined,
+		pageId: parts[1] || undefined,
+	};
+}
+
+export function buildUrlPath(flowId?: string, pageId?: string): string {
+	if (!flowId) return "/";
+	if (!pageId) return `/${flowId}`;
+	return `/${flowId}/${pageId}`;
+}
+
+export function resolveUrlIds(
+	urlFlowId: string | undefined,
+	urlPageId: string | undefined,
+	flows: { id: string; pages: { id: string }[] }[],
+): { flowId: string | undefined; pageId: string | undefined } {
+	const defaultFlowId = flows[0]?.id;
+
+	if (!urlFlowId) {
+		return { flowId: defaultFlowId, pageId: undefined };
+	}
+
+	const flow = flows.find((f) => f.id === urlFlowId);
+	if (!flow) {
+		alert(`Flow not found: "${urlFlowId}". Showing the first available flow.`);
+		return { flowId: defaultFlowId, pageId: flows[0]?.pages[0]?.id };
+	}
+
+	if (!urlPageId) {
+		return { flowId: urlFlowId, pageId: undefined };
+	}
+
+	const pageExists = flow.pages.some((p) => p.id === urlPageId);
+	if (!pageExists) {
+		alert(`Page not found: "${urlPageId}". Showing the first page.`);
+		return { flowId: urlFlowId, pageId: flow.pages[0]?.id };
+	}
+
+	return { flowId: urlFlowId, pageId: urlPageId };
+}


### PR DESCRIPTION
## Summary

- Adds URL-based routing so the active flow and page are reflected in the browser URL path (`/{flowId}/{pageId}`), and navigating to a URL directly opens the correct flow and page
- Uses the browser History API directly (no new dependencies) with bidirectional sync: state changes update the URL via `pushState`, and browser back/forward triggers state updates via `popstate`
- Shows a browser alert and falls back to the first flow/page when an invalid flow or page ID is used in the URL

## Changes

- **`web/app/utils/urlUtils.ts`** (new) — `parseUrlPath()` extracts flow/page IDs from the URL, `buildUrlPath()` constructs the path, and `resolveUrlIds()` validates IDs against available flows with alert + fallback for invalid ones
- **`web/app/hooks/useUrlSync.ts`** (new) — hook that syncs app state to the URL on changes, normalizes the URL on initial mount with `replaceState`, and handles `popstate` events for browser navigation
- **`web/app/state/AppProvider.tsx`** — reads the URL on mount to determine initial `activeFlowId`/`activePageId` instead of always defaulting to the first flow; wires up `useUrlSync`
- **`web/app/state/reducers/pageReducer.ts`** — `SET_ACTIVE_FLOW` now properly clears `activePageId` and `focusMode` to prevent stale page IDs from leaking into the URL

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] All 46 web unit tests pass
- [x] All 7 API e2e tests pass
- [x] All 8 web e2e tests pass
- [x] `./run-e2e.sh --skip-ios` passes


Made with [Cursor](https://cursor.com)