### PR TITLE
[BUG] Secondary sheet atomic dismiss and breadcrumb cleanup

### DIFF
--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -36,7 +36,6 @@ import {
 	panelContentFadeTransitionStyle,
 	panelShadowStyle,
 	rightPanelStyle,
-	secondaryPageWrapperHiddenStyle,
 	secondaryPageWrapperStyle,
 	sidePanelWidthTransitionStyle,
 } from "./appLayoutStyles";
@@ -270,21 +269,18 @@ function AppContent() {
 								>
 									<AppPage pageId={page.id} />
 								</CanvasPageFrame>
-								{focusMode && isActive && (
-									<CanvasPageFrame
-										wrapperStyle={
-											showSecondary
-												? secondaryPageWrapperStyle
-												: secondaryPageWrapperHiddenStyle
-										}
-										className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
-										data-testid="secondary-sheet-page"
-									>
-										{secondarySheetRow && (
+								{focusMode &&
+									isActive &&
+									showSecondary &&
+									secondarySheetRow && (
+										<CanvasPageFrame
+											wrapperStyle={secondaryPageWrapperStyle}
+											className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
+											data-testid="secondary-sheet-page"
+										>
 											<SecondarySheetPage sheetRowId={secondarySheetRow.id} />
-										)}
-									</CanvasPageFrame>
-								)}
+										</CanvasPageFrame>
+									)}
 							</Fragment>
 						);
 					})}

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -219,8 +219,6 @@ function AppContent() {
 		return findRowInPages(secondarySheetRowId, pages);
 	}, [secondarySheetRowId, focusMode, pages]);
 
-	const showSecondary = Boolean(secondarySheetRow);
-
 	useEffect(() => {
 		return monitorForElements({
 			onDragStart({ location }: BaseEventPayload<ElementDragType>) {
@@ -269,18 +267,15 @@ function AppContent() {
 								>
 									<AppPage pageId={page.id} />
 								</CanvasPageFrame>
-								{focusMode &&
-									isActive &&
-									showSecondary &&
-									secondarySheetRow && (
-										<CanvasPageFrame
-											wrapperStyle={secondaryPageWrapperStyle}
-											className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
-											data-testid="secondary-sheet-page"
-										>
-											<SecondarySheetPage sheetRowId={secondarySheetRow.id} />
-										</CanvasPageFrame>
-									)}
+								{focusMode && isActive && secondarySheetRow && (
+									<CanvasPageFrame
+										wrapperStyle={secondaryPageWrapperStyle}
+										className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
+										data-testid="secondary-sheet-page"
+									>
+										<SecondarySheetPage sheetRowId={secondarySheetRow.id} />
+									</CanvasPageFrame>
+								)}
 							</Fragment>
 						);
 					})}

--- a/web/app/appLayoutStyles.ts
+++ b/web/app/appLayoutStyles.ts
@@ -33,14 +33,11 @@ export const pageWrapperHiddenStyle: CSSProperties = {
 	pointerEvents: "none",
 };
 
-const secondaryPageFrameBase: CSSProperties = {
+export const secondaryPageWrapperStyle: CSSProperties = {
 	...pagePhoneFrameBase,
 	marginLeft: "var(--size-4)",
-};
-
-export const secondaryPageWrapperStyle: CSSProperties = {
-	...secondaryPageFrameBase,
 	opacity: 1,
+	transition: undefined,
 };
 
 export const panelShadowStyle: CSSProperties = {

--- a/web/app/appLayoutStyles.ts
+++ b/web/app/appLayoutStyles.ts
@@ -43,12 +43,6 @@ export const secondaryPageWrapperStyle: CSSProperties = {
 	opacity: 1,
 };
 
-export const secondaryPageWrapperHiddenStyle: CSSProperties = {
-	...secondaryPageFrameBase,
-	opacity: 0,
-	pointerEvents: "none",
-};
-
 export const panelShadowStyle: CSSProperties = {
 	boxShadow: "var(--shadow-subtle)",
 };

--- a/web/app/components/NavigationBreadcrumb.tsx
+++ b/web/app/components/NavigationBreadcrumb.tsx
@@ -190,20 +190,6 @@ export function NavigationBreadcrumb() {
 								onClick={() => {
 									dispatchRow({ type: "TOGGLE_FOCUS_MODE" });
 								}}
-								onDoubleClick={(e) => {
-									e.preventDefault();
-									const nextTitle = window.prompt(
-										"Page title",
-										activePage.title,
-									);
-									if (nextTitle !== null) {
-										dispatchRow({
-											type: "UPDATE_PAGE_TITLE",
-											pageId: activePage.id,
-											title: nextTitle,
-										});
-									}
-								}}
 							>
 								{breadcrumbLabelForPage(activePage, pages)}
 							</button>

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -67,11 +67,11 @@ test.describe("Secondary Sheet Page", () => {
 
 		await enterCanvasFocusModeByPageTitle(page, "Page 1");
 
-		const secondaryPage = getSecondarySheetPage(page);
-		await expect(secondaryPage).toHaveCSS("opacity", "0");
+		await expect(getSecondarySheetPage(page)).toHaveCount(0);
 
 		await openSecondarySheetChildFromConfigPanel(page);
 
+		const secondaryPage = getSecondarySheetPage(page);
 		await expect(secondaryPage).toHaveCSS("opacity", "1");
 	});
 
@@ -120,7 +120,7 @@ test.describe("Secondary Sheet Page", () => {
 
 		await page.getByRole("button", { name: "Configure row: My Sheet" }).click();
 
-		await expect(secondaryPage).toHaveCSS("opacity", "0");
+		await expect(getSecondarySheetPage(page)).toHaveCount(0);
 	});
 
 	test("should dismiss secondary page when clicking canvas background", async ({
@@ -148,7 +148,7 @@ test.describe("Secondary Sheet Page", () => {
 			});
 		}
 
-		await expect(secondaryPage).toHaveCSS("opacity", "0");
+		await expect(getSecondarySheetPage(page)).toHaveCount(0);
 	});
 
 	test("should auto-enter focus mode when clicking SheetContainer children outside focus mode", async ({


### PR DESCRIPTION
## Summary

- **Secondary sheet (web builder):** Mount the secondary phone frame only when a sheet row is open. Dismissing via the canvas background previously faded the frame while inner content unmounted immediately (content disappeared before the phone bezel). This now matches focus-mode exit: frame + content are removed together. Removed `secondaryPageWrapperHiddenStyle`, the redundant `showSecondary` flag, and the inherited opacity transition on the secondary frame.
- **Navigation breadcrumb:** Removed double-click `window.prompt` flow for editing page titles (leftover debug-style UX).
- **Tests:** Secondary sheet Playwright specs now assert the secondary frame is absent from the DOM when closed instead of `opacity: 0`.

JIRA:

Figma:

Stream:

## Test plan

- [x] `bun run build`, `bun run lint`, `bun run test` in `web/`
