### PR TITLE
[FEAT] Delete pages on web with reference guard

### DIFF
--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -1,12 +1,17 @@
-import { useCallback, useMemo } from "react";
-import { ChevronRight } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { ChevronRight, Trash2 } from "lucide-react";
 
 import { LUCIDE_STROKE_WIDTH } from "../icons/iconSyntax";
 import { useFlowsContext } from "../state";
 import type { Row } from "../types/row";
 import { useRowById } from "../hooks/useRowById";
 import { findFlowById } from "../utils/flowHelpers";
+import {
+	findPageReferences,
+	type PageReferenceEntry,
+} from "../utils/actionHelpers";
 import { ActionEditor } from "./ActionEditor";
+import { PageInUseDialog } from "./PageInUseDialog";
 
 function isRow(value: unknown): value is Row {
 	return value !== null && typeof value === "object" && "config" in value;
@@ -52,12 +57,35 @@ export function ConfigurationPanel() {
 	const currentConfigRowId = configStack.at(-1) ?? row?.id;
 	const currentConfigRow = useRowById(currentConfigRowId);
 
-	const activePage = useMemo(() => {
-		const flow = findFlowById(flows, activeFlowId);
-		return flow?.pages.find((p) => p.id === activePageId);
-	}, [flows, activeFlowId, activePageId]);
+	const activeFlow = useMemo(
+		() => findFlowById(flows, activeFlowId),
+		[flows, activeFlowId],
+	);
+
+	const activePage = useMemo(
+		() => activeFlow?.pages.find((p) => p.id === activePageId),
+		[activeFlow, activePageId],
+	);
 
 	const showPageTitleInPanel = Boolean(activePage) && configStack.length === 0;
+
+	const [pageInUseReferences, setPageInUseReferences] = useState<
+		PageReferenceEntry[]
+	>([]);
+
+	const canDeleteCurrentPage = Boolean(
+		activeFlow && activePage && activeFlow.pages.length > 1,
+	);
+
+	const handleDeletePageClick = useCallback(() => {
+		if (!activeFlow || !activePage || !canDeleteCurrentPage) return;
+		const references = findPageReferences(activeFlow, activePage.id);
+		if (references.length > 0) {
+			setPageInUseReferences(references);
+			return;
+		}
+		dispatchRow({ type: "REMOVE_PAGE", pageId: activePage.id });
+	}, [activeFlow, activePage, canDeleteCurrentPage, dispatchRow]);
 
 	const openChildConfiguration = useCallback(
 		(childRowId: string, parentRow: Row) => {
@@ -171,18 +199,42 @@ export function ConfigurationPanel() {
 
 	return (
 		<div className="evy-flex evy-flex-col evy-h-full">
+			<PageInUseDialog
+				references={pageInUseReferences}
+				onClose={() => setPageInUseReferences([])}
+			/>
 			<div className="evy-p-4 evy-text-xl evy-font-semibold evy-text-center evy-border-b evy-border-gray evy-bg-white">
 				Configuration
 			</div>
 			<div className="evy-flex evy-flex-col evy-min-h-full evy-p-4 evy-gap-4 evy-overflow-scroll">
 				{showPageTitleInPanel && activePage && (
 					<div className="evy-mb-2">
-						<label
-							htmlFor="config-panel-page-title"
-							className="evy-text-sm evy-font-medium evy-text-black"
-						>
-							Page title
-						</label>
+						<div className="evy-flex evy-items-center evy-justify-between evy-gap-2">
+							<label
+								htmlFor="config-panel-page-title"
+								className="evy-text-sm evy-font-medium evy-text-black"
+							>
+								Page title
+							</label>
+							<button
+								type="button"
+								className="evy-bin-button evy-bg-transparent evy-border-none evy-cursor-pointer evy-shrink-0"
+								onClick={handleDeletePageClick}
+								disabled={!canDeleteCurrentPage}
+								aria-label="Remove page from flow"
+								title={
+									canDeleteCurrentPage
+										? "Remove page from flow"
+										: "Cannot remove the only page in this flow"
+								}
+							>
+								<Trash2
+									className="evy-h-4 evy-w-4"
+									strokeWidth={LUCIDE_STROKE_WIDTH}
+									aria-hidden
+								/>
+							</button>
+						</div>
 						<input
 							id="config-panel-page-title"
 							type="text"

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -87,6 +87,10 @@ export function ConfigurationPanel() {
 		dispatchRow({ type: "REMOVE_PAGE", pageId: activePage.id });
 	}, [activeFlow, activePage, canDeleteCurrentPage, dispatchRow]);
 
+	const dismissPageInUseDialog = useCallback(() => {
+		setPageInUseReferences([]);
+	}, []);
+
 	const openChildConfiguration = useCallback(
 		(childRowId: string, parentRow: Row) => {
 			dispatchRow({
@@ -201,7 +205,7 @@ export function ConfigurationPanel() {
 		<div className="evy-flex evy-flex-col evy-h-full">
 			<PageInUseDialog
 				references={pageInUseReferences}
-				onClose={() => setPageInUseReferences([])}
+				onClose={dismissPageInUseDialog}
 			/>
 			<div className="evy-p-4 evy-text-xl evy-font-semibold evy-text-center evy-border-b evy-border-gray evy-bg-white">
 				Configuration

--- a/web/app/components/PageInUseDialog.tsx
+++ b/web/app/components/PageInUseDialog.tsx
@@ -4,7 +4,7 @@ import { TriangleAlert } from "lucide-react";
 
 import { LUCIDE_STROKE_WIDTH } from "../icons/iconSyntax";
 import { useEscapeKey } from "../hooks/useEscapeKey";
-import type { PageReferenceEntry } from "../utils/pageReferences";
+import type { PageReferenceEntry } from "../utils/actionHelpers";
 import { modalSharedCss } from "./modalSharedCss";
 import { pageInUseDialogCss } from "./pageInUseDialogCss";
 
@@ -62,7 +62,7 @@ export function PageInUseDialog({ references, onClose }: PageInUseDialogProps) {
 						</ul>
 					</div>
 
-					<div className="evy-page-in-use-footer">
+					<div className="evy-modal-footer evy-modal-footer--center">
 						<button
 							type="button"
 							className="evy-modal-btn evy-modal-btn--md evy-modal-btn-primary"

--- a/web/app/components/PageInUseDialog.tsx
+++ b/web/app/components/PageInUseDialog.tsx
@@ -1,0 +1,80 @@
+import { useId } from "react";
+import { createPortal } from "react-dom";
+import { TriangleAlert } from "lucide-react";
+
+import { LUCIDE_STROKE_WIDTH } from "../icons/iconSyntax";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+import type { PageReferenceEntry } from "../utils/pageReferences";
+import { modalSharedCss } from "./modalSharedCss";
+import { pageInUseDialogCss } from "./pageInUseDialogCss";
+
+type PageInUseDialogProps = {
+	references: PageReferenceEntry[];
+	onClose: () => void;
+};
+
+export function PageInUseDialog({ references, onClose }: PageInUseDialogProps) {
+	const titleId = useId();
+
+	useEscapeKey(onClose, references.length > 0);
+
+	if (references.length === 0) return null;
+
+	return createPortal(
+		<>
+			<style>{`${modalSharedCss}\n${pageInUseDialogCss}`}</style>
+			<div className="evy-modal-root">
+				<button
+					type="button"
+					className="evy-modal-backdrop"
+					aria-label="Close dialog"
+					onClick={onClose}
+					data-testid="page-in-use-overlay"
+				/>
+				<div
+					className="evy-modal-panel evy-modal-panel--page-in-use"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby={titleId}
+					data-testid="page-in-use-dialog"
+				>
+					<div className="evy-page-in-use-header evy-flex evy-items-center evy-gap-2">
+						<TriangleAlert
+							className="evy-h-4 evy-w-4 evy-shrink-0"
+							strokeWidth={LUCIDE_STROKE_WIDTH}
+							aria-hidden
+						/>
+						<span className="evy-text-lg evy-font-semibold" id={titleId}>
+							Page in use
+						</span>
+					</div>
+
+					<div className="evy-page-in-use-body">
+						<p className="evy-page-in-use-description">
+							This page is being referenced in the following pages and rows:
+						</p>
+						<ul className="evy-page-in-use-list">
+							{references.map((ref) => (
+								<li key={ref.referenceKey}>
+									{ref.pageLabel}: {ref.rowLabel}
+								</li>
+							))}
+						</ul>
+					</div>
+
+					<div className="evy-page-in-use-footer">
+						<button
+							type="button"
+							className="evy-modal-btn evy-modal-btn--md evy-modal-btn-primary"
+							onClick={onClose}
+							data-testid="page-in-use-dismiss"
+						>
+							Ok, let me remove those references first
+						</button>
+					</div>
+				</div>
+			</div>
+		</>,
+		document.body,
+	);
+}

--- a/web/app/components/modalSharedCss.ts
+++ b/web/app/components/modalSharedCss.ts
@@ -1,6 +1,6 @@
 /**
  * Shared modal styles for overlay + backdrop + panel shell + footer buttons.
- * Used by {@link ActionPopup} and {@link CreateFlowDialog}.
+ * Used by {@link ActionPopup}, {@link CreateFlowDialog}, and {@link PageInUseDialog}.
  */
 export const modalSharedCss = `
 .evy-modal-root {
@@ -48,6 +48,9 @@ export const modalSharedCss = `
 	display: flex;
 	justify-content: flex-end;
 	gap: var(--size-2);
+}
+.evy-modal-footer--center {
+	justify-content: center;
 }
 .evy-modal-btn {
 	font-family: inherit;

--- a/web/app/components/pageInUseDialogCss.ts
+++ b/web/app/components/pageInUseDialogCss.ts
@@ -1,4 +1,4 @@
-/** Page-in-use warning dialog; shell + footer use {@link modalSharedCss}. */
+/** Page-in-use warning dialog body + header; panel shell + footer use {@link modalSharedCss}. */
 export const pageInUseDialogCss = `
 .evy-modal-panel--page-in-use {
 	width: min(480px, calc(100vw - var(--size-8)));
@@ -29,11 +29,5 @@ export const pageInUseDialogCss = `
 .evy-page-in-use-list li {
 	font-size: var(--text-sm);
 	line-height: 1.6;
-}
-.evy-page-in-use-footer {
-	padding: var(--size-4);
-	border-top: 1px solid var(--color-gray-border);
-	display: flex;
-	justify-content: center;
 }
 `;

--- a/web/app/components/pageInUseDialogCss.ts
+++ b/web/app/components/pageInUseDialogCss.ts
@@ -1,0 +1,39 @@
+/** Page-in-use warning dialog; shell + footer use {@link modalSharedCss}. */
+export const pageInUseDialogCss = `
+.evy-modal-panel--page-in-use {
+	width: min(480px, calc(100vw - var(--size-8)));
+	max-height: 80vh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+.evy-page-in-use-header {
+	padding: var(--size-4);
+	border-bottom: 1px solid var(--color-gray-border);
+}
+.evy-page-in-use-body {
+	padding: var(--size-4) var(--size-8);
+	overflow: auto;
+	flex: 1;
+	min-height: 0;
+}
+.evy-page-in-use-description {
+	font-size: var(--text-sm);
+	margin: 0 0 var(--size-3) 0;
+}
+.evy-page-in-use-list {
+	margin: 0;
+	padding-left: var(--size-4);
+	list-style: disc;
+}
+.evy-page-in-use-list li {
+	font-size: var(--text-sm);
+	line-height: 1.6;
+}
+.evy-page-in-use-footer {
+	padding: var(--size-4);
+	border-top: 1px solid var(--color-gray-border);
+	display: flex;
+	justify-content: center;
+}
+`;

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -343,6 +343,7 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			);
 			return updateState({ updatedPages: newPages });
 		}
+		// UI only deletes the active page; reducer still handles arbitrary pageId for tests/future use.
 		case "REMOVE_PAGE": {
 			if (flow.pages.length <= 1) return state;
 			const updatedPages = flow.pages.filter((p) => p.id !== action.pageId);

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -343,6 +343,20 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			);
 			return updateState({ updatedPages: newPages });
 		}
+		case "REMOVE_PAGE": {
+			if (flow.pages.length <= 1) return state;
+			const updatedPages = flow.pages.filter((p) => p.id !== action.pageId);
+			if (updatedPages.length === flow.pages.length) return state;
+
+			const wasActivePage = state.activePageId === action.pageId;
+
+			return updateState({
+				updatedPages,
+				activePageId: wasActivePage ? updatedPages[0]?.id : state.activePageId,
+				activeRowId: wasActivePage ? undefined : state.activeRowId,
+				configStack: wasActivePage ? [] : state.configStack,
+			});
+		}
 		case "OPEN_SECONDARY_SHEET": {
 			return {
 				...state,

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -45,6 +45,7 @@ export type RowAction =
 			name: string;
 	  }
 	| { type: "ADD_PAGE" }
+	| { type: "REMOVE_PAGE"; pageId: string }
 	| {
 			type: "SET_ACTIVE_ROW";
 			pageId: string;

--- a/web/app/utils/actionHelpers.ts
+++ b/web/app/utils/actionHelpers.ts
@@ -41,3 +41,7 @@ export {
 	getFlowOptions,
 	getPageOptions,
 } from "./actionFlowOptions";
+export {
+	findPageReferences,
+	type PageReferenceEntry,
+} from "./pageReferences";

--- a/web/app/utils/pageReferences.ts
+++ b/web/app/utils/pageReferences.ts
@@ -1,0 +1,83 @@
+import type { SDUI_Flow, SDUI_Page } from "../types/flow";
+import type { Row } from "../types/row";
+import { parseBranch } from "./actionBranch";
+import { breadcrumbLabelForPage, breadcrumbLabelForRow } from "./navLabels";
+import { getRowsRecursive } from "./rowTree";
+
+export type PageReferenceEntry = {
+	/** Stable key for list rendering (`${pageId}:${rowId}`). */
+	referenceKey: string;
+	pageLabel: string;
+	rowLabel: string;
+};
+
+function branchReferencesPage(
+	branchString: string,
+	flowId: string,
+	targetPageId: string,
+): boolean {
+	const parsed = parseBranch(branchString);
+	if (!parsed || parsed.functionName !== "navigate") return false;
+	if (parsed.args.length < 2) return false;
+	const [navFlowId, navPageId] = parsed.args;
+	return navFlowId === flowId && navPageId === targetPageId;
+}
+
+function rowReferencesTargetPage(
+	row: Row,
+	flowId: string,
+	targetPageId: string,
+): boolean {
+	const actions = row.config.actions;
+	if (!actions) return false;
+	return actions.some(
+		(action) =>
+			branchReferencesPage(action.true, flowId, targetPageId) ||
+			branchReferencesPage(action.false, flowId, targetPageId),
+	);
+}
+
+function collectReferencesForPage(
+	page: SDUI_Page,
+	flow: SDUI_Flow,
+	targetPageId: string,
+	seenRowIds: Set<string>,
+	results: PageReferenceEntry[],
+): void {
+	const pageLabel = breadcrumbLabelForPage(page, flow.pages);
+
+	const visitRow = (row: Row) => {
+		if (!rowReferencesTargetPage(row, flow.id, targetPageId)) return;
+		if (seenRowIds.has(row.id)) return;
+		seenRowIds.add(row.id);
+		results.push({
+			referenceKey: `${page.id}:${row.id}`,
+			pageLabel,
+			rowLabel: breadcrumbLabelForRow(row),
+		});
+	};
+
+	for (const topRow of page.rows) {
+		for (const row of getRowsRecursive(topRow)) {
+			visitRow(row);
+		}
+	}
+	if (page.footer) {
+		for (const row of getRowsRecursive(page.footer)) {
+			visitRow(row);
+		}
+	}
+}
+
+/** Finds rows in `flow` whose actions navigate to `targetPageId` within the same flow. */
+export function findPageReferences(
+	flow: SDUI_Flow,
+	targetPageId: string,
+): PageReferenceEntry[] {
+	const results: PageReferenceEntry[] = [];
+	const seenRowIds = new Set<string>();
+	for (const page of flow.pages) {
+		collectReferencesForPage(page, flow, targetPageId, seenRowIds, results);
+	}
+	return results;
+}

--- a/web/app/utils/pageReferences.ts
+++ b/web/app/utils/pageReferences.ts
@@ -41,31 +41,21 @@ function collectReferencesForPage(
 	page: SDUI_Page,
 	flow: SDUI_Flow,
 	targetPageId: string,
-	seenRowIds: Set<string>,
 	results: PageReferenceEntry[],
 ): void {
 	const pageLabel = breadcrumbLabelForPage(page, flow.pages);
+	const rowsOnPage: Row[] = [
+		...page.rows.flatMap((topRow) => getRowsRecursive(topRow)),
+		...(page.footer ? getRowsRecursive(page.footer) : []),
+	];
 
-	const visitRow = (row: Row) => {
-		if (!rowReferencesTargetPage(row, flow.id, targetPageId)) return;
-		if (seenRowIds.has(row.id)) return;
-		seenRowIds.add(row.id);
+	for (const row of rowsOnPage) {
+		if (!rowReferencesTargetPage(row, flow.id, targetPageId)) continue;
 		results.push({
 			referenceKey: `${page.id}:${row.id}`,
 			pageLabel,
 			rowLabel: breadcrumbLabelForRow(row),
 		});
-	};
-
-	for (const topRow of page.rows) {
-		for (const row of getRowsRecursive(topRow)) {
-			visitRow(row);
-		}
-	}
-	if (page.footer) {
-		for (const row of getRowsRecursive(page.footer)) {
-			visitRow(row);
-		}
 	}
 }
 
@@ -75,9 +65,8 @@ export function findPageReferences(
 	targetPageId: string,
 ): PageReferenceEntry[] {
 	const results: PageReferenceEntry[] = [];
-	const seenRowIds = new Set<string>();
 	for (const page of flow.pages) {
-		collectReferencesForPage(page, flow, targetPageId, seenRowIds, results);
+		collectReferencesForPage(page, flow, targetPageId, results);
 	}
 	return results;
 }


### PR DESCRIPTION
## Summary

Adds the ability to remove the current page from a flow in the web builder configuration panel, with safeguards when the page is still referenced elsewhere.

- **Remove page control**: Trash button next to "Page title" in the configuration panel. Disabled when the flow has only one page.
- **`REMOVE_PAGE` action**: New row action in `pageReducer` removes the page from the flow, switches to another page when the deleted page was active, and clears config stack when appropriate.
- **References check**: `findPageReferences` scans the flow for rows whose action branches use `navigate` to the target page (same flow). If any exist, a **Page in use** modal lists the referencing page and row labels instead of deleting.
- **UI**: `PageInUseDialog` (portal, escape/backdrop close, shared modal styles) explains the block and offers a dismiss button.

## JIRA

## Figma

## Stream video



Made with [Cursor](https://cursor.com)