### PR TITLE
[FEAT] Add page button and move CSS to component-level styles

### DIFF
--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -29,6 +29,7 @@ import { useFlows } from "./hooks/useFlows";
 import { findFlowById } from "./utils/flowHelpers";
 import { findRowInPages } from "./utils/rowTree";
 import {
+	addPageButtonStyle,
 	canvasContentStyle,
 	collapsedPanelBarStyle,
 	pageWrapperHiddenStyle,
@@ -242,6 +243,8 @@ function AppContent() {
 		dispatchRow({ type: "CLEAR_ACTIVE_SELECTION" });
 	}, [dispatchRow, secondarySheetRowId]);
 
+	const showAddPageButton = Boolean(activeFlowId) && !focusMode;
+
 	return (
 		<div className="evy-relative evy-flex-1 evy-min-h-0 evy-min-w-0 evy-overflow-hidden">
 			<div className="evy-absolute evy-inset-0 evy-flex evy-min-h-0 evy-flex-col">
@@ -281,6 +284,17 @@ function AppContent() {
 					})}
 				</CanvasViewport>
 			</div>
+			{showAddPageButton && (
+				<button
+					type="button"
+					onClick={() => dispatchRow({ type: "ADD_PAGE" })}
+					style={addPageButtonStyle}
+					className="evy-bg-white evy-border evy-border-gray-dark evy-rounded-full evy-px-4 evy-py-2 evy-text-sm evy-cursor-pointer evy-text-gray-dark evy-font-medium evy-focus-visible:outline-none"
+					aria-label="Add a page"
+				>
+					Add a page
+				</button>
+			)}
 			<CollapsibleSidePanel
 				side="left"
 				isExpanded={isRowsPanelExpanded}

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -29,7 +29,6 @@ import { useFlows } from "./hooks/useFlows";
 import { findFlowById } from "./utils/flowHelpers";
 import { findRowInPages } from "./utils/rowTree";
 import {
-	addPageButtonStyle,
 	canvasContentStyle,
 	collapsedPanelBarStyle,
 	pageWrapperHiddenStyle,
@@ -45,6 +44,24 @@ import { LUCIDE_STROKE_WIDTH } from "./icons/iconSyntax";
 const PANEL_EXPANDED_WIDTH_PX = 300;
 
 const COLLAPSED_PANEL_ICON_STYLE = { color: "var(--color-evy-gray)" };
+const PHONE_FRAME_STYLE: CSSProperties = {
+	backgroundImage: 'url("/phone.svg")',
+	backgroundRepeat: "no-repeat",
+	backgroundSize: "contain",
+};
+const LEFT_PANEL_BORDER_STYLE: CSSProperties = {
+	borderRightWidth: "1px",
+	borderRightStyle: "solid",
+};
+const ADD_PAGE_BUTTON_STYLE: CSSProperties = {
+	position: "absolute",
+	bottom: "var(--size-4)",
+	left: "50%",
+	transform: "translateX(-50%)",
+	zIndex: 15,
+	borderColor: "var(--color-evy-gray-dark)",
+	borderRadius: "9999px",
+};
 
 function useHoverToggle() {
 	const [hovered, setHovered] = useState(false);
@@ -113,7 +130,9 @@ function CollapsibleSidePanel({
 			zIndex: 20,
 			width: isExpanded ? PANEL_EXPANDED_WIDTH_PX : "var(--size-nav-bar)",
 			...(side === "left" ? { left: 0 } : { right: 0 }),
-			...(side === "left" ? panelShadowStyle : rightPanelStyle),
+			...(side === "left"
+				? { ...panelShadowStyle, ...LEFT_PANEL_BORDER_STYLE }
+				: rightPanelStyle),
 		};
 	}, [isExpanded, side]);
 
@@ -137,7 +156,7 @@ function CollapsibleSidePanel({
 
 	const outerClassName =
 		side === "left"
-			? "evy-flex evy-flex-col evy-overflow-hidden evy-bg-white evy-border-r evy-border-gray"
+			? "evy-flex evy-flex-col evy-overflow-hidden evy-bg-white evy-border-gray"
 			: "evy-flex evy-flex-col evy-overflow-hidden evy-bg-white evy-border-gray";
 
 	const innerClassName =
@@ -257,23 +276,27 @@ function AppContent() {
 					{pages.map((page) => {
 						const isActive = page.id === activePageId;
 						const isHidden = focusMode && !isActive;
-						const wrapperStyle = isHidden
-							? pageWrapperHiddenStyle
-							: pageWrapperStyle;
+						const wrapperStyle = {
+							...(isHidden ? pageWrapperHiddenStyle : pageWrapperStyle),
+							...PHONE_FRAME_STYLE,
+						};
 
 						return (
 							<Fragment key={page.id}>
 								<CanvasPageFrame
 									pageId={page.id}
 									wrapperStyle={wrapperStyle}
-									className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
+									className="evy-flex-shrink-0"
 								>
 									<AppPage pageId={page.id} />
 								</CanvasPageFrame>
 								{focusMode && isActive && secondarySheetRow && (
 									<CanvasPageFrame
-										wrapperStyle={secondaryPageWrapperStyle}
-										className="evy-flex-shrink-0 evy-bg-phone evy-bg-no-repeat evy-bg-contain"
+										wrapperStyle={{
+											...secondaryPageWrapperStyle,
+											...PHONE_FRAME_STYLE,
+										}}
+										className="evy-flex-shrink-0"
 										data-testid="secondary-sheet-page"
 									>
 										<SecondarySheetPage sheetRowId={secondarySheetRow.id} />
@@ -288,8 +311,8 @@ function AppContent() {
 				<button
 					type="button"
 					onClick={() => dispatchRow({ type: "ADD_PAGE" })}
-					style={addPageButtonStyle}
-					className="evy-bg-white evy-border evy-border-gray-dark evy-rounded-full evy-px-4 evy-py-2 evy-text-sm evy-cursor-pointer evy-text-gray-dark evy-font-medium evy-focus-visible:outline-none"
+					style={ADD_PAGE_BUTTON_STYLE}
+					className="evy-bg-white evy-border evy-px-4 evy-py-2 evy-text-sm evy-cursor-pointer evy-text-gray-dark evy-font-medium evy-focus-visible:outline-none"
 					aria-label="Add a page"
 				>
 					Add a page

--- a/web/app/appLayoutStyles.ts
+++ b/web/app/appLayoutStyles.ts
@@ -9,6 +9,14 @@ export const canvasContentStyle: CSSProperties = {
 	gap: "var(--size-4)",
 };
 
+export const addPageButtonStyle: CSSProperties = {
+	position: "absolute",
+	bottom: "var(--size-4)",
+	left: "50%",
+	transform: "translateX(-50%)",
+	zIndex: 15,
+};
+
 const pagePhoneFrameBase: CSSProperties = {
 	overflow: "hidden",
 	height: "var(--size-662)",

--- a/web/app/appLayoutStyles.ts
+++ b/web/app/appLayoutStyles.ts
@@ -9,14 +9,6 @@ export const canvasContentStyle: CSSProperties = {
 	gap: "var(--size-4)",
 };
 
-export const addPageButtonStyle: CSSProperties = {
-	position: "absolute",
-	bottom: "var(--size-4)",
-	left: "50%",
-	transform: "translateX(-50%)",
-	zIndex: 15,
-};
-
 const pagePhoneFrameBase: CSSProperties = {
 	overflow: "hidden",
 	height: "var(--size-662)",

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -220,15 +220,6 @@ body {
 .evy-bg-white {
 	background-color: var(--color-white);
 }
-.evy-bg-phone {
-	background-image: url("/phone.svg");
-}
-.evy-bg-no-repeat {
-	background-repeat: no-repeat;
-}
-.evy-bg-contain {
-	background-size: contain;
-}
 .evy-bg-transparent {
 	background-color: transparent;
 }
@@ -279,10 +270,6 @@ body {
 	border-width: 1px;
 	border-style: solid;
 }
-.evy-border-r {
-	border-right-width: 1px;
-	border-right-style: solid;
-}
 .evy-border-b {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
@@ -293,9 +280,6 @@ body {
 .evy-border-gray-light {
 	border-color: var(--color-evy-gray-light);
 }
-.evy-border-gray-dark {
-	border-color: var(--color-evy-gray-dark);
-}
 
 /* Border radius utilities */
 .evy-rounded-sm {
@@ -303,9 +287,6 @@ body {
 }
 .evy-rounded-md {
 	border-radius: var(--radius-md);
-}
-.evy-rounded-full {
-	border-radius: 9999px;
 }
 
 /* Position utilities */
@@ -410,13 +391,6 @@ label {
 	filter: brightness(0) saturate(100%) invert(23%) sepia(95%) saturate(5000%)
 		hue-rotate(355deg) brightness(88%) contrast(95%)
 		drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
-}
-
-.evy-inline-icon {
-	display: inline-block;
-	height: 1em;
-	width: 1em;
-	vertical-align: middle;
 }
 
 .evy-v-dropzone {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -293,6 +293,9 @@ body {
 .evy-border-gray-light {
 	border-color: var(--color-evy-gray-light);
 }
+.evy-border-gray-dark {
+	border-color: var(--color-evy-gray-dark);
+}
 
 /* Border radius utilities */
 .evy-rounded-sm {
@@ -300,6 +303,9 @@ body {
 }
 .evy-rounded-md {
 	border-radius: var(--radius-md);
+}
+.evy-rounded-full {
+	border-radius: 9999px;
 }
 
 /* Position utilities */

--- a/web/app/icons/parseIconText.tsx
+++ b/web/app/icons/parseIconText.tsx
@@ -1,6 +1,13 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { LUCIDE_STROKE_WIDTH, PARSE_ICON_REGEX } from "./iconSyntax";
 import resolveIcon from "./resolveIcon";
+
+const INLINE_ICON_STYLE: CSSProperties = {
+	display: "inline-block",
+	height: "1em",
+	width: "1em",
+	verticalAlign: "middle",
+};
 
 export default function parseIconText(input: string): ReactNode {
 	const parts: ReactNode[] = [];
@@ -20,7 +27,7 @@ export default function parseIconText(input: string): ReactNode {
 			parts.push(
 				<IconComponent
 					key={matchStart}
-					className="evy-inline-icon"
+					style={INLINE_ICON_STYLE}
 					aria-hidden
 					strokeWidth={LUCIDE_STROKE_WIDTH}
 				/>,

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -12,7 +12,10 @@ import {
 	getRowsRecursive,
 	findRowInPages,
 } from "../../utils/rowTree";
-import { buildNewClientFlow } from "../../utils/flowFactory";
+import {
+	buildNewClientFlow,
+	buildNewClientPage,
+} from "../../utils/flowFactory";
 import { findFlowById } from "../../utils/flowHelpers";
 
 export const pageReducer = (state: AppState, action: RowAction): AppState => {
@@ -35,6 +38,23 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			activeFlowId: newFlow.id,
 			activeRowId: undefined,
 			activePageId: newFlow.pages[0]?.id,
+			configStack: [],
+		};
+	}
+
+	if (action.type === "ADD_PAGE") {
+		const activeFlowId = state.activeFlowId;
+		if (!activeFlowId) return state;
+
+		const newPage = buildNewClientPage();
+
+		return {
+			...state,
+			flows: state.flows.map((f) =>
+				f.id === activeFlowId ? { ...f, pages: [...f.pages, newPage] } : f,
+			),
+			activePageId: newPage.id,
+			activeRowId: undefined,
 			configStack: [],
 		};
 	}

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -44,6 +44,7 @@ export type RowAction =
 			type: "CREATE_FLOW";
 			name: string;
 	  }
+	| { type: "ADD_PAGE" }
 	| {
 			type: "SET_ACTIVE_ROW";
 			pageId: string;

--- a/web/app/utils/flowFactory.ts
+++ b/web/app/utils/flowFactory.ts
@@ -1,24 +1,31 @@
-import type { SDUI_Flow as ServerFlow } from "evy-types";
+import type {
+	SDUI_Flow as ServerFlow,
+	SDUI_Page as ServerPage,
+} from "evy-types";
 
 import type { SDUI_Flow } from "../types/flow";
 import { decodeFlows } from "./decodeFlow";
+
+/**
+ * Builds a minimal valid blank page for the builder UI and API validation.
+ */
+export function buildNewClientPage(): ServerPage {
+	return {
+		id: crypto.randomUUID(),
+		title: "",
+		rows: [],
+	};
+}
 
 /**
  * Builds a minimal valid flow (one empty page) for the builder UI and API validation.
  */
 export function buildNewClientFlow(name: string): SDUI_Flow {
 	const flowId = crypto.randomUUID();
-	const pageId = crypto.randomUUID();
 	const serverFlow: ServerFlow = {
 		id: flowId,
 		name,
-		pages: [
-			{
-				id: pageId,
-				title: "",
-				rows: [],
-			},
-		],
+		pages: [buildNewClientPage()],
 	};
 	return decodeFlows([serverFlow])[0];
 }

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -39,7 +39,7 @@ interface ServerPageInput {
 }
 
 export const SELECTORS = {
-	phoneContainer: 'div[class*="evy-bg-phone"]',
+	phoneContainer: "[data-canvas-page-frame]",
 	pageContent: '[class*="evy-overflow-scroll"]',
 	rowContainer:
 		'div[class*="evy-flex"][class*="evy-flex-col"][class*="evy-w-full"]',

--- a/web/tests/websocket.spec.ts
+++ b/web/tests/websocket.spec.ts
@@ -94,7 +94,7 @@ test.describe("WebSocket Connection States", () => {
 		await expect(getConfigPanel(page)).toBeVisible();
 
 		// Center: Phone mockup(s)
-		const phoneContainer = page.locator('div[class*="evy-bg-phone"]');
+		const phoneContainer = page.locator("[data-canvas-page-frame]");
 		await expect(phoneContainer.first()).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

- **Add Page button**: Adds an "Add a page" button to the canvas viewport that appears when a flow is active and focus mode is off. Dispatches a new `ADD_PAGE` action that creates a blank page via a new `buildNewClientPage()` factory function and appends it to the active flow.
- **CSS audit & cleanup**: Moves phone-frame background styles, left-panel border, and inline-icon styles from global CSS classes to component-level `CSSProperties` objects (`PHONE_FRAME_STYLE`, `LEFT_PANEL_BORDER_STYLE`, `INLINE_ICON_STYLE`). Removes unused global CSS classes (`evy-bg-phone`, `evy-bg-no-repeat`, `evy-bg-contain`, `evy-border-r`, `evy-inline-icon`).
- **Test selector update**: Replaces `div[class*="evy-bg-phone"]` selectors in tests with `[data-canvas-page-frame]` for more stable querying.

## JIRA: 

## Figma: 

## Stream video: 


Made with [Cursor](https://cursor.com)