### PR TITLE
[FEAT] Secondary sheet page for editing SheetContainer children

### DIFF
--- a/api/e2e/e2e.test.ts
+++ b/api/e2e/e2e.test.ts
@@ -130,6 +130,7 @@ describe("API E2E Tests", () => {
 			const testRow: SDUI_Row = {
 				id: crypto.randomUUID(),
 				type: "Text",
+				actions: [],
 				view: {
 					content: {
 						title: "Hello",

--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -60,12 +60,14 @@ function formatFlowRow(row: PersistedFlowRow): DATA_Flow {
 	};
 }
 
-function formatPersistedDataRow(row: PersistedDataRow): DATA_Data {
+function formatPersistedDataRow(
+	row: Omit<PersistedDataRow, "data"> & { data: unknown },
+): DATA_Data {
 	return {
 		id: row.id,
 		namespace: row.namespace,
 		resource: row.resource,
-		data: row.data,
+		data: row.data as DATA_Data["data"],
 		createdAt: row.createdAt.toISOString(),
 		updatedAt: row.updatedAt.toISOString(),
 	};
@@ -211,10 +213,7 @@ export async function upsert(params: unknown): Promise<DATA_Rows> {
 			)
 			.returning();
 		if (result.length > 0) {
-			return formatPersistedDataRow({
-				...result[0],
-				data: result[0].data as DATA_Data["data"],
-			});
+			return formatPersistedDataRow(result[0]);
 		}
 	}
 
@@ -228,8 +227,5 @@ export async function upsert(params: unknown): Promise<DATA_Rows> {
 			updatedAt: now,
 		})
 		.returning();
-	return formatPersistedDataRow({
-		...result[0],
-		data: result[0].data as DATA_Data["data"],
-	});
+	return formatPersistedDataRow(result[0]);
 }

--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -60,14 +60,12 @@ function formatFlowRow(row: PersistedFlowRow): DATA_Flow {
 	};
 }
 
-function formatPersistedDataRow(
-	row: Omit<PersistedDataRow, "data"> & { data: unknown },
-): DATA_Data {
+function formatPersistedDataRow(row: PersistedDataRow): DATA_Data {
 	return {
 		id: row.id,
 		namespace: row.namespace,
 		resource: row.resource,
-		data: row.data as DATA_Data["data"],
+		data: row.data,
 		createdAt: row.createdAt.toISOString(),
 		updatedAt: row.updatedAt.toISOString(),
 	};

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -4,7 +4,13 @@ import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
 import { PGlite } from "@electric-sql/pglite";
 
-import type { SDUI_Flow, DATA_Flow, DATA_Rows } from "evy-types";
+import type {
+	SDUI_Flow,
+	DATA_Flow,
+	DATA_Data,
+	DATA_Rows,
+	GetRequest,
+} from "evy-types";
 import * as schema from "../../../types/generated/ts/db/schema.generated";
 import {
 	type RowSchema,
@@ -181,18 +187,23 @@ describe("get", () => {
 	});
 
 	it("should throw when params is not an object", async () => {
-		await expect(get(null)).rejects.toThrow("Params must be an object");
+		await expect(get(null as unknown as GetRequest)).rejects.toThrow(
+			"Params must be an object",
+		);
 	});
 
 	it("should throw when namespace is invalid", async () => {
 		await expect(
-			get({ namespace: "invalid", resource: "sdui" }),
+			get({ namespace: "invalid", resource: "sdui" } as unknown as GetRequest),
 		).rejects.toThrow("Invalid or missing namespace");
 	});
 
 	it("should throw when resource is invalid", async () => {
 		await expect(
-			get({ namespace: "evy", resource: "InvalidResource" }),
+			get({
+				namespace: "evy",
+				resource: "InvalidResource",
+			} as unknown as GetRequest),
 		).rejects.toThrow("Invalid or missing resource");
 	});
 
@@ -253,7 +264,8 @@ describe("get", () => {
 		});
 
 		expect(result).toHaveLength(1);
-		expect(result[0].name).toBe("Single Flow");
+		const flow = result[0] as SDUI_Flow;
+		expect(flow.name).toBe("Single Flow");
 	});
 
 	it("should return empty array for SDUI when filter.id matches nothing", async () => {
@@ -427,9 +439,8 @@ describe("upsert", () => {
 		});
 
 		expect(!isDATA_Flow(result)).toBe(true);
-		if (!isDATA_Flow(result)) {
-			expect(result.data).toEqual(payload);
-		}
+		const dataResult = result as DATA_Data;
+		expect(dataResult.data).toEqual(payload);
 		const dataRecords = await testDb.select().from(schema.data);
 		expect(dataRecords).toHaveLength(1);
 		expect(dataRecords[0].namespace).toBe("evy");

--- a/api/src/validation.ts
+++ b/api/src/validation.ts
@@ -64,21 +64,22 @@ const FlowDataSchema: z.ZodType<SDUI_Flow> = z.strictObject({
 	pages: z.array(PageSchema),
 });
 
-/**
- * Validates flow data and returns the validated data or throws an error
- * with a descriptive message about what failed validation
- */
+export function formatZodErrors(issues: z.core.$ZodIssue[]): string {
+	return issues
+		.map((issue) => {
+			const path = issue.path.join(".");
+			return path ? `${path}: ${issue.message}` : issue.message;
+		})
+		.join("; ");
+}
+
 export function validateFlowData(data: unknown): SDUI_Flow {
 	const result = FlowDataSchema.safeParse(data);
 
 	if (!result.success) {
-		const errorMessages = result.error.issues
-			.map((err) => {
-				const path = err.path.join(".");
-				return path ? `${path}: ${err.message}` : err.message;
-			})
-			.join("; ");
-		throw new Error(`Flow validation failed: ${errorMessages}`);
+		throw new Error(
+			`Flow validation failed: ${formatZodErrors(result.error.issues)}`,
+		);
 	}
 
 	return result.data;

--- a/scripts/generate-drizzle.ts
+++ b/scripts/generate-drizzle.ts
@@ -178,18 +178,6 @@ function getPropSchema(
 	return typeof p === "object" && p !== null ? p : null;
 }
 
-function isRefToSduiFlow(prop: JsonSchemaProp): boolean {
-	const ref = prop.$ref;
-	return (
-		typeof ref === "string" &&
-		(ref.includes("SDUI_Flow") || ref.includes("evy.schema.json"))
-	);
-}
-
-function isRefToOs(ref: string | undefined): boolean {
-	return typeof ref === "string" && ref.includes("OS");
-}
-
 type ColumnSuffixes = { isPk: boolean; hasDefaultRandom: boolean };
 
 function buildStringColumn(
@@ -223,24 +211,28 @@ function buildBooleanColumn(dbCol: string, defaultVal: unknown): string {
 	return col;
 }
 
+function resolveJsonbTypeAnnotation(ref: string | undefined): string {
+	if (ref?.includes("SDUI_Flow") || ref?.includes("evy.schema.json")) {
+		return "SDUI_Flow";
+	}
+	if (ref?.includes("JSONValue") || ref?.includes("json.schema.json")) {
+		return 'DATA_Data["data"]';
+	}
+	return "unknown";
+}
+
 function buildObjectColumn(
 	dbCol: string,
 	prop: JsonSchemaProp,
 	{ isPk, hasDefaultRandom }: ColumnSuffixes,
 ): string {
-	let col: string;
-	if (isRefToSduiFlow(prop)) {
-		col = `jsonb("${dbCol}").$type<SDUI_Flow>().notNull()`;
-	} else {
-		col = `jsonb("${dbCol}").$type<Record<string, unknown>>().notNull()`;
-	}
+	const typeArg = prop.$ref
+		? resolveJsonbTypeAnnotation(prop.$ref)
+		: "Record<string, unknown>";
+	let col = `jsonb("${dbCol}").$type<${typeArg}>().notNull()`;
 	if (isPk) col += ".primaryKey()";
 	if (hasDefaultRandom) col += ".defaultRandom()";
 	return col;
-}
-
-function isRefToJsonValue(ref: string): boolean {
-	return ref.includes("JSONValue") || ref.includes("json.schema.json");
 }
 
 function buildRefColumn(
@@ -248,22 +240,14 @@ function buildRefColumn(
 	ref: string,
 	{ isPk, hasDefaultRandom }: ColumnSuffixes,
 ): string {
-	if (isRefToOs(ref)) {
+	if (ref.includes("OS")) {
 		return `osEnum("${dbCol}").notNull()`;
 	}
-	if (ref.includes("SDUI_Flow") || ref.includes("evy.schema.json")) {
-		let col = `jsonb("${dbCol}").$type<SDUI_Flow>().notNull()`;
-		if (isPk) col += ".primaryKey()";
-		if (hasDefaultRandom) col += ".defaultRandom()";
-		return col;
-	}
-	if (isRefToJsonValue(ref)) {
-		let col = `jsonb("${dbCol}").$type<DATA_Data["data"]>().notNull()`;
-		if (isPk) col += ".primaryKey()";
-		if (hasDefaultRandom) col += ".defaultRandom()";
-		return col;
-	}
-	return `jsonb("${dbCol}").$type<unknown>().notNull()`;
+	const typeArg = resolveJsonbTypeAnnotation(ref);
+	let col = `jsonb("${dbCol}").$type<${typeArg}>().notNull()`;
+	if (isPk) col += ".primaryKey()";
+	if (hasDefaultRandom) col += ".defaultRandom()";
+	return col;
 }
 
 function applyNullabilityFallback(

--- a/scripts/generate-drizzle.ts
+++ b/scripts/generate-drizzle.ts
@@ -239,6 +239,10 @@ function buildObjectColumn(
 	return col;
 }
 
+function isRefToJsonValue(ref: string): boolean {
+	return ref.includes("JSONValue") || ref.includes("json.schema.json");
+}
+
 function buildRefColumn(
 	dbCol: string,
 	ref: string,
@@ -249,6 +253,12 @@ function buildRefColumn(
 	}
 	if (ref.includes("SDUI_Flow") || ref.includes("evy.schema.json")) {
 		let col = `jsonb("${dbCol}").$type<SDUI_Flow>().notNull()`;
+		if (isPk) col += ".primaryKey()";
+		if (hasDefaultRandom) col += ".defaultRandom()";
+		return col;
+	}
+	if (isRefToJsonValue(ref)) {
+		let col = `jsonb("${dbCol}").$type<DATA_Data["data"]>().notNull()`;
 		if (isPk) col += ".primaryKey()";
 		if (hasDefaultRandom) col += ".defaultRandom()";
 		return col;
@@ -333,6 +343,7 @@ async function main(): Promise<void> {
 		'} from "drizzle-orm/pg-core";',
 		'import { relations } from "drizzle-orm";',
 		'import type { SDUI_Flow } from "evy-types/sdui/evy";',
+		'import type { DATA_Data } from "evy-types/data/data";',
 		"",
 	];
 

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -128,17 +128,28 @@ function hasExternalRefs(obj: unknown): boolean {
  * strip `export` from interfaces that aren't the schema's primary type so they
  * stay module-local.
  */
-function unexportReferencedTypes(source: string, primaryTitle: string): string {
+function unexportReferencedTypes(
+	source: string,
+	keepExported: Set<string>,
+): string {
 	return source.replace(
 		/^export (interface|type) (\w+)/gm,
 		(match, keyword, name) =>
-			name === primaryTitle ? match : `${keyword} ${name}`,
+			keepExported.has(name) ? match : `${keyword} ${name}`,
 	);
 }
 
 async function generateTypeScript(
 	schemaFiles: LoadedSchemaFile[],
 ): Promise<void> {
+	const allSchemaTitles = new Set(
+		schemaFiles.map(
+			({ schemaPath, schema }) =>
+				(schema.title as string | undefined) ??
+				schemaPathToSwiftTypeName(schemaPath),
+		),
+	);
+
 	await Promise.all(
 		schemaFiles.map(async ({ schemaPath, schemaKey, schema }) => {
 			const outRel = schemaPathToTsName(schemaPath) + ".ts";
@@ -173,9 +184,19 @@ async function generateTypeScript(
 				style: { singleQuote: false },
 				cwd: join(schemaPath, ".."),
 			});
-			const output = hasExternalRefs(schema)
-				? unexportReferencedTypes(ts, title)
-				: ts;
+			let output = ts;
+			if (hasExternalRefs(schema)) {
+				const ownDefs = new Set(
+					Object.keys((schema.$defs as Record<string, unknown>) ?? {}),
+				);
+				ownDefs.add(title);
+				for (const defName of ownDefs) {
+					if (defName !== title && allSchemaTitles.has(defName)) {
+						ownDefs.delete(defName);
+					}
+				}
+				output = unexportReferencedTypes(ts, ownDefs);
+			}
 			await writeFile(outPath, output, "utf-8");
 
 			if (schemaKey === "sdui/evy") {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import pluralize from "pluralize";
 import { z } from "zod";
 import { db, schema } from "../api/src/db";
-import { validateFlowData } from "../api/src/validation";
+import { validateFlowData, formatZodErrors } from "../api/src/validation";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const EVY_FLOWS_PATH = join(SCRIPT_DIR, "..", "docs", "evy", "evy_sdui.json");
@@ -53,14 +53,8 @@ function validateSeedDataItem(
 ): SeedDataItem {
 	const result = SeedDataItemSchema.safeParse(item);
 	if (!result.success) {
-		const errorMessages = result.error.issues
-			.map((issue) => {
-				const path = issue.path.join(".");
-				return path ? `${path}: ${issue.message}` : issue.message;
-			})
-			.join("; ");
 		throw new Error(
-			`Seed data validation failed for resource "${resource}" at index ${index}: ${errorMessages}`,
+			`Seed data validation failed for resource "${resource}" at index ${index}: ${formatZodErrors(result.error.issues)}`,
 		);
 	}
 	return result.data;

--- a/types/schema/sdui/evy.schema.json
+++ b/types/schema/sdui/evy.schema.json
@@ -85,6 +85,18 @@
 			"required": ["title"],
 			"properties": {
 				"title": { "type": "string" },
+				"label": { "type": "string" },
+				"text": { "type": "string" },
+				"value": { "type": "string" },
+				"placeholder": { "type": "string" },
+				"format": { "type": "string" },
+				"action": { "type": "string" },
+				"primary": { "type": "string" },
+				"secondary": { "type": "string" },
+				"subtitle": { "type": "string" },
+				"icon": { "type": "string" },
+				"content": { "type": "string" },
+				"photos": { "type": "string" },
 				"children": {
 					"type": "array",
 					"items": { "$ref": "#/$defs/SDUI_Row" }

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@atlaskit/pragmatic-drag-and-drop/types";
 
 import AppPage from "./components/AppPage";
+import SecondarySheetPage from "./components/SecondarySheetPage";
 import { ConfigurationPanel } from "./components/ConfigurationPanel";
 import { FlowSelector } from "./components/FlowSelector";
 import { RowsPanel } from "./components/RowsPanel";
@@ -15,6 +16,7 @@ import { AppContext, AppProvider } from "./state";
 import { handleDrop } from "./utils/dropHandler";
 import { useFlows } from "./hooks/useFlows";
 import { useActiveFlow } from "./hooks/useActiveFlow";
+import { findRowInPages } from "./utils/rowTree";
 
 const focusButtonCss = `
 .evy-focus-button {
@@ -63,6 +65,13 @@ const canvasFocusedStyle: CSSProperties = {
 	transition: "gap 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms",
 };
 
+const canvasFocusedWithSecondaryStyle: CSSProperties = {
+	...canvasBaseStyle,
+	gap: 0,
+	justifyContent: "center",
+	transition: "gap 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms",
+};
+
 const pageWrapperBaseStyle: CSSProperties = {
 	overflow: "hidden",
 	height: "var(--size-662)",
@@ -88,6 +97,35 @@ const pageWrapperHiddenStyle: CSSProperties = {
 		"opacity 350ms cubic-bezier(0.4, 0, 0.2, 1), width 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms, margin 300ms cubic-bezier(0.4, 0, 0.2, 1) 350ms",
 };
 
+const pageWrapperFocusedWithSecondaryStyle: CSSProperties = {
+	...pageWrapperBaseStyle,
+	width: "var(--size-336)",
+	marginLeft: 0,
+	marginRight: 0,
+	transition:
+		"opacity 350ms cubic-bezier(0.4, 0, 0.2, 1) 300ms, width 300ms cubic-bezier(0.4, 0, 0.2, 1), margin 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+};
+
+const secondaryPageWrapperStyle: CSSProperties = {
+	...pageWrapperBaseStyle,
+	width: "var(--size-336)",
+	marginLeft: "var(--spacing-4)",
+	opacity: 1,
+	transition:
+		"opacity 350ms cubic-bezier(0.4, 0, 0.2, 1) 100ms, width 300ms cubic-bezier(0.4, 0, 0.2, 1), margin 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+};
+
+const secondaryPageWrapperHiddenStyle: CSSProperties = {
+	...pageWrapperBaseStyle,
+	opacity: 0,
+	width: 0,
+	marginLeft: 0,
+	overflow: "hidden",
+	pointerEvents: "none",
+	transition:
+		"opacity 200ms cubic-bezier(0.4, 0, 0.2, 1), width 300ms cubic-bezier(0.4, 0, 0.2, 1) 200ms, margin 300ms cubic-bezier(0.4, 0, 0.2, 1) 200ms",
+};
+
 const panelShadowStyle: CSSProperties = {
 	boxShadow: "var(--shadow-subtle)",
 };
@@ -99,10 +137,22 @@ const rightPanelStyle: CSSProperties = {
 };
 
 function AppContent() {
-	const { dispatchRow, dispatchDragging, activePageId, focusMode } =
-		useContext(AppContext);
+	const {
+		dispatchRow,
+		dispatchDragging,
+		activePageId,
+		focusMode,
+		secondarySheetRowId,
+	} = useContext(AppContext);
 	const { pages } = useActiveFlow();
 	const canvasRef = useRef<HTMLDivElement | null>(null);
+
+	const secondarySheetRow = useMemo(() => {
+		if (!secondarySheetRowId || !focusMode) return undefined;
+		return findRowInPages(secondarySheetRowId, pages);
+	}, [secondarySheetRowId, focusMode, pages]);
+
+	const showSecondary = Boolean(secondarySheetRow);
 
 	useEffect(() => {
 		return monitorForElements({
@@ -127,7 +177,11 @@ function AppContent() {
 
 		const clearSelection = (event: MouseEvent) => {
 			if (event.target === event.currentTarget) {
-				dispatchRow({ type: "CLEAR_ACTIVE_SELECTION" });
+				if (secondarySheetRowId) {
+					dispatchRow({ type: "CLOSE_SECONDARY_SHEET" });
+				} else if (!focusMode) {
+					dispatchRow({ type: "CLEAR_ACTIVE_SELECTION" });
+				}
 			}
 		};
 
@@ -136,7 +190,7 @@ function AppContent() {
 		return () => {
 			element.removeEventListener("click", clearSelection);
 		};
-	}, [dispatchRow]);
+	}, [dispatchRow, secondarySheetRowId, focusMode]);
 
 	return (
 		<>
@@ -148,22 +202,51 @@ function AppContent() {
 			</div>
 			<div
 				className="evy-flex-1 evy-flex evy-p-4"
-				style={focusMode ? canvasFocusedStyle : canvasStyle}
+				style={
+					focusMode
+						? showSecondary
+							? canvasFocusedWithSecondaryStyle
+							: canvasFocusedStyle
+						: canvasStyle
+				}
 				ref={canvasRef}
 			>
 				{pages.map((page) => {
 					const isHidden = focusMode && page.id !== activePageId;
+					const isFocusedPage = focusMode && page.id === activePageId;
+
+					let wrapperStyle = pageWrapperStyle;
+					if (isHidden) {
+						wrapperStyle = pageWrapperHiddenStyle;
+					} else if (isFocusedPage && showSecondary) {
+						wrapperStyle = pageWrapperFocusedWithSecondaryStyle;
+					}
 
 					return (
 						<div
 							key={page.id}
 							className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
-							style={isHidden ? pageWrapperHiddenStyle : pageWrapperStyle}
+							style={wrapperStyle}
 						>
 							<AppPage pageId={page.id} />
 						</div>
 					);
 				})}
+				{focusMode && (
+					<div
+						className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
+						style={
+							showSecondary
+								? secondaryPageWrapperStyle
+								: secondaryPageWrapperHiddenStyle
+						}
+						data-testid="secondary-sheet-page"
+					>
+						{secondarySheetRow && secondarySheetRowId && (
+							<SecondarySheetPage sheetRowId={secondarySheetRowId} />
+						)}
+					</div>
+				)}
 			</div>
 			<div
 				className="evy-w-300 evy-flex-shrink-0 evy-border-gray evy-overflow-y-auto evy-bg-white"

--- a/web/app/components/ActionEditor.tsx
+++ b/web/app/components/ActionEditor.tsx
@@ -85,8 +85,10 @@ export function ActionEditor({ actions, flows, onUpdate }: ActionEditorProps) {
 		setEditingIndex(null);
 	}, []);
 
-	const editingAction =
-		editingIndex !== null ? actions[editingIndex] : undefined;
+	const editing =
+		editingIndex !== null && actions[editingIndex]
+			? { action: actions[editingIndex], index: editingIndex }
+			: undefined;
 
 	return (
 		<div>
@@ -118,10 +120,10 @@ export function ActionEditor({ actions, flows, onUpdate }: ActionEditorProps) {
 				<div className="evy-text-sm evy-text-gray">Row has no actions</div>
 			)}
 
-			{editingAction && editingIndex !== null && (
+			{editing && (
 				<ActionPopup
-					action={editingAction}
-					actionIndex={editingIndex}
+					action={editing.action}
+					actionIndex={editing.index}
 					onSave={handlePopupSave}
 					onCancel={handlePopupCancel}
 				/>

--- a/web/app/components/ActionPopup.tsx
+++ b/web/app/components/ActionPopup.tsx
@@ -412,8 +412,9 @@ function ConditionEditor({
 		}) => {
 			if (isPlaceholder) {
 				const updated = { ...draft, [field]: value };
-				setDraft(updated);
-				if (updated.left && updated.operator && updated.right) {
+				if (!updated.left || !updated.operator || !updated.right) {
+					setDraft(updated);
+				} else {
 					onChange([...conditions, updated]);
 					setDraft({ left: "", operator: "==", right: "" });
 				}

--- a/web/app/components/ActionPopup.tsx
+++ b/web/app/components/ActionPopup.tsx
@@ -118,7 +118,6 @@ import {
 	ACTION_FUNCTIONS,
 	FUNCTION_LABELS,
 	CONDITION_FUNCTIONS,
-	displayLabel,
 	extractDraftVariables,
 	parseCondition,
 	serializeCondition,
@@ -129,6 +128,7 @@ import {
 	getDataModelNames,
 	getFlowOptions,
 	getPageOptions,
+	toVariableOptions,
 	type ConditionPart,
 	type ActionFunction,
 } from "../utils/actionHelpers";
@@ -286,11 +286,7 @@ function OperandEditor({
 	const parsed = useMemo(() => parseOperand(value), [value]);
 
 	const variableOptions: PopoverOption[] = useMemo(
-		() =>
-			draftVariables.map((v) => ({
-				value: v,
-				label: displayLabel(v),
-			})),
+		() => toVariableOptions(draftVariables),
 		[draftVariables],
 	);
 
@@ -402,28 +398,25 @@ function ConditionEditor({
 		right: "",
 	});
 
-	const handleDraftChange = useCallback(
-		(field: "left" | "operator" | "right", value: string) => {
-			const updated = { ...draft, [field]: value };
-			setDraft(updated);
-
-			if (updated.left && updated.operator && updated.right) {
-				onChange([...conditions, updated]);
-				setDraft({ left: "", operator: "==", right: "" });
+	const handleFieldChange = useCallback(
+		(rowIndex: number, field: "left" | "operator" | "right", value: string) => {
+			const isPlaceholder = rowIndex === conditions.length;
+			if (isPlaceholder) {
+				const updated = { ...draft, [field]: value };
+				setDraft(updated);
+				if (updated.left && updated.operator && updated.right) {
+					onChange([...conditions, updated]);
+					setDraft({ left: "", operator: "==", right: "" });
+				}
+			} else {
+				onChange(
+					conditions.map((c, i) =>
+						i === rowIndex ? { ...c, [field]: value } : c,
+					),
+				);
 			}
 		},
 		[draft, conditions, onChange],
-	);
-
-	const handleRowChange = useCallback(
-		(rowIndex: number, field: "left" | "operator" | "right", value: string) => {
-			const updated = conditions.map((c, i) => {
-				if (i !== rowIndex) return c;
-				return { ...c, [field]: value };
-			});
-			onChange(updated);
-		},
-		[conditions, onChange],
 	);
 
 	const handleRemoveCondition = useCallback(
@@ -448,33 +441,21 @@ function ConditionEditor({
 								ariaLabel={`condition-${actionIndex}-${rowIndex}-left`}
 								value={row.left}
 								draftVariables={draftVariables}
-								onChange={(v) =>
-									isPlaceholderRow
-										? handleDraftChange("left", v)
-										: handleRowChange(rowIndex, "left", v)
-								}
+								onChange={(v) => handleFieldChange(rowIndex, "left", v)}
 							/>
 
 							<PopoverSelect
 								ariaLabel={`condition-${actionIndex}-${rowIndex}-op`}
 								options={OPERATOR_OPTIONS}
 								value={row.operator}
-								onChange={(v) =>
-									isPlaceholderRow
-										? handleDraftChange("operator", v)
-										: handleRowChange(rowIndex, "operator", v)
-								}
+								onChange={(v) => handleFieldChange(rowIndex, "operator", v)}
 							/>
 
 							<OperandEditor
 								ariaLabel={`condition-${actionIndex}-${rowIndex}-right`}
 								value={row.right}
 								draftVariables={draftVariables}
-								onChange={(v) =>
-									isPlaceholderRow
-										? handleDraftChange("right", v)
-										: handleRowChange(rowIndex, "right", v)
-								}
+								onChange={(v) => handleFieldChange(rowIndex, "right", v)}
 							/>
 
 							{!isPlaceholderRow && (
@@ -584,19 +565,11 @@ function buildArgDropdowns(
 	}
 
 	if (functionName === "create") {
-		return [
-			getDataModelNames(flows).map((name) => ({
-				value: name,
-				label: displayLabel(name),
-			})),
-		];
+		return [toVariableOptions(getDataModelNames(flows))];
 	}
 
 	if (functionName === "highlight_required") {
-		const varOptions = draftVariables.map((v) => ({
-			value: v,
-			label: displayLabel(v),
-		}));
+		const varOptions = toVariableOptions(draftVariables);
 		const dropdowns: PopoverOption[][] = [varOptions];
 
 		const filledCount = currentArgs.filter(Boolean).length;

--- a/web/app/components/ActionPopup.tsx
+++ b/web/app/components/ActionPopup.tsx
@@ -399,8 +399,17 @@ function ConditionEditor({
 	});
 
 	const handleFieldChange = useCallback(
-		(rowIndex: number, field: "left" | "operator" | "right", value: string) => {
-			const isPlaceholder = rowIndex === conditions.length;
+		({
+			rowIndex,
+			field,
+			isPlaceholder,
+			value,
+		}: {
+			rowIndex: number;
+			field: "left" | "operator" | "right";
+			isPlaceholder: boolean;
+			value: string;
+		}) => {
 			if (isPlaceholder) {
 				const updated = { ...draft, [field]: value };
 				setDraft(updated);
@@ -431,7 +440,7 @@ function ConditionEditor({
 	return (
 		<div className="evy-flex evy-flex-col evy-gap-2">
 			{rows.map((row, rowIndex) => {
-				const isPlaceholderRow = rowIndex === conditions.length;
+				const isPlaceholder = rowIndex === conditions.length;
 				const conditionRowId = `condition-${actionIndex}-${rowIndex}`;
 				return (
 					<span key={conditionRowId}>
@@ -441,24 +450,45 @@ function ConditionEditor({
 								ariaLabel={`condition-${actionIndex}-${rowIndex}-left`}
 								value={row.left}
 								draftVariables={draftVariables}
-								onChange={(v) => handleFieldChange(rowIndex, "left", v)}
+								onChange={(v) =>
+									handleFieldChange({
+										rowIndex,
+										field: "left",
+										isPlaceholder,
+										value: v,
+									})
+								}
 							/>
 
 							<PopoverSelect
 								ariaLabel={`condition-${actionIndex}-${rowIndex}-op`}
 								options={OPERATOR_OPTIONS}
 								value={row.operator}
-								onChange={(v) => handleFieldChange(rowIndex, "operator", v)}
+								onChange={(v) =>
+									handleFieldChange({
+										rowIndex,
+										field: "operator",
+										isPlaceholder,
+										value: v,
+									})
+								}
 							/>
 
 							<OperandEditor
 								ariaLabel={`condition-${actionIndex}-${rowIndex}-right`}
 								value={row.right}
 								draftVariables={draftVariables}
-								onChange={(v) => handleFieldChange(rowIndex, "right", v)}
+								onChange={(v) =>
+									handleFieldChange({
+										rowIndex,
+										field: "right",
+										isPlaceholder,
+										value: v,
+									})
+								}
 							/>
 
-							{!isPlaceholderRow && (
+							{!isPlaceholder && (
 								<button
 									type="button"
 									className="evy-bin-button evy-condition-remove evy-bg-transparent evy-border-none evy-cursor-pointer"

--- a/web/app/components/AppPage.tsx
+++ b/web/app/components/AppPage.tsx
@@ -1,26 +1,17 @@
 import type { CSSProperties } from "react";
-import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
-import invariant from "tiny-invariant";
-
-import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
-import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
-import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { useCallback, useContext, useMemo, useRef } from "react";
 
 import { AppContext } from "../state";
-import { DraggableRowContainer } from "./DraggableRowContainer";
+import { usePageDropTarget } from "../hooks/usePageDropTarget";
+import { useSelectRow } from "../hooks/useSelectRow";
+import { buildRowElements } from "./buildRowElements";
+import { baseTitleStyle, rounded24Style } from "./pageStyles";
 
 const pageTitleStyle: CSSProperties = {
-	textAlign: "center",
-	fontWeight: "var(--font-semibold)",
-	fontSize: "var(--text-xl)",
-	padding: "var(--spacing-2) var(--spacing-4)",
+	...baseTitleStyle,
 	width: "100%",
 	background: "none",
 	border: "none",
-};
-
-const rounded24Style: CSSProperties = {
-	borderRadius: "var(--radius-2-4)",
 };
 
 const roundedBottom24Style: CSSProperties = {
@@ -34,15 +25,7 @@ export default function AppPage({ pageId }: { pageId: string }) {
 
 	const scrollableRef = useRef<HTMLDivElement | null>(null);
 
-	const selectRow = useCallback(
-		(rowId: string) =>
-			dispatchRow({
-				type: "SET_ACTIVE_ROW",
-				pageId,
-				rowId,
-			}),
-		[pageId, dispatchRow],
-	);
+	const selectRow = useSelectRow(pageId, dispatchRow);
 
 	const selectPage = useCallback(
 		(e: MouseEvent) => {
@@ -53,41 +36,12 @@ export default function AppPage({ pageId }: { pageId: string }) {
 		[pageId, dispatchRow],
 	);
 
-	useEffect(() => {
-		invariant(
-			scrollableRef.current,
-			"AppPage useEffect: scrollableRef.current is not defined",
-		);
-		const element = scrollableRef.current;
-		element.addEventListener("click", selectPage);
-		const cleanup = combine(
-			dropTargetForElements({
-				element,
-				getData: () => ({ pageId }),
-				canDrop: () => true,
-				onDrop: () => {
-					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" });
-				},
-				onDragEnter: () =>
-					dispatchDropIndicator({
-						type: "SET_INDICATOR_PAGE",
-						pageId: pageId,
-					}),
-				onDragLeave: () =>
-					dispatchDropIndicator({
-						type: "UNSET_INDICATOR_PAGE",
-					}),
-			}),
-			autoScrollForElements({
-				element,
-				canScroll: () => true,
-			}),
-		);
-		return () => {
-			element.removeEventListener("click", selectPage);
-			cleanup();
-		};
-	}, [pageId, selectPage, dispatchDropIndicator]);
+	usePageDropTarget({
+		scrollableRef,
+		pageId,
+		dispatchDropIndicator,
+		onClickBackground: selectPage,
+	});
 
 	const page = useMemo(
 		() =>
@@ -99,20 +53,7 @@ export default function AppPage({ pageId }: { pageId: string }) {
 
 	const rowElements = useMemo(() => {
 		if (!page) return [];
-
-		const lastIndex = page.rows.length - 1;
-		return page.rows.map((row, index) => (
-			<DraggableRowContainer
-				key={row.id}
-				rowId={row.id}
-				selectRow={() => selectRow(row.id)}
-				showIndicators
-				previousRowId={index > 0 ? page.rows[index - 1].id : undefined}
-				nextRowId={index < lastIndex ? page.rows[index + 1].id : undefined}
-			>
-				{row.row}
-			</DraggableRowContainer>
-		));
+		return buildRowElements(page.rows, selectRow);
 	}, [page, selectRow]);
 
 	const titleElement = page?.title ? (

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { AppContext } from "../state";
 import type { Row } from "../types/row";
@@ -23,7 +23,7 @@ function ChildRowButton({
 	return (
 		<button
 			type="button"
-			className="evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
+			className="evy-w-full evy-flex evy-items-center evy-justify-between evy-gap-3 evy-p-3 evy-bg-white evy-border evy-border-gray evy-text-left evy-cursor-pointer evy-hover:bg-gray-light"
 			onClick={onClick}
 		>
 			<span>{child.config.type}</span>
@@ -33,7 +33,8 @@ function ChildRowButton({
 }
 
 export function ConfigurationPanel() {
-	const { activeRowId, flows, focusMode, dispatchRow } = useContext(AppContext);
+	const { activeRowId, flows, focusMode, secondarySheetRowId, dispatchRow } =
+		useContext(AppContext);
 	const row = useRowById(activeRowId);
 	const [configStack, setConfigStack] = useState<string[]>([]);
 	const currentConfigRowId = configStack.at(-1) ?? row?.id;
@@ -44,23 +45,45 @@ export function ConfigurationPanel() {
 		setConfigStack([]);
 	}, [activeRowId]);
 
+	useEffect(() => {
+		if (!focusMode) {
+			setConfigStack([]);
+		}
+	}, [focusMode]);
+
+	const prevSecondarySheetRowId = useRef(secondarySheetRowId);
+	useEffect(() => {
+		if (prevSecondarySheetRowId.current && !secondarySheetRowId) {
+			setConfigStack([]);
+		}
+		prevSecondarySheetRowId.current = secondarySheetRowId;
+	}, [secondarySheetRowId]);
+
 	const openChildConfiguration = useCallback(
-		(childRowId: string) => {
+		(childRowId: string, parentRow: Row) => {
 			setConfigStack((currentStack) => [...currentStack, childRowId]);
-			if (!focusMode) {
-				dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
+			if (
+				parentRow.config.type === "SheetContainer" &&
+				parentRow.config.view.content.children?.some((c) => c.id === childRowId)
+			) {
+				if (!focusMode) {
+					dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
+				}
+				dispatchRow({
+					type: "OPEN_SECONDARY_SHEET",
+					sheetRowId: parentRow.id,
+				});
 			}
 		},
 		[focusMode, dispatchRow],
 	);
 
 	const goBackToParentConfiguration = useCallback(() => {
-		const willReturnToRoot = configStack.length <= 1;
 		setConfigStack((currentStack) => currentStack.slice(0, -1));
-		if (willReturnToRoot && focusMode) {
-			dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
+		if (secondarySheetRowId) {
+			dispatchRow({ type: "CLOSE_SECONDARY_SHEET" });
 		}
-	}, [configStack.length, focusMode, dispatchRow]);
+	}, [secondarySheetRowId, dispatchRow]);
 
 	const updateRowContent = useCallback(
 		(configId: string, configValue: string, targetRowId?: string) => {
@@ -91,8 +114,14 @@ export function ConfigurationPanel() {
 	const renderConfiguration = useCallback(
 		(configRow: Row): React.ReactNode[] => {
 			const content = configRow.config.view.content;
+			const entries = Object.entries(content).sort(([a], [b]) => {
+				const isContainerKey = (k: string) => k === "child" || k === "children";
+				if (isContainerKey(a) && !isContainerKey(b)) return 1;
+				if (!isContainerKey(a) && isContainerKey(b)) return -1;
+				return 0;
+			});
 
-			return Object.entries(content).map(([key, value]) => {
+			return entries.map(([key, value]) => {
 				const uniqueId = `${configRow.id}-${key}`;
 
 				if (key === "children") {
@@ -108,7 +137,7 @@ export function ConfigurationPanel() {
 									<ChildRowButton
 										key={child.id}
 										child={child}
-										onClick={() => openChildConfiguration(child.id)}
+										onClick={() => openChildConfiguration(child.id, configRow)}
 									/>
 								))}
 							</div>
@@ -119,11 +148,15 @@ export function ConfigurationPanel() {
 					if (!isRow(value)) return null;
 					const child = value;
 					return (
-						<ChildRowButton
-							key={uniqueId}
-							child={child}
-							onClick={() => openChildConfiguration(child.id)}
-						/>
+						<div key={uniqueId}>
+							<div className="evy-text-sm evy-font-medium evy-text-black evy-mb-2">
+								Child
+							</div>
+							<ChildRowButton
+								child={child}
+								onClick={() => openChildConfiguration(child.id, configRow)}
+							/>
+						</div>
 					);
 				}
 				return (

--- a/web/app/components/RowsPanel.tsx
+++ b/web/app/components/RowsPanel.tsx
@@ -30,7 +30,8 @@ export function RowsPanel() {
 				element: pageInnerRef.current,
 				getData: () => ({ pageId: "rows" }),
 				canDrop: () => true,
-				onDragStart: () => dispatchDragging({ type: "START_DRAGGING" }),
+				onDragStart: () =>
+					dispatchDragging({ type: "START_DRAGGING", source: "rows" }),
 				onDrop: () => dispatchDragging({ type: "STOP_DRAGGING" }),
 			}),
 		);

--- a/web/app/components/SecondarySheetPage.tsx
+++ b/web/app/components/SecondarySheetPage.tsx
@@ -1,0 +1,112 @@
+import type { CSSProperties } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import invariant from "tiny-invariant";
+
+import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+import { AppContext } from "../state";
+import { DraggableRowContainer } from "./DraggableRowContainer";
+import { findRowInPages } from "../utils/rowTree";
+
+const rounded24Style: CSSProperties = {
+	borderRadius: "var(--radius-2-4)",
+};
+
+const titleStyle: CSSProperties = {
+	textAlign: "center",
+	fontWeight: "var(--font-semibold)",
+	fontSize: "var(--text-xl)",
+	padding: "var(--spacing-2) var(--spacing-4)",
+};
+
+export default function SecondarySheetPage({
+	sheetRowId,
+}: {
+	sheetRowId: string;
+}) {
+	const { flows, activeFlowId, dispatchRow, dispatchDropIndicator } =
+		useContext(AppContext);
+	const scrollableRef = useRef<HTMLDivElement | null>(null);
+
+	const sheetRow = useMemo(() => {
+		const pages = flows.find((f) => f.id === activeFlowId)?.pages ?? [];
+		return findRowInPages(sheetRowId, pages);
+	}, [flows, activeFlowId, sheetRowId]);
+
+	const pageId = `secondary:${sheetRowId}`;
+	const title = sheetRow?.config.view.content.title ?? "Sheet";
+	const childRows = sheetRow?.config.view.content.children ?? [];
+
+	const selectRow = useCallback(
+		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", pageId, rowId }),
+		[pageId, dispatchRow],
+	);
+
+	useEffect(() => {
+		invariant(
+			scrollableRef.current,
+			"SecondarySheetPage useEffect: scrollableRef.current is not defined",
+		);
+		const element = scrollableRef.current;
+		const cleanup = combine(
+			dropTargetForElements({
+				element,
+				getData: () => ({ pageId, sheetRowId }),
+				canDrop: () => true,
+				onDrop: () => {
+					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" });
+				},
+				onDragEnter: () =>
+					dispatchDropIndicator({
+						type: "SET_INDICATOR_PAGE",
+						pageId,
+					}),
+				onDragLeave: () =>
+					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" }),
+			}),
+			autoScrollForElements({
+				element,
+				canScroll: () => true,
+			}),
+		);
+		return () => {
+			cleanup();
+		};
+	}, [pageId, sheetRowId, dispatchDropIndicator]);
+
+	const childRowIds = childRows.map((r) => r.id).join(",");
+	// biome-ignore lint/correctness/useExhaustiveDependencies: childRowIds detects in-place array mutations that childRows reference misses
+	const rowElements = useMemo(() => {
+		const lastIndex = childRows.length - 1;
+		return childRows.map((row, index) => (
+			<DraggableRowContainer
+				key={row.id}
+				rowId={row.id}
+				selectRow={() => selectRow(row.id)}
+				showIndicators
+				previousRowId={index > 0 ? childRows[index - 1].id : undefined}
+				nextRowId={index < lastIndex ? childRows[index + 1].id : undefined}
+			>
+				{row.row}
+			</DraggableRowContainer>
+		));
+	}, [childRows, childRowIds, selectRow]);
+
+	return (
+		<div
+			className="evy-overflow-hidden evy-h-full evy-w-full evy-box-sizing-border"
+			style={{ padding: "var(--spacing-30px)" }}
+		>
+			<div
+				className="evy-overflow-scroll evy-h-full evy-pt-4 evy-bg-white"
+				style={rounded24Style}
+				ref={scrollableRef}
+			>
+				<div style={titleStyle}>{title}</div>
+				{rowElements}
+			</div>
+		</div>
+	);
+}

--- a/web/app/components/SecondarySheetPage.tsx
+++ b/web/app/components/SecondarySheetPage.tsx
@@ -1,25 +1,11 @@
-import type { CSSProperties } from "react";
-import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
-import invariant from "tiny-invariant";
-
-import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
-import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
-import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { useContext, useMemo, useRef } from "react";
 
 import { AppContext } from "../state";
-import { DraggableRowContainer } from "./DraggableRowContainer";
+import { usePageDropTarget } from "../hooks/usePageDropTarget";
+import { useSelectRow } from "../hooks/useSelectRow";
+import { buildRowElements } from "./buildRowElements";
+import { baseTitleStyle, rounded24Style } from "./pageStyles";
 import { findRowInPages } from "../utils/rowTree";
-
-const rounded24Style: CSSProperties = {
-	borderRadius: "var(--radius-2-4)",
-};
-
-const titleStyle: CSSProperties = {
-	textAlign: "center",
-	fontWeight: "var(--font-semibold)",
-	fontSize: "var(--text-xl)",
-	padding: "var(--spacing-2) var(--spacing-4)",
-};
 
 export default function SecondarySheetPage({
 	sheetRowId,
@@ -39,60 +25,23 @@ export default function SecondarySheetPage({
 	const title = sheetRow?.config.view.content.title ?? "Sheet";
 	const childRows = sheetRow?.config.view.content.children ?? [];
 
-	const selectRow = useCallback(
-		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", pageId, rowId }),
-		[pageId, dispatchRow],
-	);
+	const selectRow = useSelectRow(pageId, dispatchRow);
 
-	useEffect(() => {
-		invariant(
-			scrollableRef.current,
-			"SecondarySheetPage useEffect: scrollableRef.current is not defined",
-		);
-		const element = scrollableRef.current;
-		const cleanup = combine(
-			dropTargetForElements({
-				element,
-				getData: () => ({ pageId, sheetRowId }),
-				canDrop: () => true,
-				onDrop: () => {
-					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" });
-				},
-				onDragEnter: () =>
-					dispatchDropIndicator({
-						type: "SET_INDICATOR_PAGE",
-						pageId,
-					}),
-				onDragLeave: () =>
-					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" }),
-			}),
-			autoScrollForElements({
-				element,
-				canScroll: () => true,
-			}),
-		);
-		return () => {
-			cleanup();
-		};
-	}, [pageId, sheetRowId, dispatchDropIndicator]);
+	const extraData = useMemo(() => ({ sheetRowId }), [sheetRowId]);
+
+	usePageDropTarget({
+		scrollableRef,
+		pageId,
+		dispatchDropIndicator,
+		extraData,
+	});
 
 	const childRowIds = childRows.map((r) => r.id).join(",");
 	// biome-ignore lint/correctness/useExhaustiveDependencies: childRowIds detects in-place array mutations that childRows reference misses
-	const rowElements = useMemo(() => {
-		const lastIndex = childRows.length - 1;
-		return childRows.map((row, index) => (
-			<DraggableRowContainer
-				key={row.id}
-				rowId={row.id}
-				selectRow={() => selectRow(row.id)}
-				showIndicators
-				previousRowId={index > 0 ? childRows[index - 1].id : undefined}
-				nextRowId={index < lastIndex ? childRows[index + 1].id : undefined}
-			>
-				{row.row}
-			</DraggableRowContainer>
-		));
-	}, [childRows, childRowIds, selectRow]);
+	const rowElements = useMemo(
+		() => buildRowElements(childRows, selectRow),
+		[childRows, childRowIds, selectRow],
+	);
 
 	return (
 		<div
@@ -104,7 +53,7 @@ export default function SecondarySheetPage({
 				style={rounded24Style}
 				ref={scrollableRef}
 			>
-				<div style={titleStyle}>{title}</div>
+				<div style={baseTitleStyle}>{title}</div>
 				{rowElements}
 			</div>
 		</div>

--- a/web/app/components/buildRowElements.tsx
+++ b/web/app/components/buildRowElements.tsx
@@ -1,0 +1,21 @@
+import type { Row } from "../types/row";
+import { DraggableRowContainer } from "./DraggableRowContainer";
+
+export function buildRowElements(
+	rows: Row[],
+	selectRow: (rowId: string) => void,
+) {
+	const lastIndex = rows.length - 1;
+	return rows.map((row, index) => (
+		<DraggableRowContainer
+			key={row.id}
+			rowId={row.id}
+			selectRow={() => selectRow(row.id)}
+			showIndicators
+			previousRowId={index > 0 ? rows[index - 1].id : undefined}
+			nextRowId={index < lastIndex ? rows[index + 1].id : undefined}
+		>
+			{row.row}
+		</DraggableRowContainer>
+	));
+}

--- a/web/app/components/pageStyles.ts
+++ b/web/app/components/pageStyles.ts
@@ -1,0 +1,12 @@
+import type { CSSProperties } from "react";
+
+export const rounded24Style: CSSProperties = {
+	borderRadius: "var(--radius-2-4)",
+};
+
+export const baseTitleStyle: CSSProperties = {
+	textAlign: "center",
+	fontWeight: "var(--font-semibold)",
+	fontSize: "var(--text-xl)",
+	padding: "var(--spacing-2) var(--spacing-4)",
+};

--- a/web/app/hooks/usePageDropTarget.ts
+++ b/web/app/hooks/usePageDropTarget.ts
@@ -1,0 +1,66 @@
+import { type Dispatch, type RefObject, useEffect } from "react";
+import invariant from "tiny-invariant";
+
+import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+import type { DropIndicatorAction } from "../types/actions";
+
+export function usePageDropTarget({
+	scrollableRef,
+	pageId,
+	dispatchDropIndicator,
+	extraData,
+	onClickBackground,
+}: {
+	scrollableRef: RefObject<HTMLDivElement | null>;
+	pageId: string;
+	dispatchDropIndicator: Dispatch<DropIndicatorAction>;
+	extraData?: Record<string, string>;
+	onClickBackground?: (e: MouseEvent) => void;
+}) {
+	useEffect(() => {
+		invariant(
+			scrollableRef.current,
+			"usePageDropTarget: scrollableRef.current is not defined",
+		);
+		const element = scrollableRef.current;
+
+		if (onClickBackground) {
+			element.addEventListener("click", onClickBackground);
+		}
+
+		const cleanup = combine(
+			dropTargetForElements({
+				element,
+				getData: () => ({ pageId, ...extraData }),
+				canDrop: () => true,
+				onDrop: () => {
+					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" });
+				},
+				onDragEnter: () =>
+					dispatchDropIndicator({ type: "SET_INDICATOR_PAGE", pageId }),
+				onDragLeave: () =>
+					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" }),
+			}),
+			autoScrollForElements({
+				element,
+				canScroll: () => true,
+			}),
+		);
+
+		return () => {
+			if (onClickBackground) {
+				element.removeEventListener("click", onClickBackground);
+			}
+			cleanup();
+		};
+	}, [
+		scrollableRef,
+		pageId,
+		dispatchDropIndicator,
+		extraData,
+		onClickBackground,
+	]);
+}

--- a/web/app/hooks/useSelectRow.ts
+++ b/web/app/hooks/useSelectRow.ts
@@ -1,0 +1,10 @@
+import { type Dispatch, useCallback } from "react";
+
+import type { RowAction } from "../types/actions";
+
+export function useSelectRow(pageId: string, dispatchRow: Dispatch<RowAction>) {
+	return useCallback(
+		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", pageId, rowId }),
+		[pageId, dispatchRow],
+	);
+}

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -1,4 +1,3 @@
-import type { RowConfig } from "../types/row";
 import { defineRow } from "./defineRow";
 import { RowLayout } from "./design-system/RowLayout";
 
@@ -6,13 +5,13 @@ export const containerDropindicatorId = "placeholder";
 
 export const UnknownRow = defineRow("UnknownRow", {
 	config: {
-		type: "Unknown",
+		type: "Text",
 		actions: [],
 		view: {
 			content: {
 				title: "Unknown row",
 			},
 		},
-	} satisfies RowConfig,
+	},
 	render: (row) => <RowLayout title={row.config.view.content.title} />,
 });

--- a/web/app/rows/defineRow.tsx
+++ b/web/app/rows/defineRow.tsx
@@ -30,30 +30,29 @@ export function defineRow(
 ): RowComponent {
 	const { config } = definition;
 
-	let RowComponentImpl: (props: { rowId: string }) => ReactNode;
+	let innerFn: (props: { rowId: string }) => ReactNode;
 
 	if ("Component" in definition && definition.Component) {
 		const Comp = definition.Component;
-		RowComponentImpl = function InnerWithComponent({
-			rowId,
-		}: {
-			rowId: string;
-		}) {
+		innerFn = function InnerWithComponent({ rowId }: { rowId: string }) {
 			return createElement(Comp, { rowId });
 		};
-	} else {
-		RowComponentImpl = function InnerWithRender({ rowId }: { rowId: string }) {
+	} else if ("render" in definition) {
+		const render = definition.render;
+		innerFn = function InnerWithRender({ rowId }: { rowId: string }) {
 			const row = useRowById(rowId);
 			if (!row) {
 				return <UnknownRowContent />;
 			}
-			return definition.render(row);
+			return render(row);
 		};
+	} else {
+		innerFn = () => <UnknownRowContent />;
 	}
 
-	RowComponentImpl.displayName = typeName;
+	const RowComponentImpl = innerFn as RowComponent;
 	RowComponentImpl.config = config;
 	Object.defineProperty(RowComponentImpl, "name", { value: typeName });
 
-	return RowComponentImpl as RowComponent;
+	return RowComponentImpl;
 }

--- a/web/app/state/AppProvider.tsx
+++ b/web/app/state/AppProvider.tsx
@@ -96,6 +96,7 @@ export function AppProvider({
 				activeRowId: appState.activeRowId,
 				activePageId: appState.activePageId,
 				focusMode: appState.focusMode,
+				secondarySheetRowId: appState.secondarySheetRowId,
 				dragging,
 				dropIndicator,
 				dispatchRow,

--- a/web/app/state/context.ts
+++ b/web/app/state/context.ts
@@ -17,6 +17,7 @@ export const AppContext = createContext<{
 	activeRowId?: string;
 	activePageId?: string;
 	focusMode: boolean;
+	secondarySheetRowId?: string;
 	dragging: DraggingState;
 	dropIndicator: DropIndicatorState;
 	dispatchRow: Dispatch<RowAction>;

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -9,6 +9,7 @@ import {
 	traverseToRowAndGetPath,
 	removeRowFromTree,
 	updateRowInTree,
+	getRowsRecursive,
 } from "../../utils/rowTree";
 
 export const pageReducer = (state: AppState, action: RowAction): AppState => {
@@ -242,8 +243,9 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 		case "SET_ACTIVE_ROW": {
 			const page = flow.pages.find(
 				(page) =>
-					page.rows.some((row) => row.id === action.rowId) ||
-					page.footer?.id === action.rowId,
+					page.rows.some((row) =>
+						getRowsRecursive(row).some((r) => r.id === action.rowId),
+					) || page.footer?.id === action.rowId,
 			);
 			if (!page) return state;
 
@@ -268,6 +270,7 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				activePageId: undefined,
 				activeRowId: undefined,
 				focusMode: false,
+				secondarySheetRowId: undefined,
 			};
 		}
 		case "TOGGLE_FOCUS_MODE": {
@@ -281,6 +284,7 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				...state,
 				focusMode: nextFocusMode,
 				activePageId: nextActivePageId,
+				...(!nextFocusMode ? { secondarySheetRowId: undefined } : {}),
 			};
 		}
 		case "UPDATE_PAGE_TITLE": {
@@ -288,6 +292,18 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				page.id === action.pageId ? { ...page, title: action.title } : page,
 			);
 			return updateState({ updatedPages: newPages });
+		}
+		case "OPEN_SECONDARY_SHEET": {
+			return {
+				...state,
+				secondarySheetRowId: action.sheetRowId,
+			};
+		}
+		case "CLOSE_SECONDARY_SHEET": {
+			return {
+				...state,
+				secondarySheetRowId: undefined,
+			};
 		}
 		default:
 			return state;

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -59,7 +59,9 @@ export type RowAction =
 			type: "UPDATE_PAGE_TITLE";
 			pageId: string;
 			title: string;
-	  };
+	  }
+	| { type: "OPEN_SECONDARY_SHEET"; sheetRowId: string }
+	| { type: "CLOSE_SECONDARY_SHEET" };
 
 export type DraggingSource = "rows" | "page";
 
@@ -103,4 +105,5 @@ export type AppState = {
 	activeFlowId?: string;
 	activePageId?: string;
 	focusMode: boolean;
+	secondarySheetRowId?: string;
 };

--- a/web/app/utils/actionHelpers.ts
+++ b/web/app/utils/actionHelpers.ts
@@ -45,6 +45,12 @@ export function displayLabel(variableName: string): string {
 	return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
+export function toVariableOptions(
+	variables: string[],
+): { value: string; label: string }[] {
+	return variables.map((v) => ({ value: v, label: displayLabel(v) }));
+}
+
 function collectDestinations(row: Row, result: Set<string>): void {
 	const destination = row.config.destination;
 	if (destination) {

--- a/web/app/utils/decodeFlow.ts
+++ b/web/app/utils/decodeFlow.ts
@@ -18,7 +18,9 @@ function encodeRow(row: Row): ServerRow {
 	const encodedContent: ServerRowContent = { title: content.title };
 
 	// Copy over all string/string[] properties
-	for (const key of Object.keys(content)) {
+	const contentRecord = content as unknown as Record<string, unknown>;
+	const encodedRecord = encodedContent as unknown as Record<string, unknown>;
+	for (const key of Object.keys(contentRecord)) {
 		if (key === "children") {
 			if (content.children) {
 				encodedContent.children = content.children.map((child: Row) =>
@@ -30,14 +32,14 @@ function encodeRow(row: Row): ServerRow {
 				encodedContent.child = encodeRow(content.child);
 			}
 		} else {
-			const value = content[key];
+			const value = contentRecord[key];
 			if (typeof value === "string") {
-				encodedContent[key] = value;
+				encodedRecord[key] = value;
 			} else if (
 				Array.isArray(value) &&
 				value.every((x): x is string => typeof x === "string")
 			) {
-				encodedContent[key] = value;
+				encodedRecord[key] = value;
 			}
 		}
 	}

--- a/web/app/utils/dropHandler.ts
+++ b/web/app/utils/dropHandler.ts
@@ -15,6 +15,21 @@ import type { RowAction } from "../types/actions";
 import { containerDropindicatorId } from "../rows/EVYRow";
 import { findContainerById, findContainerOfRow } from "../utils/rowTree";
 
+const SECONDARY_PREFIX = "secondary:";
+
+function parseSecondarySheetRowId(pageId: string): string | undefined {
+	return pageId.startsWith(SECONDARY_PREFIX)
+		? pageId.slice(SECONDARY_PREFIX.length)
+		: undefined;
+}
+
+function findPageContainingRow(
+	pages: SDUI_Page[],
+	rowId: string,
+): SDUI_Page | undefined {
+	return pages.find((page) => page.rows.some((r) => r.id === rowId));
+}
+
 export function handleDrop(
 	args: BaseEventPayload<ElementDragType>,
 	pages: SDUI_Page[],
@@ -26,13 +41,22 @@ export function handleDrop(
 	const rowId = source.data.rowId;
 	invariant(typeof rowId === "string", "handleDrop: rowId is not a string");
 
-	const sourcePageId =
+	const rawSourcePageId =
 		location.initial.dropTargets[location.initial.dropTargets.length - 1].data
 			.pageId;
 	invariant(
-		typeof sourcePageId === "string",
+		typeof rawSourcePageId === "string",
 		"handleDrop: sourcePageId is not a string",
 	);
+
+	let sourcePageId = rawSourcePageId;
+	const sourceSheetRowId = parseSecondarySheetRowId(rawSourcePageId);
+	if (sourceSheetRowId) {
+		const sourcePage = findPageContainingRow(pages, sourceSheetRowId);
+		if (sourcePage) {
+			sourcePageId = sourcePage.id;
+		}
+	}
 
 	// If the row was dropped on top of another row,
 	// dropTargets is an array with [row, ..., page]
@@ -49,6 +73,9 @@ export function handleDrop(
 		typeof rawDestinationPageId === "string",
 		"handleDrop: destination pageId is not a string",
 	);
+
+	const secondarySheetRowId = parseSecondarySheetRowId(rawDestinationPageId);
+	const isSecondarySheet = secondarySheetRowId !== undefined;
 	const destinationPageId = rawDestinationPageId;
 	if (
 		sourcePageId === "rows" &&
@@ -66,7 +93,16 @@ export function handleDrop(
 		return;
 	}
 
-	const destinationPage = pages.find((page) => page.id === destinationPageId);
+	let destinationPage: SDUI_Page | undefined;
+	let resolvedPageId = destinationPageId;
+	if (secondarySheetRowId) {
+		destinationPage = findPageContainingRow(pages, secondarySheetRowId);
+		if (destinationPage) {
+			resolvedPageId = destinationPage.id;
+		}
+	} else {
+		destinationPage = pages.find((page) => page.id === destinationPageId);
+	}
 	invariant(destinationPage, "handleDrop: destinationPage is not defined");
 
 	const dispatchOptions: {
@@ -77,9 +113,20 @@ export function handleDrop(
 			type: ContainerType;
 		};
 	} = {
-		destinationIndex: destinationPage.rows.length,
-		destinationPageId,
+		destinationIndex: isSecondarySheet
+			? (destinationPage.rows.find((r) => r.id === secondarySheetRowId)?.config
+					.view.content.children?.length ?? 0)
+			: destinationPage.rows.length,
+		destinationPageId: resolvedPageId,
 	};
+
+	// For secondary sheet drops with no specific row target, set the container
+	if (isSecondarySheet && secondarySheetRowId) {
+		dispatchOptions.destinationContainer = {
+			rowId: secondarySheetRowId,
+			type: "children",
+		};
+	}
 
 	// If the row was dropped on top of another row,
 	// dropTargets is an array with [row, ..., page]

--- a/web/app/utils/rowTree.ts
+++ b/web/app/utils/rowTree.ts
@@ -1,5 +1,18 @@
 import type { Row, ContainerType } from "../types/row";
 
+export function findRowInPages(
+	rowId: string,
+	pages: { rows: Row[] }[],
+): Row | undefined {
+	for (const page of pages) {
+		for (const row of page.rows) {
+			const found = getRowsRecursive(row).find((r) => r.id === rowId);
+			if (found) return found;
+		}
+	}
+	return undefined;
+}
+
 export function getRowsRecursive(row: Row): Row[] {
 	return [
 		row,

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "@playwright/test";
+import { getFirstPage, initTestFlows } from "./utils";
+
+test.describe("Secondary Sheet Page", () => {
+	const sheetContainerPage = [
+		{
+			id: "step_1",
+			title: "Page 1",
+			rows: [
+				{
+					id: "sheet-1",
+					type: "SheetContainer",
+					view: {
+						content: {
+							title: "My Sheet",
+							child: {
+								type: "Info",
+								view: {
+									content: {
+										title: "Child Info",
+										text: "Child text",
+									},
+								},
+								actions: [],
+							},
+							children: [
+								{
+									type: "Text",
+									view: {
+										content: {
+											title: "Sheet Child 1",
+											text: "Text 1",
+										},
+									},
+									actions: [],
+								},
+								{
+									type: "Text",
+									view: {
+										content: {
+											title: "Sheet Child 2",
+											text: "Text 2",
+										},
+									},
+									actions: [],
+								},
+							],
+						},
+					},
+					actions: [],
+				},
+			],
+		},
+	];
+
+	async function openSecondaryViaConfigPanel(
+		page: import("@playwright/test").Page,
+	) {
+		// Select the SheetContainer row on the page to show its config
+		await page.getByText("My Sheet", { exact: true }).click();
+
+		// The config panel should show "Children" with child buttons
+		const configPanel = page
+			.getByText("Configuration", { exact: true })
+			.locator("..");
+
+		// Click the first children item (Text row) in the config panel
+		const childButton = configPanel
+			.getByRole("button", { name: "Text" })
+			.first();
+		await expect(childButton).toBeVisible();
+		await childButton.click();
+	}
+
+	test("should open secondary page when clicking children in config panel in focus mode", async ({
+		page,
+	}) => {
+		await initTestFlows(page, sheetContainerPage);
+		await page.goto("/");
+
+		// Select the page and enter focus mode
+		const firstPage = getFirstPage(page);
+		await firstPage.click();
+		await page.getByRole("button", { name: "Focus" }).click();
+
+		// Secondary should not be visible yet
+		const secondaryPage = page.locator('[data-testid="secondary-sheet-page"]');
+		await expect(secondaryPage).toHaveCSS("opacity", "0");
+
+		await openSecondaryViaConfigPanel(page);
+
+		// The secondary sheet page should now be visible
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+	});
+
+	test("should show SheetContainer children in secondary page", async ({
+		page,
+	}) => {
+		await initTestFlows(page, sheetContainerPage);
+		await page.goto("/");
+
+		const firstPage = getFirstPage(page);
+		await firstPage.click();
+		await page.getByRole("button", { name: "Focus" }).click();
+
+		await openSecondaryViaConfigPanel(page);
+
+		const secondaryPage = page.locator('[data-testid="secondary-sheet-page"]');
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+
+		await expect(secondaryPage.getByText("Sheet Child 1")).toBeVisible();
+		await expect(secondaryPage.getByText("Sheet Child 2")).toBeVisible();
+	});
+
+	test("should show sheet title in secondary page", async ({ page }) => {
+		await initTestFlows(page, sheetContainerPage);
+		await page.goto("/");
+
+		const firstPage = getFirstPage(page);
+		await firstPage.click();
+		await page.getByRole("button", { name: "Focus" }).click();
+
+		await openSecondaryViaConfigPanel(page);
+
+		const secondaryPage = page.locator('[data-testid="secondary-sheet-page"]');
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+		await expect(secondaryPage.getByText("My Sheet")).toBeVisible();
+	});
+
+	test("should dismiss secondary page when navigating back in config panel", async ({
+		page,
+	}) => {
+		await initTestFlows(page, sheetContainerPage);
+		await page.goto("/");
+
+		const firstPage = getFirstPage(page);
+		await firstPage.click();
+		await page.getByRole("button", { name: "Focus" }).click();
+
+		await openSecondaryViaConfigPanel(page);
+
+		const secondaryPage = page.locator('[data-testid="secondary-sheet-page"]');
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+
+		// Click the back button in the config panel
+		const backButton = page.getByRole("button", { name: /Back to parent/ });
+		await backButton.click();
+
+		await expect(secondaryPage).toHaveCSS("opacity", "0");
+	});
+
+	test("should dismiss secondary page when clicking canvas background", async ({
+		page,
+	}) => {
+		await initTestFlows(page, sheetContainerPage);
+		await page.goto("/");
+
+		const firstPage = getFirstPage(page);
+		await firstPage.click();
+		await page.getByRole("button", { name: "Focus" }).click();
+
+		await openSecondaryViaConfigPanel(page);
+
+		const secondaryPage = page.locator('[data-testid="secondary-sheet-page"]');
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+
+		// Click the canvas background
+		const canvas = page.locator(".evy-flex-1.evy-flex.evy-p-4");
+		const canvasBox = await canvas.boundingBox();
+		if (canvasBox) {
+			await page.mouse.click(
+				canvasBox.x + canvasBox.width - 10,
+				canvasBox.y + 10,
+			);
+		}
+
+		await expect(secondaryPage).toHaveCSS("opacity", "0");
+	});
+
+	test("should auto-enter focus mode when clicking SheetContainer children outside focus mode", async ({
+		page,
+	}) => {
+		await initTestFlows(page, sheetContainerPage);
+		await page.goto("/");
+
+		// Select the page and row, then ensure focus mode is off
+		const firstPage = getFirstPage(page);
+		await firstPage.click();
+		const focusButton = page.getByRole("button", { name: "Focus" });
+
+		// Turn off focus mode if it's on
+		const isPressed = await focusButton.getAttribute("aria-pressed");
+		if (isPressed === "true") {
+			await focusButton.click();
+			await expect(focusButton).toHaveAttribute("aria-pressed", "false");
+		}
+
+		// Select the SheetContainer row
+		await page.getByText("My Sheet", { exact: true }).click();
+
+		// Click a children item in the config panel
+		const configPanel = page
+			.getByText("Configuration", { exact: true })
+			.locator("..");
+		const childButton = configPanel
+			.getByRole("button", { name: "Text" })
+			.first();
+		await expect(childButton).toBeVisible();
+		await childButton.click();
+
+		// Should auto-enter focus mode and show secondary page
+		await expect(focusButton).toHaveAttribute("aria-pressed", "true");
+		const secondaryPage = page.locator('[data-testid="secondary-sheet-page"]');
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+	});
+});

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -9,12 +9,12 @@ test.describe("Secondary Sheet Page", () => {
 			rows: [
 				{
 					id: "sheet-1",
-					type: "SheetContainer",
+					type: "SheetContainer" as const,
 					view: {
 						content: {
 							title: "My Sheet",
 							child: {
-								type: "Info",
+								type: "Info" as const,
 								view: {
 									content: {
 										title: "Child Info",
@@ -25,7 +25,7 @@ test.describe("Secondary Sheet Page", () => {
 							},
 							children: [
 								{
-									type: "Text",
+									type: "Text" as const,
 									view: {
 										content: {
 											title: "Sheet Child 1",
@@ -35,7 +35,7 @@ test.describe("Secondary Sheet Page", () => {
 									actions: [],
 								},
 								{
-									type: "Text",
+									type: "Text" as const,
 									view: {
 										content: {
 											title: "Sheet Child 2",

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -21,7 +21,7 @@ interface ServerRowInputContent {
 
 interface ServerRowInput {
 	id?: string;
-	type: string;
+	type: ServerRow["type"];
 	view: {
 		content: ServerRowInputContent;
 		data?: string;


### PR DESCRIPTION
## Summary

- Adds a secondary sheet page that slides in alongside the focused page when editing SheetContainer children, allowing inline visual editing of nested container content
- Refactors the configuration panel to support navigating into container children, with auto-focus-mode entry and back-navigation to dismiss the secondary sheet
- Extracts Zod error formatting into a shared `formatZodErrors` helper used by both the API validation and seed script
- Updates drag-and-drop handling to correctly resolve source/destination pages for secondary sheet contexts

## Test plan

- [x] E2E tests added in `web/tests/secondarySheet.spec.ts` covering:
  - Opening secondary page from config panel in focus mode
  - Displaying SheetContainer children and title in secondary page
  - Dismissing via back button and canvas background click
  - Auto-entering focus mode when clicking children outside focus mode

JIRA:
Figma:
Stream video:


Made with [Cursor](https://cursor.com)