### PR TITLE
[FEAT] iOS photo count sync, contextual alerts, and action UI labels

### DIFF
--- a/ios/evy/ContentView.swift
+++ b/ios/evy/ContentView.swift
@@ -75,7 +75,7 @@ struct ContentView: View {
             for key in createKeys {
                 guard let itemData = itemData else {
 					alertTitle = "Unable to load item"
-                    alertMessage = "Plese check your internet connection"
+                    alertMessage = "Please check your internet connection"
                     showingAlert = true
                     routes.removeLast()
                     break

--- a/ios/evy/ContentView.swift
+++ b/ios/evy/ContentView.swift
@@ -36,12 +36,14 @@ struct ContentView: View {
     @State private var routes: [Route] = []
     @State private var currentFlowId: String = HOME_FLOW_ID
 	@State private var showingAlert = false
+	@State private var alertTitle = ""
 	@State private var alertMessage = ""
 	@State private var loading = true
 	@State private var itemData: Data? // Temporary to avoid making navigation async
     @State private var activeDraftKeys: Set<String> = []
     
     private func showError(_ error: Error) {
+		alertTitle = "Error"
         alertMessage = error.localizedDescription
         showingAlert = true
     }
@@ -62,7 +64,8 @@ struct ContentView: View {
             }
             
             guard let newFlow = flows.first(where: { $0.id == route.flowId }) else {
-                alertMessage = "Flow not found - please check API connection"
+				alertTitle = "Unable to load flow"
+                alertMessage = "Please check your internet connection"
                 showingAlert = true
                 routes.removeLast()
                 break
@@ -71,7 +74,8 @@ struct ContentView: View {
             let createKeys = Self.extractCreateKeys(from: newFlow)
             for key in createKeys {
                 guard let itemData = itemData else {
-                    alertMessage = "Item data not loaded"
+					alertTitle = "Unable to load item"
+                    alertMessage = "Plese check your internet connection"
                     showingAlert = true
                     routes.removeLast()
                     break
@@ -90,6 +94,7 @@ struct ContentView: View {
             createFlow(currentFlowId: currentFlowId, key: key)
 
         case .highlightRequired(let fieldName):
+			alertTitle = "Missing information"
             alertMessage = "\(fieldName) is required"
             showingAlert = true
             
@@ -165,10 +170,12 @@ struct ContentView: View {
                         flows = try await EVY.getSDUI()
                         loading = false
                     } catch let error as EVYRPCError {
+						alertTitle = "Error"
                         alertMessage = error.localizedDescription
                         showingAlert = true
                         loading = false
                     } catch {
+						alertTitle = "Error"
                         alertMessage = error.localizedDescription
                         showingAlert = true
                         loading = false
@@ -188,7 +195,7 @@ struct ContentView: View {
                 }
         }
 		.alert(isPresented: $showingAlert) {
-			Alert(title: Text("Error"),
+			Alert(title: Text(alertTitle),
 				  message: Text(alertMessage),
 				  dismissButton: .default(Text("Ok")))
 		}

--- a/ios/evy/UI/Views/EVYSelectPhoto.swift
+++ b/ios/evy/UI/Views/EVYSelectPhoto.swift
@@ -77,6 +77,16 @@ struct EVYSelectPhoto: View {
 			EVYTextView(subtitle, style: .info)
                 .padding(.vertical, Constants.padding)
         }
+        .onChange(of: photos) {
+            do {
+                let encoded = try JSONEncoder().encode(photos)
+                try EVY.updateData(encoded, at: destination)
+            } catch {
+                #if DEBUG
+                print("[EVYSelectPhoto] Error updating photos: \(error)")
+                #endif
+            }
+        }
     }
 }
 

--- a/web/app/components/ActionEditor.tsx
+++ b/web/app/components/ActionEditor.tsx
@@ -189,7 +189,7 @@ function ActionSummaryCard({
 				{conditions.length > 0 && (
 					<div className="evy-mb-1">
 						<span className="evy-text-sm evy-font-medium evy-text-gray">
-							Conditions (OR):
+							Conditions:
 						</span>
 						<ul className="evy-action-summary-list">
 							{conditions.map((cond) => (

--- a/web/app/components/ActionPopup.tsx
+++ b/web/app/components/ActionPopup.tsx
@@ -93,7 +93,7 @@ export function ActionPopup({
 
 					<div className="evy-popup-body">
 						<div className="evy-popup-section">
-							<span className="evy-popup-section-title">Conditions (OR)</span>
+							<span className="evy-popup-section-title">Conditions</span>
 							<ConditionEditor
 								conditions={conditions}
 								draftVariables={draftVariables}


### PR DESCRIPTION
## Summary

- **iOS – photo count:** Persist selected gallery photo IDs to the draft via `EVY.updateData` when `photos` changes in `EVYSelectPhoto`, so subtitles like `Photos: {count(photo_ids)}/10` update after each pick (same pattern as `EVYInlinePicker` / `EVYSearchMultiple`).
- **iOS – alerts:** Use a dedicated `alertTitle` so users see contextual titles (e.g. “Unable to load flow”, “Missing information”) instead of a generic “Error” everywhere.
- **Web – builder:** Shorten action condition section labels from “Conditions (OR)” to “Conditions” in `ActionEditor` and `ActionPopup`.
- **Chore:** Fix typo in the “Unable to load item” alert message (“Please”).

## Test plan

- [ ] iOS: Create listing → add photo from gallery → confirm photo count under the picker increments.
- [ ] iOS: Trigger flow / item / validation errors and confirm alert titles match context.
- [ ] Web: Open action editor/popup and confirm condition section title reads “Conditions”.

JIRA: 

Figma: 

Stream video: 
