### PR TITLE
[BUG] Remove temporary Docker rebuild fallback from E2E workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -40,9 +40,6 @@ jobs:
 
             - name: Start PostgreSQL
               run: |
-                  if ! command -v pg_ctlcluster &> /dev/null; then
-                    apt-get update -qq && apt-get install -y -qq --no-install-recommends postgresql > /dev/null
-                  fi
                   pg_ctlcluster 16 main start
                   su - postgres -c "psql -c \"CREATE USER evy WITH PASSWORD 'evy' CREATEDB;\""
                   su - postgres -c "createdb -O evy evy"


### PR DESCRIPTION
## Summary

- Removes the temporary `apt-get install postgresql` fallback guard from the E2E CI workflow's "Start PostgreSQL" step
- The custom CI image (`ghcr.io/evy-platform/evy-ci:playwright-1.58.2`) now includes PostgreSQL, so the runtime install is no longer needed

JIRA: 


Made with [Cursor](https://cursor.com)