### PR TITLE
[BUG] Fix nested row drag-and-drop crash across pages

### DIFF
--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -123,16 +123,22 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 
 			// Reuse the same tree insertion logic as MOVE_ROW so dragging a brand-new
 			// row from the sidebar and moving an existing nested row behave the same.
+			const insertionResult = insertRowIntoTree(
+				page.rows,
+				rowDataAdd,
+				action.destinationIndex,
+				action.destinationContainer,
+			);
+			invariant(
+				insertionResult.inserted,
+				"PageReducer addRow: destination container not found in tree",
+			);
+
 			const updatedPages = flow.pages.map((p) =>
 				p.id === action.destinationPageId
 					? {
 							...p,
-							rows: insertRowIntoTree(
-								page.rows,
-								rowDataAdd,
-								action.destinationIndex,
-								action.destinationContainer,
-							),
+							rows: insertionResult.rows,
 						}
 					: p,
 			);
@@ -157,34 +163,24 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				action.rowId,
 			);
 
-			// When moving within the same page, removing the dragged row can also
-			// remove the destination container if the user is dropping into one of
-			// that row's descendants. Bail out instead of trying to reinsert into a
-			// container that no longer exists in the updated tree.
-			if (
-				action.destinationContainer &&
-				action.originPageId === action.destinationPageId
-			) {
-				const destinationContainer = findRowInPages(
-					action.destinationContainer.rowId,
-					[{ rows: originRowsWithoutRow }],
-				);
-				if (!destinationContainer) return state;
-			}
-
 			const newPages = flow.pages.map((page) => {
 				if (
 					page.id === action.originPageId &&
 					page.id === action.destinationPageId
 				) {
+					const insertionResult = insertRowIntoTree(
+						originRowsWithoutRow,
+						row,
+						action.destinationIndex,
+						action.destinationContainer,
+					);
+					// Removing the dragged row can drop the destination container from the
+					// tree (e.g. invalid same-page drop into a descendant). No-op is expected.
+					if (!insertionResult.inserted) return page;
+
 					return {
 						...page,
-						rows: insertRowIntoTree(
-							originRowsWithoutRow,
-							row,
-							action.destinationIndex,
-							action.destinationContainer,
-						),
+						rows: insertionResult.rows,
 					};
 				}
 				if (page.id === action.originPageId) {
@@ -194,14 +190,20 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 					};
 				}
 				if (page.id === action.destinationPageId) {
+					const insertionResult = insertRowIntoTree(
+						page.rows,
+						row,
+						action.destinationIndex,
+						action.destinationContainer,
+					);
+					invariant(
+						insertionResult.inserted,
+						"PageReducer moveRow: destination container not found in tree",
+					);
+
 					return {
 						...page,
-						rows: insertRowIntoTree(
-							page.rows,
-							row,
-							action.destinationIndex,
-							action.destinationContainer,
-						),
+						rows: insertionResult.rows,
 					};
 				}
 				return page;

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -6,11 +6,11 @@ import type { SDUI_Page } from "../../types/flow";
 import type { Row } from "../../types/row";
 import { baseRows } from "../../rows/baseRows";
 import {
-	traverseToRowAndGetPath,
 	removeRowFromTree,
 	updateRowInTree,
 	getRowsRecursive,
 	findRowInPages,
+	insertRowIntoTree,
 } from "../../utils/rowTree";
 import {
 	buildNewClientFlow,
@@ -121,60 +121,20 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			const page = flow.pages.find((p) => p.id === action.destinationPageId);
 			if (!page) return state;
 
-			if (action.destinationContainer) {
-				const destinationRowId = action.destinationContainer.rowId;
-				const stepsToDestinationContainer = page.rows
-					.flatMap((row, index) => {
-						if (row.id === destinationRowId) {
-							return [[index]];
-						}
-						const match = traverseToRowAndGetPath(row, destinationRowId);
-						if (match.length > 0) return [[index, ...match]];
-						return [];
-					})
-					.find((s) => s !== undefined);
-
-				invariant(
-					stepsToDestinationContainer?.length,
-					"PageReducer addRow: stepsToDestinationContainer is not defined",
-				);
-
-				const firstStep = stepsToDestinationContainer[0];
-				invariant(typeof firstStep === "number", "expected number index");
-				let path = page.rows[firstStep];
-				if (stepsToDestinationContainer.length > 1) {
-					path = stepsToDestinationContainer
-						.slice(1)
-						.reduce((acc: Row, curr: number | "child"): Row => {
-							if (curr === "child") {
-								const child = acc.config.view.content.child;
-								invariant(child, "PageReducer addRow: child is not defined");
-								return child;
-							}
-							const child = acc.config.view.content.children?.[curr];
-							invariant(
-								child,
-								"PageReducer addRow: children element is not defined",
-							);
-							return child;
-						}, path);
-				}
-
-				if (action.destinationContainer.type === "child") {
-					path.config.view.content.child = rowDataAdd;
-				} else if (action.destinationContainer.type === "children") {
-					path.config.view.content.children?.splice(
-						action.destinationIndex,
-						0,
-						rowDataAdd,
-					);
-				}
-			} else {
-				page.rows.splice(action.destinationIndex, 0, rowDataAdd);
-			}
-
+			// Reuse the same tree insertion logic as MOVE_ROW so dragging a brand-new
+			// row from the sidebar and moving an existing nested row behave the same.
 			const updatedPages = flow.pages.map((p) =>
-				p.id === action.destinationPageId ? { ...p, rows: [...p.rows] } : p,
+				p.id === action.destinationPageId
+					? {
+							...p,
+							rows: insertRowIntoTree(
+								page.rows,
+								rowDataAdd,
+								action.destinationIndex,
+								action.destinationContainer,
+							),
+						}
+					: p,
 			);
 
 			return updateState({
@@ -184,35 +144,65 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			});
 		}
 		case "MOVE_ROW": {
-			const row = flow.pages
-				.find((page) => page.id === action.originPageId)
-				?.rows.find((r) => r.id === action.rowId);
+			const originPage = flow.pages.find(
+				(page) => page.id === action.originPageId,
+			);
+			if (!originPage) return state;
+
+			const row = findRowInPages(action.rowId, [originPage]);
 			invariant(row, "PageReducer moveRow: row is not defined");
+
+			const originRowsWithoutRow = removeRowFromTree(
+				originPage.rows,
+				action.rowId,
+			);
+
+			// When moving within the same page, removing the dragged row can also
+			// remove the destination container if the user is dropping into one of
+			// that row's descendants. Bail out instead of trying to reinsert into a
+			// container that no longer exists in the updated tree.
+			if (
+				action.destinationContainer &&
+				action.originPageId === action.destinationPageId
+			) {
+				const destinationContainer = findRowInPages(
+					action.destinationContainer.rowId,
+					[{ rows: originRowsWithoutRow }],
+				);
+				if (!destinationContainer) return state;
+			}
 
 			const newPages = flow.pages.map((page) => {
 				if (
 					page.id === action.originPageId &&
 					page.id === action.destinationPageId
 				) {
-					const destinationItems = [
-						...page.rows.filter((r) => r.id !== action.rowId),
-					];
-					destinationItems.splice(action.destinationIndex, 0, row);
 					return {
 						...page,
-						rows: destinationItems,
+						rows: insertRowIntoTree(
+							originRowsWithoutRow,
+							row,
+							action.destinationIndex,
+							action.destinationContainer,
+						),
 					};
 				}
 				if (page.id === action.originPageId) {
 					return {
 						...page,
-						rows: page.rows.filter((r) => r.id !== action.rowId),
+						rows: originRowsWithoutRow,
 					};
 				}
 				if (page.id === action.destinationPageId) {
-					const destinationItems = [...page.rows];
-					destinationItems.splice(action.destinationIndex, 0, row);
-					return { ...page, rows: destinationItems };
+					return {
+						...page,
+						rows: insertRowIntoTree(
+							page.rows,
+							row,
+							action.destinationIndex,
+							action.destinationContainer,
+						),
+					};
 				}
 				return page;
 			});

--- a/web/app/utils/rowTree.ts
+++ b/web/app/utils/rowTree.ts
@@ -184,6 +184,8 @@ export function traverseToRowAndGetPath(
 }
 
 function removeRowInSubtree(row: Row, targetRowId: string): Row {
+	let nextRow = row;
+
 	if (row.config.view.content.children) {
 		const filteredChildren = row.config.view.content.children.filter(
 			(child) => child.id !== targetRowId,
@@ -191,36 +193,114 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 		const updatedChildren = filteredChildren.map((child) =>
 			removeRowInSubtree(child, targetRowId),
 		);
-		return {
-			...row,
-			config: {
-				...row.config,
-				view: {
-					...row.config.view,
-					content: {
-						...row.config.view.content,
-						children: updatedChildren,
+		const childUpdated =
+			filteredChildren.length !== row.config.view.content.children.length ||
+			updatedChildren.some((child, index) => child !== filteredChildren[index]);
+		if (childUpdated) {
+			nextRow = {
+				...row,
+				config: {
+					...row.config,
+					view: {
+						...row.config.view,
+						content: {
+							...row.config.view.content,
+							children: updatedChildren,
+						},
 					},
 				},
-			},
-		};
+			};
+		}
 	}
-	if (row.config.view.content.child?.id === targetRowId) {
+
+	// Some container rows expose both `children` and a single `child`.
+	// We must keep traversing after the `children` pass so moves/removals from
+	// sheet-like containers do not leave the nested `child` behind.
+	if (nextRow.config.view.content.child?.id === targetRowId) {
 		return {
-			...row,
+			...nextRow,
 			config: {
-				...row.config,
+				...nextRow.config,
 				view: {
-					...row.config.view,
+					...nextRow.config.view,
 					content: {
-						...row.config.view.content,
+						...nextRow.config.view.content,
 						child: undefined,
 					},
 				},
 			},
 		};
 	}
-	if (row.config.view.content.child) {
+
+	if (nextRow.config.view.content.child) {
+		const updatedChild = removeRowInSubtree(
+			nextRow.config.view.content.child,
+			targetRowId,
+		);
+		if (updatedChild !== nextRow.config.view.content.child) {
+			return {
+				...nextRow,
+				config: {
+					...nextRow.config,
+					view: {
+						...nextRow.config.view,
+						content: {
+							...nextRow.config.view.content,
+							child: updatedChild,
+						},
+					},
+				},
+			};
+		}
+	}
+
+	return nextRow;
+}
+
+export function removeRowFromTree(rows: Row[], targetRowId: string): Row[] {
+	return rows
+		.filter((r) => r.id !== targetRowId)
+		.map((r) => removeRowInSubtree(r, targetRowId));
+}
+
+function insertRowAtIndex(
+	rows: Row[],
+	row: Row,
+	destinationIndex: number,
+): Row[] {
+	const normalizedIndex = Math.max(0, Math.min(destinationIndex, rows.length));
+	const updatedRows = [...rows];
+	updatedRows.splice(normalizedIndex, 0, row);
+	return updatedRows;
+}
+
+function insertRowIntoSubtree(
+	row: Row,
+	targetRowId: string,
+	rowToInsert: Row,
+	destinationIndex: number,
+	destinationType: ContainerType,
+): Row | null {
+	if (row.id === targetRowId) {
+		// Drag/drop destinations can point at either a single-slot `child`
+		// container or an ordered `children` collection, so insertion needs to
+		// preserve both shapes instead of assuming top-level page rows only.
+		if (destinationType === "child") {
+			return {
+				...row,
+				config: {
+					...row.config,
+					view: {
+						...row.config.view,
+						content: {
+							...row.config.view.content,
+							child: rowToInsert,
+						},
+					},
+				},
+			};
+		}
+
 		return {
 			...row,
 			config: {
@@ -229,22 +309,108 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 					...row.config.view,
 					content: {
 						...row.config.view.content,
-						child: removeRowInSubtree(
-							row.config.view.content.child,
-							targetRowId,
+						children: insertRowAtIndex(
+							row.config.view.content.children ?? [],
+							rowToInsert,
+							destinationIndex,
 						),
 					},
 				},
 			},
 		};
 	}
-	return row;
+
+	if (row.config.view.content.children) {
+		const updatedChildren = row.config.view.content.children.map(
+			(child) =>
+				insertRowIntoSubtree(
+					child,
+					targetRowId,
+					rowToInsert,
+					destinationIndex,
+					destinationType,
+				) ?? child,
+		);
+		const childUpdated = updatedChildren.some(
+			(child, index) => child !== row.config.view.content.children?.[index],
+		);
+		if (childUpdated) {
+			return {
+				...row,
+				config: {
+					...row.config,
+					view: {
+						...row.config.view,
+						content: {
+							...row.config.view.content,
+							children: updatedChildren,
+						},
+					},
+				},
+			};
+		}
+	}
+
+	if (row.config.view.content.child) {
+		const updatedChild = insertRowIntoSubtree(
+			row.config.view.content.child,
+			targetRowId,
+			rowToInsert,
+			destinationIndex,
+			destinationType,
+		);
+		if (updatedChild) {
+			return {
+				...row,
+				config: {
+					...row.config,
+					view: {
+						...row.config.view,
+						content: {
+							...row.config.view.content,
+							child: updatedChild,
+						},
+					},
+				},
+			};
+		}
+	}
+
+	return null;
 }
 
-export function removeRowFromTree(rows: Row[], targetRowId: string): Row[] {
-	return rows
-		.filter((r) => r.id !== targetRowId)
-		.map((r) => removeRowInSubtree(r, targetRowId));
+export function insertRowIntoTree(
+	rows: Row[],
+	rowToInsert: Row,
+	destinationIndex: number,
+	destinationContainer?: { rowId: string; type: ContainerType },
+): Row[] {
+	// Shared by ADD_ROW and MOVE_ROW so both code paths support nested drop
+	// targets. The previous crash happened because MOVE_ROW only knew how to
+	// reinsert into top-level page rows.
+	if (!destinationContainer) {
+		return insertRowAtIndex(rows, rowToInsert, destinationIndex);
+	}
+
+	let inserted = false;
+	const updatedRows = rows.map((row) => {
+		const updatedRow = insertRowIntoSubtree(
+			row,
+			destinationContainer.rowId,
+			rowToInsert,
+			destinationIndex,
+			destinationContainer.type,
+		);
+		if (!updatedRow) return row;
+		inserted = true;
+		return updatedRow;
+	});
+
+	invariant(
+		inserted,
+		"insertRowIntoTree: destination container is not defined",
+	);
+	return updatedRows;
 }
 
 function updateRowInSubtree(

--- a/web/app/utils/rowTree.ts
+++ b/web/app/utils/rowTree.ts
@@ -6,7 +6,7 @@ import type { Row, ContainerType } from "../types/row";
 const SECONDARY_PAGE_ID_PREFIX = "secondary:";
 
 /** If `pageId` is a secondary-sheet pseudo id, returns the host row id; otherwise `undefined`. */
-export function parseSecondarySheetRowId(pageId: string): string | undefined {
+function parseSecondarySheetRowId(pageId: string): string | undefined {
 	return pageId.startsWith(SECONDARY_PAGE_ID_PREFIX)
 		? pageId.slice(SECONDARY_PAGE_ID_PREFIX.length)
 		: undefined;
@@ -26,7 +26,7 @@ export function resolveSourcePageIdFromRaw(
 	return sourcePage?.id ?? rawSourcePageId;
 }
 
-export type ResolvedDropDestinationPage = {
+type ResolvedDropDestinationPage = {
 	page: SDUI_Page;
 	resolvedPageId: string;
 	secondarySheetRowId: string | undefined;
@@ -65,7 +65,7 @@ export function resolveDestinationPageFromRawPageId(
 }
 
 /** Page whose top-level `rows` contains the given row id (not recursive). */
-export function findPageContainingRow(
+function findPageContainingRow(
 	pages: SDUI_Page[],
 	rowId: string,
 ): SDUI_Page | undefined {
@@ -78,10 +78,27 @@ export function findRowInPages(
 ): Row | undefined {
 	for (const page of pages) {
 		for (const row of page.rows) {
-			const found = getRowsRecursive(row).find((r) => r.id === rowId);
+			const found = findRowInSubtree(row, rowId);
 			if (found) return found;
 		}
 	}
+	return undefined;
+}
+
+function findRowInSubtree(row: Row, rowId: string): Row | undefined {
+	if (row.id === rowId) return row;
+
+	const child = row.config.view.content.child;
+	if (child) {
+		const foundChild = findRowInSubtree(child, rowId);
+		if (foundChild) return foundChild;
+	}
+
+	for (const childRow of row.config.view.content.children ?? []) {
+		const foundChild = findRowInSubtree(childRow, rowId);
+		if (foundChild) return foundChild;
+	}
+
 	return undefined;
 }
 
@@ -159,28 +176,21 @@ export function findContainerById(
 	return null;
 }
 
-export function traverseToRowAndGetPath(
+/** Immutable shallow merge of `row.config.view.content` (child/children updates). */
+function withContentUpdate(
 	row: Row,
-	targetRowId: string,
-): Array<number | "child"> {
-	if (row.id === targetRowId) return [];
-
-	const child = row.config.view.content.child;
-	if (child?.id === targetRowId) {
-		const path = traverseToRowAndGetPath(child, targetRowId);
-		if (path.length > 0) return ["child", ...path];
-	}
-
-	const children = row.config.view.content.children;
-	if (children) {
-		for (const [index, c] of children.entries()) {
-			if (c.id === targetRowId) return [index];
-
-			const path = traverseToRowAndGetPath(c, targetRowId);
-			if (path.length > 0) return [index, ...path];
-		}
-	}
-	return [];
+	contentPatch: Partial<Row["config"]["view"]["content"]>,
+): Row {
+	return {
+		...row,
+		config: {
+			...row.config,
+			view: {
+				...row.config.view,
+				content: { ...row.config.view.content, ...contentPatch },
+			},
+		},
+	};
 }
 
 function removeRowInSubtree(row: Row, targetRowId: string): Row {
@@ -197,19 +207,7 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 			filteredChildren.length !== row.config.view.content.children.length ||
 			updatedChildren.some((child, index) => child !== filteredChildren[index]);
 		if (childUpdated) {
-			nextRow = {
-				...row,
-				config: {
-					...row.config,
-					view: {
-						...row.config.view,
-						content: {
-							...row.config.view.content,
-							children: updatedChildren,
-						},
-					},
-				},
-			};
+			nextRow = withContentUpdate(row, { children: updatedChildren });
 		}
 	}
 
@@ -217,19 +215,7 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 	// We must keep traversing after the `children` pass so moves/removals from
 	// sheet-like containers do not leave the nested `child` behind.
 	if (nextRow.config.view.content.child?.id === targetRowId) {
-		return {
-			...nextRow,
-			config: {
-				...nextRow.config,
-				view: {
-					...nextRow.config.view,
-					content: {
-						...nextRow.config.view.content,
-						child: undefined,
-					},
-				},
-			},
-		};
+		return withContentUpdate(nextRow, { child: undefined });
 	}
 
 	if (nextRow.config.view.content.child) {
@@ -238,19 +224,7 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 			targetRowId,
 		);
 		if (updatedChild !== nextRow.config.view.content.child) {
-			return {
-				...nextRow,
-				config: {
-					...nextRow.config,
-					view: {
-						...nextRow.config.view,
-						content: {
-							...nextRow.config.view.content,
-							child: updatedChild,
-						},
-					},
-				},
-			};
+			return withContentUpdate(nextRow, { child: updatedChild });
 		}
 	}
 
@@ -274,109 +248,85 @@ function insertRowAtIndex(
 	return updatedRows;
 }
 
+type InsertRowResult = {
+	row: Row;
+	inserted: boolean;
+};
+
+type InsertRowsResult = {
+	rows: Row[];
+	inserted: boolean;
+};
+
 function insertRowIntoSubtree(
 	row: Row,
 	targetRowId: string,
 	rowToInsert: Row,
 	destinationIndex: number,
 	destinationType: ContainerType,
-): Row | null {
+): InsertRowResult {
 	if (row.id === targetRowId) {
 		// Drag/drop destinations can point at either a single-slot `child`
 		// container or an ordered `children` collection, so insertion needs to
 		// preserve both shapes instead of assuming top-level page rows only.
 		if (destinationType === "child") {
 			return {
-				...row,
-				config: {
-					...row.config,
-					view: {
-						...row.config.view,
-						content: {
-							...row.config.view.content,
-							child: rowToInsert,
-						},
-					},
-				},
+				row: withContentUpdate(row, { child: rowToInsert }),
+				inserted: true,
 			};
 		}
 
 		return {
-			...row,
-			config: {
-				...row.config,
-				view: {
-					...row.config.view,
-					content: {
-						...row.config.view.content,
-						children: insertRowAtIndex(
-							row.config.view.content.children ?? [],
-							rowToInsert,
-							destinationIndex,
-						),
-					},
-				},
-			},
+			row: withContentUpdate(row, {
+				children: insertRowAtIndex(
+					row.config.view.content.children ?? [],
+					rowToInsert,
+					destinationIndex,
+				),
+			}),
+			inserted: true,
 		};
 	}
 
-	if (row.config.view.content.children) {
-		const updatedChildren = row.config.view.content.children.map(
-			(child) =>
-				insertRowIntoSubtree(
-					child,
-					targetRowId,
-					rowToInsert,
-					destinationIndex,
-					destinationType,
-				) ?? child,
-		);
-		const childUpdated = updatedChildren.some(
-			(child, index) => child !== row.config.view.content.children?.[index],
-		);
-		if (childUpdated) {
-			return {
-				...row,
-				config: {
-					...row.config,
-					view: {
-						...row.config.view,
-						content: {
-							...row.config.view.content,
-							children: updatedChildren,
-						},
-					},
-				},
-			};
-		}
-	}
-
-	if (row.config.view.content.child) {
-		const updatedChild = insertRowIntoSubtree(
-			row.config.view.content.child,
+	const child = row.config.view.content.child;
+	if (child) {
+		const childResult = insertRowIntoSubtree(
+			child,
 			targetRowId,
 			rowToInsert,
 			destinationIndex,
 			destinationType,
 		);
-		if (updatedChild) {
+		if (childResult.inserted) {
 			return {
-				...row,
-				config: {
-					...row.config,
-					view: {
-						...row.config.view,
-						content: {
-							...row.config.view.content,
-							child: updatedChild,
-						},
-					},
-				},
+				row: withContentUpdate(row, { child: childResult.row }),
+				inserted: true,
 			};
 		}
 	}
 
-	return null;
+	const children = row.config.view.content.children;
+	if (children) {
+		for (const [index, childRow] of children.entries()) {
+			const childResult = insertRowIntoSubtree(
+				childRow,
+				targetRowId,
+				rowToInsert,
+				destinationIndex,
+				destinationType,
+			);
+			if (!childResult.inserted) continue;
+
+			const updatedChildren = [...children];
+			updatedChildren[index] = childResult.row;
+			return {
+				row: withContentUpdate(row, { children: updatedChildren }),
+				inserted: true,
+			};
+		}
+	}
+
+	return { row, inserted: false };
 }
 
 export function insertRowIntoTree(
@@ -384,33 +334,31 @@ export function insertRowIntoTree(
 	rowToInsert: Row,
 	destinationIndex: number,
 	destinationContainer?: { rowId: string; type: ContainerType },
-): Row[] {
-	// Shared by ADD_ROW and MOVE_ROW so both code paths support nested drop
-	// targets. The previous crash happened because MOVE_ROW only knew how to
-	// reinsert into top-level page rows.
+): InsertRowsResult {
+	// Shared by ADD_ROW and MOVE_ROW so both code paths support nested drop targets.
 	if (!destinationContainer) {
-		return insertRowAtIndex(rows, rowToInsert, destinationIndex);
+		return {
+			rows: insertRowAtIndex(rows, rowToInsert, destinationIndex),
+			inserted: true,
+		};
 	}
 
-	let inserted = false;
-	const updatedRows = rows.map((row) => {
-		const updatedRow = insertRowIntoSubtree(
+	for (const [index, row] of rows.entries()) {
+		const result = insertRowIntoSubtree(
 			row,
 			destinationContainer.rowId,
 			rowToInsert,
 			destinationIndex,
 			destinationContainer.type,
 		);
-		if (!updatedRow) return row;
-		inserted = true;
-		return updatedRow;
-	});
+		if (!result.inserted) continue;
 
-	invariant(
-		inserted,
-		"insertRowIntoTree: destination container is not defined",
-	);
-	return updatedRows;
+		const updatedRows = [...rows];
+		updatedRows[index] = result.row;
+		return { rows: updatedRows, inserted: true };
+	}
+
+	return { rows, inserted: false };
 }
 
 function updateRowInSubtree(
@@ -429,19 +377,7 @@ function updateRowInSubtree(
 			(child, index) => child !== row.config.view.content.children?.[index],
 		);
 		if (childUpdated) {
-			return {
-				...row,
-				config: {
-					...row.config,
-					view: {
-						...row.config.view,
-						content: {
-							...row.config.view.content,
-							children: updatedChildren,
-						},
-					},
-				},
-			};
+			return withContentUpdate(row, { children: updatedChildren });
 		}
 	}
 	if (row.config.view.content.child) {
@@ -451,19 +387,7 @@ function updateRowInSubtree(
 			updater,
 		);
 		if (updatedChild) {
-			return {
-				...row,
-				config: {
-					...row.config,
-					view: {
-						...row.config.view,
-						content: {
-							...row.config.view.content,
-							child: updatedChild,
-						},
-					},
-				},
-			};
+			return withContentUpdate(row, { child: updatedChild });
 		}
 	}
 	return null;

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -7,6 +7,7 @@ import {
 	getPageRow,
 	getRowsPanel,
 	getSidebarRow,
+	initTestFlows,
 	setupTwoEmptyTestPages,
 } from "./utils";
 
@@ -69,6 +70,109 @@ test.describe("Drag & Drop UX", () => {
 			.locator(SELECTORS.rowContainer)
 			.count();
 		expect(newSecondPageRowCount).toBe(initialSecondPageRowCount + 1);
+	});
+
+	test("should drag a row from a child container to another page", async ({
+		page,
+	}) => {
+		await initTestFlows(page, [
+			{
+				id: "step_1",
+				title: "Page 1",
+				rows: [
+					{
+						id: "sheet-1",
+						type: "SheetContainer" as const,
+						view: {
+							content: {
+								title: "Sheet container row title",
+								child: {
+									id: "sheet-child-1",
+									type: "Info" as const,
+									view: {
+										content: {
+											title: "Child Info",
+											text: "Child text",
+										},
+									},
+									actions: [],
+								},
+								children: [],
+							},
+						},
+						actions: [],
+					},
+				],
+			},
+			{ id: "step_2", title: "Page 2", rows: [] },
+		]);
+		await page.goto("/");
+
+		const firstPage = getFirstPage(page);
+		const secondPage = page.locator(SELECTORS.phoneContainer).nth(1);
+		const secondPageContent = getPageContent(page, 1);
+		const childRow = getPageRow(page, "Child Info");
+
+		await childRow.dragTo(secondPageContent);
+
+		await expect(
+			secondPage.getByText("Child Info", { exact: true }),
+		).toBeVisible();
+		await expect(
+			firstPage.getByText("Child Info", { exact: true }),
+		).not.toBeVisible();
+	});
+
+	test("should drag a row from a children container to another page", async ({
+		page,
+	}) => {
+		await initTestFlows(page, [
+			{
+				id: "step_1",
+				title: "Page 1",
+				rows: [
+					{
+						id: "list-1",
+						type: "ListContainer" as const,
+						view: {
+							content: {
+								title: "List container row title",
+								children: [
+									{
+										id: "list-child-1",
+										type: "Info" as const,
+										view: {
+											content: {
+												title: "Nested Info",
+												text: "Nested text",
+											},
+										},
+										actions: [],
+									},
+								],
+							},
+						},
+						actions: [],
+					},
+				],
+			},
+			{ id: "step_2", title: "Page 2", rows: [] },
+		]);
+		await page.goto("/");
+
+		const firstPage = getFirstPage(page);
+		const secondPage = page.locator(SELECTORS.phoneContainer).nth(1);
+		const secondPageContent = getPageContent(page, 1);
+		const childRow = getPageRow(page, "Nested Info");
+
+		await childRow.dragTo(secondPageContent);
+
+		await expect(
+			secondPage.getByText("Nested Info", { exact: true }),
+		).toBeVisible();
+		await expect(
+			firstPage.getByText("Nested Info", { exact: true }),
+		).not.toBeVisible();
 	});
 
 	test("should remove a row from a page by dragging it to the left sidebar", async ({


### PR DESCRIPTION
## Summary

Fixes a frontend crash (`PageReducer moveRow: row is not defined`) when dragging a row from a nested `child` or `children` container onto another page. `MOVE_ROW` previously only looked up top-level page rows and ignored nested drop targets.

## Changes

- **`pageReducer`**: `MOVE_ROW` and `ADD_ROW` share `insertRowIntoTree` for nested destinations; recursive row lookup and removal; clearer invariants when the destination container is missing from the tree; same-page moves no-op when removal invalidates the drop target.
- **`rowTree`**: Recursive `removeRowFromTree` / insertion helpers that handle containers with both `children` and `child`; `findRowInPages` uses DFS without flattening; `withContentUpdate` to DRY immutable `view.content` updates; short-circuit insertion; trim unused exports where appropriate.
- **Tests**: Playwright coverage for dragging from a `child` slot and from a `children` list to another page (`dragAndDrop.spec.ts`).

## Testing

- `bun run lint` and `bun run build` in `web/`
- `bun --env-file=../.env run playwright test tests/dragAndDrop.spec.ts`

JIRA: 

Figma: 

Stream video: 


Made with [Cursor](https://cursor.com)