### PR TITLE
[FEAT] Add text interpolation, function resolution, and newline support to web builder

### DIFF
--- a/web/app/rows/design-system/EVYText.tsx
+++ b/web/app/rows/design-system/EVYText.tsx
@@ -1,4 +1,5 @@
 import parseIconText from "../../icons/parseIconText";
+import { parseText } from "../../utils/evyInterpreter";
 
 export default function EVYText({
 	text,
@@ -7,5 +8,10 @@ export default function EVYText({
 	text: string;
 	className?: string;
 }) {
-	return <span className={className}>{parseIconText(text)}</span>;
+	const resolvedText = parseText(text);
+	return (
+		<span className={className} style={{ whiteSpace: "pre-line" }}>
+			{parseIconText(resolvedText)}
+		</span>
+	);
 }

--- a/web/app/rows/design-system/Input.tsx
+++ b/web/app/rows/design-system/Input.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { parseText } from "../../utils/evyInterpreter";
 import { border } from "./border";
 
 const offsetStyles: Record<string, CSSProperties> = {
@@ -21,8 +22,8 @@ export default function Input({
 			className={`evy-w-full evy-box-sizing-border evy-text-sm ${border} evy-focus-visible:outline-none`}
 			style={offsetStyles[offset]}
 			required
-			value={value}
-			placeholder={placeholder}
+			value={parseText(value)}
+			placeholder={parseText(placeholder)}
 			readOnly
 		/>
 	);

--- a/web/app/rows/design-system/TextArea.tsx
+++ b/web/app/rows/design-system/TextArea.tsx
@@ -1,3 +1,4 @@
+import { parseText } from "../../utils/evyInterpreter";
 import { border } from "./border";
 
 export default function TextArea({
@@ -13,8 +14,8 @@ export default function TextArea({
 			rows={4}
 			className={`evy-block evy-box-sizing-border evy-p-2 evy-w-full evy-text-sm ${border} evy-focus-visible:outline-none`}
 			style={{ resize: "none" }}
-			placeholder={placeholder}
-			value={value}
+			placeholder={parseText(placeholder)}
+			value={parseText(value)}
 			readOnly
 		/>
 	);

--- a/web/app/rows/edit/SelectPhotoRow.tsx
+++ b/web/app/rows/edit/SelectPhotoRow.tsx
@@ -32,10 +32,26 @@ export default defineRow("SelectPhotoRow", {
 								: ""
 						}
 					/>
-					<p className="evy-text-sm">{row.config.view.content.content}</p>
+					<p className="evy-text-sm">
+						<EVYText
+							text={
+								typeof row.config.view.content.content === "string"
+									? row.config.view.content.content
+									: ""
+							}
+						/>
+					</p>
 				</div>
 			</div>
-			<p className="evy-text-sm">{row.config.view.content.subtitle}</p>
+			<p className="evy-text-sm">
+				<EVYText
+					text={
+						typeof row.config.view.content.subtitle === "string"
+							? row.config.view.content.subtitle
+							: ""
+					}
+				/>
+			</p>
 		</RowLayout>
 	),
 });

--- a/web/app/rows/edit/TextSelectRow.tsx
+++ b/web/app/rows/edit/TextSelectRow.tsx
@@ -1,6 +1,7 @@
 import type { RowConfig } from "../../types/row";
 import { defineRow } from "../defineRow";
 import Checkbox from "../design-system/Checkbox";
+import EVYText from "../design-system/EVYText";
 import { RowLayout } from "../design-system/RowLayout";
 
 export default defineRow("TextSelectRow", {
@@ -18,7 +19,9 @@ export default defineRow("TextSelectRow", {
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<div className="evy-flex evy-justify-between">
-				<p className="evy-text-sm">{row.config.view.content.text}</p>
+				<p className="evy-text-sm">
+					<EVYText text={row.config.view.content.text ?? ""} />
+				</p>
 				<Checkbox checked={false} />
 			</div>
 		</RowLayout>

--- a/web/app/utils/evyFunctions.ts
+++ b/web/app/utils/evyFunctions.ts
@@ -1,0 +1,46 @@
+export type EVYFunctionOutput = {
+	value: string;
+	prefix?: string;
+	suffix?: string;
+};
+
+export function evyCount(): EVYFunctionOutput {
+	return { value: "1" };
+}
+
+export function evyLength(): EVYFunctionOutput {
+	return { value: "1" };
+}
+
+export function evyFormatCurrency(): EVYFunctionOutput {
+	return { value: "1.00", prefix: "$" };
+}
+
+export function evyFormatDimension(): EVYFunctionOutput {
+	return { value: "100", suffix: "mm" };
+}
+
+export function evyFormatWeight(): EVYFunctionOutput {
+	return { value: "500", suffix: "g" };
+}
+
+export function evyFormatAddress(): EVYFunctionOutput {
+	return { value: "1 Main Street, 2000\nSydney, NSW" };
+}
+
+const functionHandlers: Record<string, () => EVYFunctionOutput | null> = {
+	count: evyCount,
+	length: evyLength,
+	formatCurrency: evyFormatCurrency,
+	formatDimension: evyFormatDimension,
+	formatWeight: evyFormatWeight,
+	formatAddress: evyFormatAddress,
+	buildCurrency: () => null,
+	buildAddress: () => null,
+};
+
+export function callFunction(name: string): EVYFunctionOutput | null {
+	const handler = functionHandlers[name];
+	if (!handler) return null;
+	return handler();
+}

--- a/web/app/utils/evyInterpreter.ts
+++ b/web/app/utils/evyInterpreter.ts
@@ -1,0 +1,55 @@
+import { callFunction } from "./evyFunctions";
+
+const FUNCTION_WITH_BRACES = /\{([a-zA-Z_]+)\(([^)]*)\)\}/;
+const PROPS_PATTERN = /\{(?!")[^}^"]*(?!")\}/;
+
+function resolveFunction(match: string): string | null {
+	const fnMatch = match.match(/^\{([a-zA-Z_]+)\(([^)]*)\)\}$/);
+	if (!fnMatch) return null;
+
+	const functionName = fnMatch[1];
+	const result = callFunction(functionName);
+	if (!result) return "";
+
+	return `${result.prefix ?? ""}${result.value}${result.suffix ?? ""}`;
+}
+
+function propToUserFriendlyString(prop: string): string {
+	const lastSegment = prop.split(".").pop() ?? prop;
+	return lastSegment.replace(/_/g, " ");
+}
+
+export function parseText(input: string): string {
+	if (!input) return input;
+
+	let text = input;
+	let safety = 0;
+
+	while (safety++ < 50) {
+		const fnMatch = FUNCTION_WITH_BRACES.exec(text);
+		if (fnMatch) {
+			const resolved = resolveFunction(fnMatch[0]);
+			if (resolved !== null) {
+				text = text.replace(fnMatch[0], resolved);
+				continue;
+			}
+		}
+
+		const propsMatch = PROPS_PATTERN.exec(text);
+		if (propsMatch) {
+			const inner = propsMatch[0].slice(1, -1);
+
+			if (/[><=!]/.test(inner)) {
+				text = text.replace(propsMatch[0], "");
+				continue;
+			}
+
+			text = text.replace(propsMatch[0], propToUserFriendlyString(inner));
+			continue;
+		}
+
+		break;
+	}
+
+	return text.replace(/\\n/g, "\n");
+}


### PR DESCRIPTION
## Summary

- **Text interpolation engine**: Added `evyInterpreter.ts` and `evyFunctions.ts` to resolve SDUI template expressions (e.g. `{count(photo_ids)}` → `1`, `{item.title}` → `title`) and function calls (`count`, `length`, `formatCurrency`, `formatDimension`, `formatWeight`, `formatAddress`) in displayed text.
- **Newline rendering**: `EVYText` now parses literal `\n` sequences into real newlines and uses `white-space: pre-line` so line breaks display correctly across all rows.
- **Consistent text rendering**: Updated `TextSelectRow`, `SelectPhotoRow`, `Input`, and `TextArea` to route text through `parseText`/`EVYText` instead of rendering raw template strings, ensuring interpolation and newline handling work everywhere.

## Test plan

- [ ] Verify the "Sharing data publicly" page shows bullet-pointed list with proper line breaks
- [ ] Verify "Accept app payments" description splits into separate lines at `\n`
- [ ] Verify "Photos: {count(photo_ids)}/10" displays as "Photos: 1/10"
- [ ] Verify other function calls (`formatCurrency`, `formatDimension`, etc.) resolve in their respective rows
- [ ] Verify Input and TextArea placeholders/values resolve template expressions


Made with [Cursor](https://cursor.com)