### PR TITLE
[REFACTOR] move single-use web styles into components

### DIFF
--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -1,4 +1,5 @@
-import { useContext, useEffect, useMemo, useRef } from "react";
+import type { CSSProperties } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import type {
@@ -14,6 +15,91 @@ import { AppContext, AppProvider } from "./state";
 import { handleDrop } from "./utils/dropHandler";
 import { useFlows } from "./hooks/useFlows";
 import { useActiveFlow } from "./hooks/useActiveFlow";
+
+const focusButtonCss = `
+@keyframes focus-glow {
+	0%, 100% { box-shadow: 0 0 6px 1px oklch(35.84% 0.0103 285.87 / 0.35); }
+	50% { box-shadow: 0 0 14px 4px oklch(35.84% 0.0103 285.87 / 0.6); }
+}
+.evy-focus-button--active {
+	border-color: var(--color-evy-gray-dark);
+	box-shadow: 0 0 8px 2px oklch(35.84% 0.0103 285.87 / 0.5);
+	animation: focus-glow 2s ease-in-out infinite;
+}
+`;
+
+const focusButtonStyle: CSSProperties = {
+	fontSize: "var(--text-sm)",
+	fontWeight: "var(--font-medium)",
+	height: "var(--size-navbar-control)",
+	padding: "0 var(--spacing-4)",
+	border: "1px solid var(--color-gray-border)",
+	borderRadius: "var(--radius-md)",
+	backgroundColor: "var(--color-white)",
+	cursor: "pointer",
+	position: "relative",
+	display: "inline-flex",
+	alignItems: "center",
+	justifyContent: "center",
+	transition: "border-color var(--transition), box-shadow var(--transition)",
+};
+
+const focusButtonHoverStyle: CSSProperties = {
+	...focusButtonStyle,
+	borderColor: "var(--color-evy-gray)",
+};
+
+const canvasBaseStyle: CSSProperties = {
+	flexDirection: "row",
+	overflow: "auto",
+};
+
+const canvasStyle: CSSProperties = {
+	...canvasBaseStyle,
+	gap: "var(--spacing-4)",
+	transition: "gap 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+};
+
+const canvasFocusedStyle: CSSProperties = {
+	...canvasBaseStyle,
+	gap: 0,
+	transition: "gap 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms",
+};
+
+const pageWrapperBaseStyle: CSSProperties = {
+	overflow: "hidden",
+	height: "var(--size-662)",
+};
+
+const pageWrapperStyle: CSSProperties = {
+	...pageWrapperBaseStyle,
+	marginLeft: "auto",
+	marginRight: "auto",
+	width: "var(--size-336)",
+	transition:
+		"opacity 350ms cubic-bezier(0.4, 0, 0.2, 1) 300ms, width 300ms cubic-bezier(0.4, 0, 0.2, 1), margin 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+};
+
+const pageWrapperHiddenStyle: CSSProperties = {
+	...pageWrapperBaseStyle,
+	opacity: 0,
+	width: 0,
+	marginLeft: 0,
+	marginRight: 0,
+	pointerEvents: "none",
+	transition:
+		"opacity 350ms cubic-bezier(0.4, 0, 0.2, 1), width 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms, margin 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms",
+};
+
+const panelShadowStyle: CSSProperties = {
+	boxShadow: "var(--shadow-subtle)",
+};
+
+const rightPanelStyle: CSSProperties = {
+	...panelShadowStyle,
+	borderLeftWidth: "1px",
+	borderLeftStyle: "solid",
+};
 
 function AppContent() {
 	const { dispatchRow, dispatchDragging, activePageId, focusMode } =
@@ -57,13 +143,15 @@ function AppContent() {
 
 	return (
 		<>
-			<div className="evy-w-300 evy-flex-shrink-0 evy-border-r evy-border-gray evy-bg-white evy-shadow-subtle">
+			<div
+				className="evy-w-300 evy-flex-shrink-0 evy-border-r evy-border-gray evy-bg-white"
+				style={panelShadowStyle}
+			>
 				<RowsPanel />
 			</div>
 			<div
-				className={`evy-flex-1 evy-overflow-auto evy-flex evy-flex-row evy-p-4 evy-canvas ${
-					focusMode ? "evy-canvas--focused" : ""
-				}`}
+				className="evy-flex-1 evy-flex evy-p-4"
+				style={focusMode ? canvasFocusedStyle : canvasStyle}
 				ref={canvasRef}
 			>
 				{pages.map((page) => {
@@ -72,16 +160,18 @@ function AppContent() {
 					return (
 						<div
 							key={page.id}
-							className={`evy-page-wrapper evy-flex-shrink-0 evy-mx-auto evy-bg-phone evy-bg-no-repeat evy-bg-contain evy-w-336 evy-h-662 ${
-								isHidden ? "evy-page-wrapper--hidden" : ""
-							}`}
+							className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
+							style={isHidden ? pageWrapperHiddenStyle : pageWrapperStyle}
 						>
 							<AppPage pageId={page.id} />
 						</div>
 					);
 				})}
 			</div>
-			<div className="evy-w-300 evy-flex-shrink-0 evy-border-l evy-border-gray evy-overflow-y-auto evy-bg-white evy-shadow-subtle">
+			<div
+				className="evy-w-300 evy-flex-shrink-0 evy-border-gray evy-overflow-y-auto evy-bg-white"
+				style={rightPanelStyle}
+			>
 				<ConfigurationPanel />
 			</div>
 		</>
@@ -91,6 +181,7 @@ function AppContent() {
 function NavBar() {
 	const { activePageId, activeFlowId, flows, dispatchRow, focusMode } =
 		useContext(AppContext);
+	const [focusBtnHovered, setFocusBtnHovered] = useState(false);
 
 	const activePage = useMemo(
 		() =>
@@ -102,6 +193,7 @@ function NavBar() {
 
 	return (
 		<div className="evy-border-b evy-border-gray evy-p-2 evy-bg-white evy-flex evy-items-center">
+			<style>{focusButtonCss}</style>
 			<a href="/">
 				<img className="evy-h-4" src="/logo.svg" alt="EVY" />
 			</a>
@@ -119,15 +211,17 @@ function NavBar() {
 								})
 							}
 							placeholder="Page title"
-							className="evy-navbar-page-title evy-text-center evy-bg-transparent evy-border-none evy-focus-visible:outline-none evy-text-lg evy-font-semibold"
+							className="evy-text-center evy-bg-transparent evy-border-none evy-focus-visible:outline-none evy-text-lg evy-font-semibold"
+							style={{ height: "var(--size-navbar-control)" }}
 							aria-label="Page title"
 						/>
 						<button
 							type="button"
 							onClick={() => dispatchRow({ type: "TOGGLE_FOCUS_MODE" })}
-							className={`evy-focus-button ${
-								focusMode ? "evy-focus-button--active" : ""
-							}`}
+							className={focusMode ? "evy-focus-button--active" : ""}
+							style={focusBtnHovered ? focusButtonHoverStyle : focusButtonStyle}
+							onMouseEnter={() => setFocusBtnHovered(true)}
+							onMouseLeave={() => setFocusBtnHovered(false)}
 							aria-pressed={focusMode}
 						>
 							Focus

--- a/web/app/components/AppPage.tsx
+++ b/web/app/components/AppPage.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import invariant from "tiny-invariant";
 
@@ -7,6 +8,25 @@ import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element
 
 import { AppContext } from "../state";
 import { DraggableRowContainer } from "./DraggableRowContainer";
+
+const pageTitleStyle: CSSProperties = {
+	textAlign: "center",
+	fontWeight: "var(--font-semibold)",
+	fontSize: "var(--text-xl)",
+	padding: "var(--spacing-2) var(--spacing-4)",
+	width: "100%",
+	background: "none",
+	border: "none",
+};
+
+const rounded24Style: CSSProperties = {
+	borderRadius: "var(--radius-2-4)",
+};
+
+const roundedBottom24Style: CSSProperties = {
+	borderBottomLeftRadius: "var(--radius-2-4)",
+	borderBottomRightRadius: "var(--radius-2-4)",
+};
 
 export default function AppPage({ pageId }: { pageId: string }) {
 	const { flows, activeFlowId, dispatchRow, dispatchDropIndicator } =
@@ -97,7 +117,8 @@ export default function AppPage({ pageId }: { pageId: string }) {
 	const titleElement = page?.title ? (
 		<button
 			type="button"
-			className="evy-page-title evy-cursor-pointer"
+			className="evy-cursor-pointer"
+			style={pageTitleStyle}
 			onClick={() => dispatchRow({ type: "SET_ACTIVE_PAGE", pageId })}
 		>
 			{page.title}
@@ -107,9 +128,15 @@ export default function AppPage({ pageId }: { pageId: string }) {
 	const footer = page?.footer;
 
 	return (
-		<div className="evy-overflow-hidden evy-p-30px evy-h-full evy-w-full evy-box-sizing-border">
+		<div
+			className="evy-overflow-hidden evy-h-full evy-w-full evy-box-sizing-border"
+			style={{ padding: "var(--spacing-30px)" }}
+		>
 			{footer ? (
-				<div className="evy-flex evy-flex-col evy-h-full evy-rounded-24 evy-bg-white">
+				<div
+					className="evy-flex evy-flex-col evy-h-full evy-bg-white"
+					style={rounded24Style}
+				>
 					{titleElement}
 					<div
 						className="evy-overflow-scroll evy-flex-1 evy-pt-4"
@@ -119,7 +146,8 @@ export default function AppPage({ pageId }: { pageId: string }) {
 					</div>
 					<button
 						type="button"
-						className="evy-border-none evy-hover:bg-gray-light evy-cursor-pointer evy-rounded-bottom-24 evy-w-full evy-bg-white evy-p-0"
+						className="evy-border-none evy-hover:bg-gray-light evy-cursor-pointer evy-w-full evy-bg-white evy-p-0"
+						style={roundedBottom24Style}
 						onClick={() => selectRow(footer.id)}
 					>
 						{footer.row}
@@ -127,7 +155,8 @@ export default function AppPage({ pageId }: { pageId: string }) {
 				</div>
 			) : (
 				<div
-					className="evy-overflow-scroll evy-h-full evy-rounded-24 evy-pt-4 evy-bg-white"
+					className="evy-overflow-scroll evy-h-full evy-pt-4 evy-bg-white"
+					style={rounded24Style}
 					ref={scrollableRef}
 				>
 					{titleElement}

--- a/web/app/components/CancelOverlay.tsx
+++ b/web/app/components/CancelOverlay.tsx
@@ -34,8 +34,9 @@ export function CancelOverlay({ dismiss }: { dismiss: () => void }) {
 	return (
 		<Fragment>
 			<div
-				className="evy-flex evy-absolute evy-inset-y-0 evy-w-full evy-opacity-60"
+				className="evy-flex evy-absolute evy-inset-y-0 evy-w-full"
 				style={{
+					opacity: 0.6,
 					backgroundColor:
 						state.type === idle.type
 							? "var(--color-evy-gray-light)"
@@ -44,11 +45,12 @@ export function CancelOverlay({ dismiss }: { dismiss: () => void }) {
 			/>
 			<button
 				type="button"
-				className="evy-flex evy-absolute evy-inset-y-0 evy-w-full evy-justify-center evy-pt-32 evy-border-none evy-bg-transparent evy-cursor-pointer"
+				className="evy-flex evy-absolute evy-inset-y-0 evy-w-full evy-justify-center evy-border-none evy-bg-transparent evy-cursor-pointer"
+				style={{ paddingTop: "var(--spacing-32)" }}
 				ref={ref}
 				onClick={dismiss}
 			>
-				<img className="evy-h-48" src="/bin.svg" alt="Delete" />
+				<img style={{ height: "var(--size-48)" }} src="/bin.svg" alt="Delete" />
 			</button>
 		</Fragment>
 	);

--- a/web/app/components/FlowSelector.tsx
+++ b/web/app/components/FlowSelector.tsx
@@ -17,7 +17,8 @@ export function FlowSelector() {
 			id="flow-select"
 			value={activeFlowId || "Select a flow"}
 			onChange={handleFlowChange}
-			className="evy-flow-selector evy-text-sm evy-font-medium evy-p-2"
+			className="evy-text-sm evy-font-medium evy-p-2"
+			style={{ paddingRight: "calc(var(--spacing-8) + var(--spacing-4))" }}
 		>
 			{flows.map((flow) => (
 				<option key={flow.id} value={flow.id}>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -77,9 +77,6 @@ body {
 .evy-flex-col {
 	flex-direction: column;
 }
-.evy-flex-row {
-	flex-direction: row;
-}
 .evy-flex-1 {
 	flex: 1 1 0%;
 }
@@ -100,9 +97,6 @@ body {
 }
 .evy-overflow-scroll {
 	overflow: scroll;
-}
-.evy-overflow-auto {
-	overflow: auto;
 }
 .evy-flex-shrink-0 {
 	flex-shrink: 0;
@@ -135,43 +129,16 @@ body {
 .evy-pl-4 {
 	padding-left: var(--spacing-4);
 }
-.evy-pl-8 {
-	padding-left: var(--spacing-8);
-}
-.evy-pr-8 {
-	padding-right: var(--spacing-8);
-}
-.evy-p-30px {
-	padding: var(--spacing-30px);
-}
-.evy-px-2 {
-	padding-left: var(--spacing-2);
-	padding-right: var(--spacing-2);
-}
 .evy-px-4 {
 	padding-left: var(--spacing-4);
 	padding-right: var(--spacing-4);
-}
-.evy-px-8 {
-	padding-left: var(--spacing-8);
-	padding-right: var(--spacing-8);
 }
 .evy-py-2 {
 	padding-top: var(--spacing-2);
 	padding-bottom: var(--spacing-2);
 }
-.evy-py-8 {
-	padding-top: var(--spacing-8);
-	padding-bottom: var(--spacing-8);
-}
 .evy-pt-4 {
 	padding-top: var(--spacing-4);
-}
-.evy-pt-32 {
-	padding-top: var(--spacing-32);
-}
-.evy-ps-2 {
-	padding-inline-start: var(--spacing-2);
 }
 
 /* Margin utilities */
@@ -195,29 +162,16 @@ body {
 }
 
 /* Width utilities */
-.evy-w-336 {
-	width: var(--size-336);
-}
-.evy-max-w-100 {
-	max-width: 100%;
-}
 .evy-w-full {
 	width: 100%;
 }
 .evy-w-300 {
 	width: 300px;
 }
-.evy-mx-auto {
-	margin-left: auto;
-	margin-right: auto;
-}
 
 /* Height utilities */
 .evy-h-4 {
 	height: var(--size-4);
-}
-.evy-h-48 {
-	height: var(--size-48);
 }
 .evy-h-full {
 	height: 100%;
@@ -225,17 +179,11 @@ body {
 .evy-h-screen {
 	height: 100vh;
 }
-.evy-h-662 {
-	height: var(--size-662);
-}
 .evy-min-h-full {
 	min-height: 100%;
 }
 
 /* Background utilities */
-.evy-bg-gray {
-	background-color: var(--color-evy-gray);
-}
 .evy-bg-gray-light {
 	background-color: var(--color-evy-gray-light);
 }
@@ -283,9 +231,6 @@ body {
 .evy-text-gray {
 	color: var(--color-evy-gray);
 }
-.evy-text-red {
-	color: var(--color-evy-red);
-}
 .evy-font-medium {
 	font-weight: var(--font-medium);
 }
@@ -305,23 +250,9 @@ body {
 	border-right-width: 1px;
 	border-right-style: solid;
 }
-.evy-border-r-0 {
-	border-right-width: 0px;
-}
-.evy-border-l {
-	border-left-width: 1px;
-	border-left-style: solid;
-}
-.evy-border-l-0 {
-	border-left-width: 0px;
-}
 .evy-border-b {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
-}
-.evy-border-t {
-	border-top-width: 1px;
-	border-top-style: solid;
 }
 .evy-border-gray {
 	border-color: var(--color-gray-border);
@@ -337,46 +268,11 @@ body {
 .evy-rounded-md {
 	border-radius: var(--radius-md);
 }
-.evy-rounded-full {
-	border-radius: 999px;
-}
-.evy-rounded-24 {
-	border-top-left-radius: var(--radius-2-4);
-	border-top-right-radius: var(--radius-2-4);
-	border-bottom-left-radius: var(--radius-2-4);
-	border-bottom-right-radius: var(--radius-2-4);
-}
-.evy-rounded-bottom-24 {
-	border-bottom-left-radius: var(--radius-2-4);
-	border-bottom-right-radius: var(--radius-2-4);
-}
-.evy-rounded-left-md {
-	border-top-left-radius: var(--radius-md);
-	border-bottom-left-radius: var(--radius-md);
-}
-.evy-rounded-right-md {
-	border-top-right-radius: var(--radius-md);
-	border-bottom-right-radius: var(--radius-md);
-}
 
 /* Position utilities */
 .evy-inset-y-0 {
 	top: 0;
 	bottom: 0;
-}
-.evy-start-0 {
-	inset-inline-start: 0;
-}
-.evy-end-0 {
-	inset-inline-end: 0;
-}
-.evy-pe-2 {
-	padding-inline-end: var(--spacing-2);
-}
-
-/* Opacity utilities */
-.evy-opacity-60 {
-	opacity: var(--opacity-60);
 }
 
 /* Pointer events */
@@ -392,11 +288,6 @@ body {
 	outline: none;
 }
 
-/* Shadow utilities */
-.evy-shadow-subtle {
-	box-shadow: var(--shadow-subtle);
-}
-
 /* Hover utilities */
 .evy-hover\:bg-gray:hover {
 	background-color: var(--color-evy-gray);
@@ -406,11 +297,6 @@ body {
 }
 .evy-hover\:text-black:hover {
 	color: var(--color-black);
-}
-
-/* Resize utilities */
-.evy-resize-none {
-	resize: none;
 }
 
 /* Form element styling */
@@ -463,100 +349,6 @@ label {
 	color: var(--color-black);
 	margin-bottom: var(--spacing-2);
 	display: block;
-}
-
-.evy-inline-icon {
-	display: inline;
-	height: 1em;
-	width: 1em;
-	vertical-align: -0.125em;
-}
-
-.evy-page-title {
-	text-align: center;
-	font-weight: var(--font-semibold);
-	font-size: var(--text-xl);
-	padding: var(--spacing-2) var(--spacing-4);
-	width: 100%;
-	background: none;
-	border: none;
-}
-
-.evy-flow-selector {
-	padding-right: calc(var(--spacing-8) + var(--spacing-4));
-}
-
-.evy-navbar-page-title {
-	height: var(--size-navbar-control);
-}
-
-.evy-focus-button {
-	font-size: var(--text-sm);
-	font-weight: var(--font-medium);
-	height: var(--size-navbar-control);
-	padding: 0 var(--spacing-4);
-	border: 1px solid var(--color-gray-border);
-	border-radius: var(--radius-md);
-	background-color: var(--color-white);
-	cursor: pointer;
-	position: relative;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	transition:
-		border-color var(--transition),
-		box-shadow var(--transition);
-}
-
-.evy-focus-button:hover {
-	border-color: var(--color-evy-gray);
-}
-
-.evy-focus-button--active {
-	border-color: var(--color-evy-gray-dark);
-	box-shadow: 0 0 8px 2px oklch(35.84% 0.0103 285.87 / 0.5);
-	animation: focus-glow 2s ease-in-out infinite;
-}
-
-@keyframes focus-glow {
-	0%,
-	100% {
-		box-shadow: 0 0 6px 1px oklch(35.84% 0.0103 285.87 / 0.35);
-	}
-
-	50% {
-		box-shadow: 0 0 14px 4px oklch(35.84% 0.0103 285.87 / 0.6);
-	}
-}
-
-.evy-canvas {
-	gap: var(--spacing-4);
-	transition: gap 300ms cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.evy-canvas--focused {
-	gap: 0;
-	transition: gap 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms;
-}
-
-.evy-page-wrapper {
-	overflow: hidden;
-	transition:
-		opacity 350ms cubic-bezier(0.4, 0, 0.2, 1) 300ms,
-		width 300ms cubic-bezier(0.4, 0, 0.2, 1),
-		margin 300ms cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.evy-page-wrapper--hidden {
-	opacity: 0;
-	width: 0;
-	margin-left: 0;
-	margin-right: 0;
-	pointer-events: none;
-	transition:
-		opacity 350ms cubic-bezier(0.4, 0, 0.2, 1),
-		width 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms,
-		margin 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms;
 }
 
 .evy-v-dropzone {

--- a/web/app/icons/parseIconText.tsx
+++ b/web/app/icons/parseIconText.tsx
@@ -1,7 +1,14 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import iconMap from "./iconMap";
 
 const ICON_REGEX = /::[a-zA-Z.]+::/g;
+
+const inlineIconStyle: CSSProperties = {
+	display: "inline",
+	height: "1em",
+	width: "1em",
+	verticalAlign: "-0.125em",
+};
 
 export default function parseIconText(input: string): ReactNode {
 	const parts: ReactNode[] = [];
@@ -22,7 +29,7 @@ export default function parseIconText(input: string): ReactNode {
 			parts.push(
 				<img
 					key={matchStart}
-					className="evy-inline-icon"
+					style={inlineIconStyle}
 					src={iconPath}
 					alt={iconName}
 				/>,

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useState } from "react";
 
 import type { Row, RowConfig } from "../../types/row";
@@ -7,6 +8,22 @@ import { RowLayout } from "../design-system/RowLayout";
 import { useRowById } from "../../hooks/useRowById";
 
 const typeName = "SelectSegmentContainerRow";
+
+const firstSegmentStyle: CSSProperties = {
+	borderTopLeftRadius: "var(--radius-md)",
+	borderBottomLeftRadius: "var(--radius-md)",
+	borderRightWidth: "0px",
+};
+
+const lastSegmentStyle: CSSProperties = {
+	borderTopRightRadius: "var(--radius-md)",
+	borderBottomRightRadius: "var(--radius-md)",
+	borderLeftWidth: "0px",
+};
+
+const segmentGroupStyle: CSSProperties = {
+	borderRadius: "999px",
+};
 
 export default defineRow(typeName, {
 	config: {
@@ -46,23 +63,25 @@ export default defineRow(typeName, {
 
 		return (
 			<RowLayout title={row.config.view.content.title}>
-				<div className="evy-rounded-full evy-flex evy-mb-2">
-					{segments.map((segment, index) => (
-						<button
-							key={segment}
-							type="button"
-							onClick={() => setSelectedTab(index)}
-							className={`evy-flex-1 evy-border ${
-								index === 0 ? "evy-rounded-left-md evy-border-r-0" : ""
-							} ${
-								index === segments.length - 1
-									? "evy-rounded-right-md evy-border-l-0"
-									: ""
-							} ${selectedTab === index ? "evy-bg-gray-light" : "evy-bg-white"}`}
-						>
-							{segment}
-						</button>
-					))}
+				<div className="evy-flex evy-mb-2" style={segmentGroupStyle}>
+					{segments.map((segment, index) => {
+						const isFirst = index === 0;
+						const isLast = index === segments.length - 1;
+						return (
+							<button
+								key={segment}
+								type="button"
+								onClick={() => setSelectedTab(index)}
+								className={`evy-flex-1 evy-border ${selectedTab === index ? "evy-bg-gray-light" : "evy-bg-white"}`}
+								style={{
+									...(isFirst && firstSegmentStyle),
+									...(isLast && lastSegmentStyle),
+								}}
+							>
+								{segment}
+							</button>
+						);
+					})}
 				</div>
 				<ContainerChildren
 					rows={rowsToShow}

--- a/web/app/rows/design-system/InlineIcon.tsx
+++ b/web/app/rows/design-system/InlineIcon.tsx
@@ -1,6 +1,17 @@
+import type { CSSProperties } from "react";
 import iconMap from "../../icons/iconMap";
 
 const ICON_SYNTAX_REGEX = /^::(.+)::$/;
+
+const leftPositionStyle: CSSProperties = {
+	insetInlineStart: 0,
+	paddingInlineStart: "var(--spacing-2)",
+};
+
+const rightPositionStyle: CSSProperties = {
+	insetInlineEnd: 0,
+	paddingInlineEnd: "var(--spacing-2)",
+};
 
 function resolveIconSrc(icon: string): string {
 	const match = icon.match(ICON_SYNTAX_REGEX);
@@ -19,12 +30,10 @@ export default function InlineIcon({
 	alt: string;
 	position?: "left" | "right";
 }) {
-	const positionClass =
-		position === "right" ? "evy-end-0 evy-pe-2" : "evy-start-0 evy-ps-2";
-
 	return (
 		<div
-			className={`evy-absolute evy-inset-y-0 ${positionClass} evy-flex evy-items-center evy-pointer-events-none`}
+			className="evy-absolute evy-inset-y-0 evy-flex evy-items-center evy-pointer-events-none"
+			style={position === "right" ? rightPositionStyle : leftPositionStyle}
 		>
 			<img className="evy-h-4" src={resolveIconSrc(icon)} alt={alt} />
 		</div>

--- a/web/app/rows/design-system/Input.tsx
+++ b/web/app/rows/design-system/Input.tsx
@@ -1,4 +1,10 @@
+import type { CSSProperties } from "react";
 import { border } from "./border";
+
+const offsetStyles: Record<string, CSSProperties> = {
+	left: { paddingLeft: "var(--spacing-8)" },
+	right: { paddingRight: "var(--spacing-8)" },
+};
 
 export default function Input({
 	value,
@@ -9,12 +15,11 @@ export default function Input({
 	placeholder: string;
 	offset?: "none" | "left" | "right";
 }) {
-	const offsetClass =
-		offset === "left" ? "evy-pl-8" : offset === "right" ? "evy-pr-8" : "";
 	return (
 		<input
 			type="text"
-			className={`evy-w-full evy-box-sizing-border evy-text-sm ${border} evy-focus-visible:outline-none ${offsetClass}`}
+			className={`evy-w-full evy-box-sizing-border evy-text-sm ${border} evy-focus-visible:outline-none`}
+			style={offsetStyles[offset]}
 			required
 			value={value}
 			placeholder={placeholder}

--- a/web/app/rows/design-system/RadioButton.tsx
+++ b/web/app/rows/design-system/RadioButton.tsx
@@ -8,11 +8,15 @@ export default function RadioButton({
 	return (
 		<button
 			type="button"
-			className={`evy-rounded-md evy-text-sm evy-px-2 evy-py-2 evy-border-none ${
+			className={`evy-rounded-md evy-text-sm evy-py-2 evy-border-none ${
 				selected
 					? "evy-bg-gray-light evy-text-black evy-hover:bg-gray"
 					: "evy-bg-gray-dark evy-text-white evy-hover:bg-gray"
 			}`}
+			style={{
+				paddingLeft: "var(--spacing-2)",
+				paddingRight: "var(--spacing-2)",
+			}}
 		>
 			{label}
 		</button>

--- a/web/app/rows/design-system/TextArea.tsx
+++ b/web/app/rows/design-system/TextArea.tsx
@@ -11,7 +11,8 @@ export default function TextArea({
 		<textarea
 			id="message"
 			rows={4}
-			className={`evy-block evy-box-sizing-border evy-p-2 evy-w-full evy-text-sm ${border} evy-focus-visible:outline-none evy-resize-none`}
+			className={`evy-block evy-box-sizing-border evy-p-2 evy-w-full evy-text-sm ${border} evy-focus-visible:outline-none`}
+			style={{ resize: "none" }}
 			placeholder={placeholder}
 			value={value}
 			readOnly

--- a/web/app/rows/edit/CalendarRow.tsx
+++ b/web/app/rows/edit/CalendarRow.tsx
@@ -20,7 +20,8 @@ export default defineRow("CalendarRow", {
 			<img
 				src="/calendar.png"
 				alt="calendar"
-				className="evy-max-w-100 evy-block evy-pointer-events-none"
+				className="evy-block evy-pointer-events-none"
+				style={{ maxWidth: "100%" }}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/SelectPhotoRow.tsx
+++ b/web/app/rows/edit/SelectPhotoRow.tsx
@@ -20,7 +20,10 @@ export default defineRow("SelectPhotoRow", {
 	} satisfies RowConfig,
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
-			<div className="evy-rounded-md evy-px-8 evy-py-8 evy-border evy-text-sm">
+			<div
+				className="evy-rounded-md evy-border evy-text-sm"
+				style={{ padding: "var(--spacing-8)" }}
+			>
 				<div className="evy-flex evy-justify-center evy-text-center evy-flex-col">
 					<EVYText
 						text={


### PR DESCRIPTION
## Summary
- move single-use CSS classes out of `web/app/globals.css` and colocate their styles in the components that own them
- simplify the new inline style setup by extracting shared style constants in `App.tsx` and `SelectSegmentContainerRow.tsx`
- remove now-unused global utility classes while keeping shared utilities and test-referenced dropzone styles in place

## Test plan
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test`

Made with [Cursor](https://cursor.com)