### PR TITLE
[FEAT] Document and implement SDData interpreter functions

### DIFF
--- a/api/src/evyFunctions.ts
+++ b/api/src/evyFunctions.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure formatting helpers aligned with SDData docs and the iOS client.
+ * Use when server-side evaluation of EVY template functions is needed.
+ */
+
+/** Split top-level comma-separated arguments, respecting nested parentheses and double-quoted segments. */
+export function splitFunctionArguments(args: string): string[] {
+	const components: string[] = [];
+	let current = "";
+	let depth = 0;
+	let inString = false;
+
+	for (const ch of args) {
+		if (inString) {
+			current += ch;
+			if (ch === '"') {
+				inString = false;
+			}
+			continue;
+		}
+		switch (ch) {
+			case '"':
+				inString = true;
+				current += ch;
+				break;
+			case "(":
+				depth += 1;
+				current += ch;
+				break;
+			case ")":
+				depth -= 1;
+				current += ch;
+				break;
+			case ",":
+				if (depth === 0) {
+					const t = current.trim();
+					if (t.length > 0) {
+						components.push(t);
+					}
+					current = "";
+				} else {
+					current += ch;
+				}
+				break;
+			default:
+				current += ch;
+		}
+	}
+	const tail = current.trim();
+	if (tail.length > 0) {
+		components.push(tail);
+	}
+	return components;
+}
+
+export function stripOptionalSurroundingQuotes(s: string): string {
+	const trimmed = s.trim();
+	if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function pad2(n: number): string {
+	return n < 10 ? `0${n}` : String(n);
+}
+
+export function normalizeDateFormatPattern(pattern: string): string {
+	return pattern.replaceAll("YYYY", "yyyy").replaceAll("DD", "dd");
+}
+
+/** Format an ISO 8601 / RFC 3339 instant using a Java-style pattern (MM/dd/yyyy, etc.). Parsed in UTC. */
+export function formatDateIso(iso: string, pattern: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) {
+		throw new Error(`evyFunctions.formatDateIso: invalid ISO date '${iso}'`);
+	}
+	const p = normalizeDateFormatPattern(pattern);
+	return p.replace(/yyyy|yy|MM|dd|HH|mm|ss/g, (token) => {
+		switch (token) {
+			case "yyyy":
+				return String(d.getUTCFullYear());
+			case "yy":
+				return String(d.getUTCFullYear()).slice(-2);
+			case "MM":
+				return pad2(d.getUTCMonth() + 1);
+			case "dd":
+				return pad2(d.getUTCDate());
+			case "HH":
+				return pad2(d.getUTCHours());
+			case "mm":
+				return pad2(d.getUTCMinutes());
+			case "ss":
+				return pad2(d.getUTCSeconds());
+			default:
+				return token;
+		}
+	});
+}
+
+export function formatDecimal(value: number, fractionDigits: number): string {
+	const places = Math.max(0, Math.min(20, Math.floor(fractionDigits)));
+	return new Intl.NumberFormat("en-US", {
+		minimumFractionDigits: places,
+		maximumFractionDigits: places,
+		useGrouping: false,
+		roundingMode: "halfExpand",
+	}).format(value);
+}
+
+/** Millimetres to metres with two fraction digits and an `m` suffix (e.g. 23240 → "23.24m"). */
+export function formatMetricLengthMm(mm: number): string {
+	const metres = mm / 1000;
+	return `${formatDecimal(metres, 2)}m`;
+}
+
+/** Millimetres to feet with two fraction digits and an `ft` suffix (international foot = 0.3048 m). */
+export function formatImperialLengthMm(mm: number): string {
+	const feet = mm / 304.8;
+	return `${formatDecimal(feet, 2)}ft`;
+}
+
+export function formatDurationMs(ms: number): string {
+	const n = Math.max(0, Math.floor(ms));
+	const units: [number, string, string][] = [
+		[86_400_000, "day", "days"],
+		[3_600_000, "hour", "hours"],
+		[60_000, "minute", "minutes"],
+		[1000, "second", "seconds"],
+	];
+	for (const [unitMs, singular, plural] of units) {
+		if (n >= unitMs) {
+			const count = Math.floor(n / unitMs);
+			return `${count} ${count === 1 ? singular : plural}`;
+		}
+	}
+	return `${n} milliseconds`;
+}

--- a/api/src/tests/evyFunctions.test.ts
+++ b/api/src/tests/evyFunctions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+	formatDateIso,
+	formatDecimal,
+	formatDurationMs,
+	formatImperialLengthMm,
+	formatMetricLengthMm,
+	splitFunctionArguments,
+	stripOptionalSurroundingQuotes,
+} from "../evyFunctions";
+
+describe("splitFunctionArguments", () => {
+	test("splits simple comma args", () => {
+		expect(splitFunctionArguments("item.price, 2")).toEqual([
+			"item.price",
+			"2",
+		]);
+	});
+
+	test("keeps quoted commas inside a segment", () => {
+		expect(splitFunctionArguments(`item.date, "MM/dd/yyyy"`)).toEqual([
+			"item.date",
+			`"MM/dd/yyyy"`,
+		]);
+	});
+});
+
+describe("stripOptionalSurroundingQuotes", () => {
+	test("strips double quotes", () => {
+		expect(stripOptionalSurroundingQuotes(`"MM/dd/yyyy"`)).toBe("MM/dd/yyyy");
+	});
+});
+
+describe("formatDecimal", () => {
+	test("rounds half away from zero to fraction digits", () => {
+		expect(formatDecimal(20.0423, 2)).toBe("20.04");
+	});
+});
+
+describe("length formatters", () => {
+	test("metric length matches docs example", () => {
+		expect(formatMetricLengthMm(23240)).toBe("23.24m");
+	});
+
+	test("imperial length matches docs example", () => {
+		expect(formatImperialLengthMm(4231)).toBe("13.88ft");
+	});
+});
+
+describe("formatDurationMs", () => {
+	test("humanizes doc example", () => {
+		expect(formatDurationMs(900_000)).toBe("15 minutes");
+	});
+});
+
+describe("formatDateIso", () => {
+	test("formats UTC calendar date from ISO string", () => {
+		expect(formatDateIso("2024-01-19T12:42:52.000Z", "MM/dd/yyyy")).toBe(
+			"01/19/2024",
+		);
+	});
+
+	test("accepts YYYY/DD style patterns from docs", () => {
+		expect(formatDateIso("2024-01-19T12:42:52.000Z", "MM/DD/YYYY")).toBe(
+			"01/19/2024",
+		);
+	});
+});

--- a/docs/evy/sddata/functions.md
+++ b/docs/evy/sddata/functions.md
@@ -4,6 +4,7 @@ Functions are used to convert an input into a different output. For example form
 
 -   Some default functions are available server-side and client-side (eg `formatDecimal`) and some are composed using those built in functions, and sent via JSON config to the clients.
 -   We need to avoid defining custom coded formatting functions in mobile clients as much as possible due to the constraints of mobile release cycles
+-   **`length`**, **`formatDimension`**, **`formatWeight`**, and the **Builder functions** (`buildCurrency`, `buildAddress`) below describe behavior **as implemented in the iOS client today** ([`ios/evy/Utils/EVYFunctions.swift`](../../../ios/evy/Utils/EVYFunctions.swift)). Earlier sections in this file are the broader target model; web may still use stubs for some functions.
 
 ## Methods
 
@@ -15,6 +16,16 @@ These are methods available to the user to compute data
 count({_variable_type_list_})
 Variable: [image1, image2]
 Output: 2
+```
+
+#### length
+
+Returns the number of **characters** in a string argument. Non-strings fall through to the raw argument text (no numeric “length”).
+
+```
+length({_variable_type_string_})
+Variable: "Hello"
+Output: 5
 ```
 
 ## Formatting functions
@@ -72,6 +83,32 @@ Outputs: 01/19/2024
 ```
 
 Input is an **ISO 8601 / RFC 3339** string (same wire type as `createdAt` / `updatedAt`), not a Unix timestamp number.
+
+#### formatDimension
+
+```
+formatDimension(_variable_type_number_) // millimetres (int or string that parses as Int)
+Variable (display): 23240
+Output: 23m
+
+Variable (editing): 23240
+Output: 23240
+```
+
+Display: `mm` if ≤100, `cm` if 101–1000, `m` if >1000; `m`/`cm` use **integer division** of mm (e.g. 23240 → `23m`). Editing: plain millimetres, no suffix.
+
+#### formatWeight
+
+```
+formatWeight(_variable_type_number_) // milligrams
+Variable (display): 1500000
+Output: 1.5kg
+
+Variable (editing): 1500000
+Output: 1500000
+```
+
+Display: `kg` if **>** 1_000_000 mg, `g` if >1000 mg, else `mg` (e.g. 1_000_000 mg → `1000g`). Input: string, int, or decimal. Editing: trimmed numeric text, no suffix.
 
 ### Dynamic formatting functions
 
@@ -151,4 +188,32 @@ Outputs: 23-25 Rosebery Avenue, 2018 Rosebery NSW
         }
     }
 }
+```
+
+## Builder functions
+
+**Implemented in iOS.** These are **not** used inside `{…}` display strings the same way as formatters. They appear as the **destination** when persisting typed field text into structured data: the client parses the destination prop (e.g. `{buildCurrency(item.price)}`), passes the **first argument** as the prop path to the value being updated, and supplies the **user’s typed string** as the second input when committing the field (see [`ios/evy/EVY.swift`](../../../ios/evy/EVY.swift) `updateValue`).
+
+#### buildCurrency
+
+Builds a **price** JSON object `{ "currency", "value" }` from the current field text.
+
+-   **`currency`:** taken from the existing value at the destination path when present; otherwise defaults to `"AUD"`.
+-   **`value`:** parsed from the typed string (empty → empty string; otherwise int, decimal, or string as appropriate).
+
+```
+Destination pattern: {buildCurrency(item.price)}
+Typed text: "13.50"
+Resulting data: { "currency": "AUD", "value": "13.50" }  // shape; actual storage is JSON-encoded
+```
+
+#### buildAddress
+
+Builds or updates an **address** object from multi-line or comma-separated typed text, merging with any existing address at the destination path (missing keys default to empty strings). Parsing supports two-line addresses, single-line comma forms, and simple street-only updates; see `evyAddressFields` / `evyParsedAddressFields` in [`ios/evy/Utils/EVYFunctions.swift`](../../../ios/evy/Utils/EVYFunctions.swift).
+
+```
+Destination pattern: {buildAddress(user.address)}
+Typed text (example):
+  "23-25 Rosebery Avenue, 2018\nRosebery, NSW"
+Result: address dictionary with unit, street, city, postcode, state populated per parser rules
 ```

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -127,14 +127,21 @@ struct EVY {
     /// Root data key to observe for `.evyDataUpdated` when `text` contains `{count(foo)}`, `{formatCurrency(item.price)}`, etc.
     /// Matches first `{…}` segment; unwraps function calls to their argument path so notifications for `foo` refresh the view.
     static func watchTarget(for text: String) -> String {
-        let parsedProps = EVY.parsePropsFromText(text)
-        if parsedProps == text {
-            return text
+        let unwrapped = EVY.parsePropsFromText(text)
+        let candidates: [String] = unwrapped == text ? [text] : [unwrapped, text]
+        for candidate in candidates {
+            if let functionCall = EVYInterpreter.parseFunctionCall(candidate) {
+                let parts = EVYInterpreter.splitFunctionArguments(functionCall.functionArgs)
+                if let first = parts.first, !first.isEmpty {
+                    return EVYInterpreter.stripOptionalSurroundingQuotes(first)
+                }
+                return functionCall.functionArgs
+            }
         }
-        if let functionCall = EVYInterpreter.parseFunctionCall(parsedProps) {
-            return functionCall.functionArgs
+        if unwrapped != text {
+            return unwrapped
         }
-        return parsedProps
+        return text
     }
 
     static func evaluateFromText(_ input: String) throws -> Bool {

--- a/ios/evy/Utils/EVYFunctions.swift
+++ b/ios/evy/Utils/EVYFunctions.swift
@@ -206,6 +206,129 @@ func evyFormatAddress(_ args: String) throws -> EVYFunctionOutput {
 }
 
 @MainActor
+func evyFormatDecimal(_ args: String,
+                      _ editing: Bool = false) throws -> EVYFunctionOutput {
+    let parts = EVYInterpreter.splitFunctionArguments(args)
+    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+        throw EVYError.formatFailed(type: "decimal", reason: "missing value argument")
+    }
+    let places: Int
+    if parts.count >= 2 {
+        let rawPlaces = EVYInterpreter.stripOptionalSurroundingQuotes(parts[1])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        places = Int(rawPlaces) ?? 2
+    } else {
+        places = 2
+    }
+
+    let res = try EVY.getDataFromProps(path)
+    let number = try evyDoubleValue(from: res, type: "decimal")
+
+    if editing {
+        return EVYFunctionOutput(value: evyPlainNumberString(number), prefix: nil, suffix: nil)
+    }
+
+    let formatter = NumberFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.minimumFractionDigits = max(0, places)
+    formatter.maximumFractionDigits = max(0, places)
+    formatter.roundingMode = .halfUp
+    formatter.numberStyle = .decimal
+    guard let formatted = formatter.string(from: NSNumber(value: number)) else {
+        throw EVYError.formatFailed(type: "decimal", reason: "could not format number")
+    }
+    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: nil)
+}
+
+@MainActor
+func evyFormatMetricLength(_ args: String,
+                           _ editing: Bool = false) throws -> EVYFunctionOutput {
+    let parts = EVYInterpreter.splitFunctionArguments(args)
+    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+        throw EVYError.formatFailed(type: "metricLength", reason: "missing value argument")
+    }
+    let res = try EVY.getDataFromProps(path)
+    let mm = try evyMillimetres(from: res)
+
+    if editing {
+        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+    }
+
+    let metres = Double(mm) / 1000.0
+    let formatted = String(format: "%.2f", metres)
+    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: "m")
+}
+
+@MainActor
+func evyFormatImperialLength(_ args: String,
+                             _ editing: Bool = false) throws -> EVYFunctionOutput {
+    let parts = EVYInterpreter.splitFunctionArguments(args)
+    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+        throw EVYError.formatFailed(type: "imperialLength", reason: "missing value argument")
+    }
+    let res = try EVY.getDataFromProps(path)
+    let mm = try evyMillimetres(from: res)
+
+    if editing {
+        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+    }
+
+    let feet = Double(mm) / 304.8
+    let formatted = String(format: "%.2f", feet)
+    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: "ft")
+}
+
+@MainActor
+func evyFormatDuration(_ args: String,
+                       _ editing: Bool = false) throws -> EVYFunctionOutput {
+    let parts = EVYInterpreter.splitFunctionArguments(args)
+    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+        throw EVYError.formatFailed(type: "duration", reason: "missing value argument")
+    }
+    let res = try EVY.getDataFromProps(path)
+    let ms = try evyMilliseconds(from: res)
+
+    if editing {
+        return EVYFunctionOutput(value: "\(ms)", prefix: nil, suffix: nil)
+    }
+
+    let label = evyHumanizeDuration(milliseconds: ms)
+    return EVYFunctionOutput(value: label, prefix: nil, suffix: nil)
+}
+
+@MainActor
+func evyFormatDate(_ args: String,
+                   _ editing: Bool = false) throws -> EVYFunctionOutput {
+    let parts = EVYInterpreter.splitFunctionArguments(args)
+    guard parts.count >= 2 else {
+        throw EVYError.formatFailed(type: "date", reason: "expected value and format pattern")
+    }
+    let path = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+    let pattern = evyNormalizeDateFormatPattern(
+        EVYInterpreter.stripOptionalSurroundingQuotes(parts[1])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+    guard !path.isEmpty, !pattern.isEmpty else {
+        throw EVYError.formatFailed(type: "date", reason: "missing value or format pattern")
+    }
+
+    let res = try EVY.getDataFromProps(path)
+    let isoString = try evyIso8601String(from: res, type: "date")
+
+    if editing {
+        return EVYFunctionOutput(value: isoString, prefix: nil, suffix: nil)
+    }
+
+    let date = try evyParseIso8601Date(isoString)
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = pattern
+    let formatted = formatter.string(from: date)
+    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: nil)
+}
+
+@MainActor
 func evyBuildCurrency(_ args: String,
                       _ value: String) throws -> Data {
     let existingCurrency = evyExistingCurrency(for: args) ?? "AUD"
@@ -231,6 +354,120 @@ func evyBuildAddress(_ args: String,
         evyAddressFields(from: value, existingAddress: existingAddress)
     )
     return try JSONEncoder().encode(builtAddress)
+}
+
+private func evyDoubleValue(from json: EVYJson, type: String) throws -> Double {
+    switch json {
+    case let .int(intValue):
+        return Double(intValue)
+    case let .decimal(decimalValue):
+        return NSDecimalNumber(decimal: decimalValue).doubleValue
+    case let .string(stringValue):
+        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = Double(trimmed) else {
+            throw EVYError.formatFailed(type: type, reason: "could not parse number from '\(trimmed)'")
+        }
+        return parsed
+    default:
+        throw EVYError.formatFailed(type: type, reason: "expected number, got \(json)")
+    }
+}
+
+private func evyPlainNumberString(_ value: Double) -> String {
+    if value.truncatingRemainder(dividingBy: 1) == 0, value <= Double(Int.max), value >= Double(Int.min) {
+        return String(Int(value))
+    }
+    return "\(value)"
+}
+
+private func evyMillimetres(from json: EVYJson) throws -> Int {
+    switch json {
+    case let .int(intValue):
+        return intValue
+    case let .string(stringValue):
+        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw EVYError.formatFailed(type: "metricLength", reason: "empty millimetre value")
+        }
+        guard let mm = Int(trimmed) else {
+            throw EVYError.formatFailed(type: "metricLength", reason: "could not parse integer from '\(trimmed)'")
+        }
+        return mm
+    default:
+        throw EVYError.formatFailed(type: "metricLength", reason: "expected integer millimetres, got \(json)")
+    }
+}
+
+private func evyMilliseconds(from json: EVYJson) throws -> Int64 {
+    switch json {
+    case let .int(intValue):
+        return Int64(intValue)
+    case let .decimal(decimalValue):
+        return NSDecimalNumber(decimal: decimalValue).int64Value
+    case let .string(stringValue):
+        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw EVYError.formatFailed(type: "duration", reason: "empty duration value")
+        }
+        guard let parsed = Int64(trimmed) else {
+            throw EVYError.formatFailed(type: "duration", reason: "could not parse integer from '\(trimmed)'")
+        }
+        return parsed
+    default:
+        throw EVYError.formatFailed(type: "duration", reason: "expected duration in milliseconds, got \(json)")
+    }
+}
+
+private func evyHumanizeDuration(milliseconds: Int64) -> String {
+    let ms = max(milliseconds, 0)
+    let units: [(Int64, String, String)] = [
+        (86_400_000, "day", "days"),
+        (3_600_000, "hour", "hours"),
+        (60_000, "minute", "minutes"),
+        (1000, "second", "seconds"),
+    ]
+    for (unitMs, singular, plural) in units {
+        if ms >= unitMs {
+            let count = ms / unitMs
+            let label = count == 1 ? singular : plural
+            return "\(count) \(label)"
+        }
+    }
+    return "\(ms) milliseconds"
+}
+
+private func evyNormalizeDateFormatPattern(_ pattern: String) -> String {
+    var result = pattern
+    result = result.replacingOccurrences(of: "YYYY", with: "yyyy")
+    result = result.replacingOccurrences(of: "DD", with: "dd")
+    return result
+}
+
+private func evyIso8601String(from json: EVYJson, type: String) throws -> String {
+    switch json {
+    case let .string(stringValue):
+        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw EVYError.formatFailed(type: type, reason: "empty date string")
+        }
+        return trimmed
+    default:
+        throw EVYError.formatFailed(type: type, reason: "expected ISO 8601 string, got \(json)")
+    }
+}
+
+private func evyParseIso8601Date(_ isoString: String) throws -> Date {
+    let withFraction = ISO8601DateFormatter()
+    withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = withFraction.date(from: isoString) {
+        return date
+    }
+    let basic = ISO8601DateFormatter()
+    basic.formatOptions = [.withInternetDateTime]
+    if let date = basic.date(from: isoString) {
+        return date
+    }
+    throw EVYError.formatFailed(type: "date", reason: "could not parse ISO 8601 date '\(isoString)'")
 }
 
 private func evyNumericValue(_ value: String) -> Decimal? {

--- a/ios/evy/Utils/EVYFunctions.swift
+++ b/ios/evy/Utils/EVYFunctions.swift
@@ -205,6 +205,21 @@ func evyFormatAddress(_ args: String) throws -> EVYFunctionOutput {
     }
 }
 
+/// First comma-separated argument as a data path; used by single-argument formatters.
+@MainActor
+private func evyJsonFromFirstArgument(args: String, errorType: String) throws -> EVYJson {
+    let path = try evyTrimmedFirstPath(from: args, errorType: errorType)
+    return try EVY.getDataFromProps(path)
+}
+
+private func evyTrimmedFirstPath(from args: String, errorType: String) throws -> String {
+    let parts = EVYInterpreter.splitFunctionArguments(args)
+    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+        throw EVYError.formatFailed(type: errorType, reason: "missing value argument")
+    }
+    return path
+}
+
 @MainActor
 func evyFormatDecimal(_ args: String,
                       _ editing: Bool = false) throws -> EVYFunctionOutput {
@@ -216,7 +231,10 @@ func evyFormatDecimal(_ args: String,
     if parts.count >= 2 {
         let rawPlaces = EVYInterpreter.stripOptionalSurroundingQuotes(parts[1])
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        places = Int(rawPlaces) ?? 2
+        guard let parsedPlaces = Int(rawPlaces), parsedPlaces >= 0, parsedPlaces <= 20 else {
+            throw EVYError.formatFailed(type: "decimal", reason: "invalid fraction digits '\(rawPlaces)'")
+        }
+        places = parsedPlaces
     } else {
         places = 2
     }
@@ -243,12 +261,8 @@ func evyFormatDecimal(_ args: String,
 @MainActor
 func evyFormatMetricLength(_ args: String,
                            _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let parts = EVYInterpreter.splitFunctionArguments(args)
-    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
-        throw EVYError.formatFailed(type: "metricLength", reason: "missing value argument")
-    }
-    let res = try EVY.getDataFromProps(path)
-    let mm = try evyMillimetres(from: res)
+    let res = try evyJsonFromFirstArgument(args: args, errorType: "metricLength")
+    let mm = try evyMillimetres(from: res, errorType: "metricLength")
 
     if editing {
         return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
@@ -262,12 +276,8 @@ func evyFormatMetricLength(_ args: String,
 @MainActor
 func evyFormatImperialLength(_ args: String,
                              _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let parts = EVYInterpreter.splitFunctionArguments(args)
-    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
-        throw EVYError.formatFailed(type: "imperialLength", reason: "missing value argument")
-    }
-    let res = try EVY.getDataFromProps(path)
-    let mm = try evyMillimetres(from: res)
+    let res = try evyJsonFromFirstArgument(args: args, errorType: "imperialLength")
+    let mm = try evyMillimetres(from: res, errorType: "imperialLength")
 
     if editing {
         return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
@@ -281,11 +291,7 @@ func evyFormatImperialLength(_ args: String,
 @MainActor
 func evyFormatDuration(_ args: String,
                        _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let parts = EVYInterpreter.splitFunctionArguments(args)
-    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
-        throw EVYError.formatFailed(type: "duration", reason: "missing value argument")
-    }
-    let res = try EVY.getDataFromProps(path)
+    let res = try evyJsonFromFirstArgument(args: args, errorType: "duration")
     let ms = try evyMilliseconds(from: res)
 
     if editing {
@@ -304,6 +310,9 @@ func evyFormatDate(_ args: String,
         throw EVYError.formatFailed(type: "date", reason: "expected value and format pattern")
     }
     let path = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !path.isEmpty else {
+        throw EVYError.formatFailed(type: "date", reason: "missing value argument")
+    }
     let pattern = evyNormalizeDateFormatPattern(
         EVYInterpreter.stripOptionalSurroundingQuotes(parts[1])
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -380,21 +389,21 @@ private func evyPlainNumberString(_ value: Double) -> String {
     return "\(value)"
 }
 
-private func evyMillimetres(from json: EVYJson) throws -> Int {
+private func evyMillimetres(from json: EVYJson, errorType: String) throws -> Int {
     switch json {
     case let .int(intValue):
         return intValue
     case let .string(stringValue):
         let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            throw EVYError.formatFailed(type: "metricLength", reason: "empty millimetre value")
+            throw EVYError.formatFailed(type: errorType, reason: "empty millimetre value")
         }
         guard let mm = Int(trimmed) else {
-            throw EVYError.formatFailed(type: "metricLength", reason: "could not parse integer from '\(trimmed)'")
+            throw EVYError.formatFailed(type: errorType, reason: "could not parse integer from '\(trimmed)'")
         }
         return mm
     default:
-        throw EVYError.formatFailed(type: "metricLength", reason: "expected integer millimetres, got \(json)")
+        throw EVYError.formatFailed(type: errorType, reason: "expected integer millimetres, got \(json)")
     }
 }
 

--- a/ios/evy/Utils/EVYInterpreter.swift
+++ b/ios/evy/Utils/EVYInterpreter.swift
@@ -75,6 +75,58 @@ struct EVYInterpreter {
         }
         return nil
     }
+
+    /// Splits top-level comma-separated function arguments, respecting nested parentheses and double-quoted segments.
+    public static func splitFunctionArguments(_ args: String) -> [String] {
+        var components: [String] = []
+        var current = ""
+        var depth = 0
+        var inString = false
+
+        for ch in args {
+            if inString {
+                current.append(ch)
+                if ch == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            switch ch {
+            case "\"":
+                inString = true
+                current.append(ch)
+            case "(":
+                depth += 1
+                current.append(ch)
+            case ")":
+                depth -= 1
+                current.append(ch)
+            case "," where depth == 0:
+                let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    components.append(trimmed)
+                }
+                current = ""
+            default:
+                current.append(ch)
+            }
+        }
+
+        let trimmedTail = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedTail.isEmpty {
+            components.append(trimmedTail)
+        }
+        return components
+    }
+
+    public static func stripOptionalSurroundingQuotes(_ s: String) -> String {
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 2, trimmed.first == "\"", trimmed.last == "\"" else {
+            return trimmed
+        }
+        return String(trimmed.dropFirst().dropLast())
+    }
     
     private static func parseText(_ input: EVYValue,
                                   _ editing: Bool) throws -> EVYValue
@@ -128,6 +180,16 @@ struct EVYInterpreter {
                 value = try evyFormatWeight(funcArgs, editing)
             case "formatAddress":
                 value = try evyFormatAddress(funcArgs)
+            case "formatDecimal":
+                value = try evyFormatDecimal(funcArgs, editing)
+            case "formatMetricLength":
+                value = try evyFormatMetricLength(funcArgs, editing)
+            case "formatImperialLength":
+                value = try evyFormatImperialLength(funcArgs, editing)
+            case "formatDuration":
+                value = try evyFormatDuration(funcArgs, editing)
+            case "formatDate":
+                value = try evyFormatDate(funcArgs, editing)
             case "buildCurrency", "buildAddress":
                 value = nil
             default:

--- a/ios/evyTests/EVYInterpreterTests.swift
+++ b/ios/evyTests/EVYInterpreterTests.swift
@@ -63,6 +63,31 @@ final class EVYInterpreterTests: XCTestCase {
         )
     }
 
+    func testWatchTargetUsesFirstArgumentForMultiArgFunction() {
+        XCTAssertEqual(
+            EVY.watchTarget(for: "{formatDecimal(item.price, 2)}"),
+            "item.price"
+        )
+    }
+
+    func testWatchTargetUsesFirstArgumentWithQuotedFormatString() {
+        XCTAssertEqual(
+            EVY.watchTarget(for: "{formatDate(item.createdAt, \"MM/dd/yyyy\")}"),
+            "item.createdAt"
+        )
+    }
+
+    func testSplitFunctionArgumentsRespectsQuotesAndNesting() {
+        XCTAssertEqual(
+            EVYInterpreter.splitFunctionArguments(#"item.date, "MM/dd/yyyy""#),
+            [#"item.date"#, #""MM/dd/yyyy""#]
+        )
+        XCTAssertEqual(
+            EVYInterpreter.splitFunctionArguments("outer.inner, 2"),
+            ["outer.inner", "2"]
+        )
+    }
+
     func testCountReflectsArrayAfterStoreUpdate() throws {
         let key = uniqueKey("photos")
         try store(.array([.string("a")]), at: key)
@@ -76,6 +101,42 @@ final class EVYInterpreterTests: XCTestCase {
         XCTAssertEqual(two.value, "n: 2")
     }
 
+    func testFormatDecimalRoundsToPlaces() throws {
+        let key = uniqueKey("amount")
+        try store(.string("20.0423"), at: key)
+        let out = try EVYInterpreter.parseTextFromText("{\(formatDecimal(key, 2))}")
+        XCTAssertEqual(out.value, "20.04")
+    }
+
+    func testFormatMetricLengthUsesTwoDecimalMetres() throws {
+        let key = uniqueKey("mm")
+        try store(.int(23240), at: key)
+        let out = try EVYInterpreter.parseTextFromText("{\(formatMetricLength(key))}")
+        XCTAssertEqual(out.toString(), "23.24m")
+    }
+
+    func testFormatImperialLengthConvertsMillimetresToFeet() throws {
+        let key = uniqueKey("mm")
+        try store(.int(4231), at: key)
+        let out = try EVYInterpreter.parseTextFromText("{\(formatImperialLength(key))}")
+        XCTAssertEqual(out.toString(), "13.88ft")
+    }
+
+    func testFormatDurationHumanizesMilliseconds() throws {
+        let key = uniqueKey("ms")
+        try store(.int(900_000), at: key)
+        let out = try EVYInterpreter.parseTextFromText("{\(formatDuration(key))}")
+        XCTAssertEqual(out.value, "15 minutes")
+    }
+
+    func testFormatDateFormatsIsoStringWithPattern() throws {
+        let key = uniqueKey("created")
+        try store(.string("2024-01-19T12:42:52.000Z"), at: key)
+        let datePattern = "MM/dd/yyyy"
+        let out = try EVYInterpreter.parseTextFromText("{\(formatDate(key, datePattern))}")
+        XCTAssertEqual(out.value, "01/19/2024")
+    }
+
     private func store(_ value: EVYJson, at key: String) throws {
         if EVY.data.exists(key: key) {
             try EVY.data.delete(key: key)
@@ -87,5 +148,25 @@ final class EVYInterpreterTests: XCTestCase {
     private func uniqueKey(_ suffix: String) -> String {
         let randomId = UUID().uuidString.replacingOccurrences(of: "-", with: "_")
         return "evy_interpreter_tests_\(suffix)_\(randomId)"
+    }
+
+    private func formatDecimal(_ key: String, _ places: Int) -> String {
+        "formatDecimal(\(key), \(places))"
+    }
+
+    private func formatMetricLength(_ key: String) -> String {
+        "formatMetricLength(\(key))"
+    }
+
+    private func formatImperialLength(_ key: String) -> String {
+        "formatImperialLength(\(key))"
+    }
+
+    private func formatDuration(_ key: String) -> String {
+        "formatDuration(\(key))"
+    }
+
+    private func formatDate(_ key: String, _ pattern: String) -> String {
+        "formatDate(\(key), \"\(pattern)\")"
     }
 }

--- a/ios/evyTests/EVYInterpreterTests.swift
+++ b/ios/evyTests/EVYInterpreterTests.swift
@@ -104,36 +104,37 @@ final class EVYInterpreterTests: XCTestCase {
     func testFormatDecimalRoundsToPlaces() throws {
         let key = uniqueKey("amount")
         try store(.string("20.0423"), at: key)
-        let out = try EVYInterpreter.parseTextFromText("{\(formatDecimal(key, 2))}")
+        let out = try EVYInterpreter.parseTextFromText("{formatDecimal(\(key), 2)}")
         XCTAssertEqual(out.value, "20.04")
     }
 
     func testFormatMetricLengthUsesTwoDecimalMetres() throws {
         let key = uniqueKey("mm")
         try store(.int(23240), at: key)
-        let out = try EVYInterpreter.parseTextFromText("{\(formatMetricLength(key))}")
+        let out = try EVYInterpreter.parseTextFromText("{formatMetricLength(\(key))}")
         XCTAssertEqual(out.toString(), "23.24m")
     }
 
     func testFormatImperialLengthConvertsMillimetresToFeet() throws {
         let key = uniqueKey("mm")
         try store(.int(4231), at: key)
-        let out = try EVYInterpreter.parseTextFromText("{\(formatImperialLength(key))}")
+        let out = try EVYInterpreter.parseTextFromText("{formatImperialLength(\(key))}")
         XCTAssertEqual(out.toString(), "13.88ft")
     }
 
     func testFormatDurationHumanizesMilliseconds() throws {
         let key = uniqueKey("ms")
         try store(.int(900_000), at: key)
-        let out = try EVYInterpreter.parseTextFromText("{\(formatDuration(key))}")
+        let out = try EVYInterpreter.parseTextFromText("{formatDuration(\(key))}")
         XCTAssertEqual(out.value, "15 minutes")
     }
 
     func testFormatDateFormatsIsoStringWithPattern() throws {
         let key = uniqueKey("created")
         try store(.string("2024-01-19T12:42:52.000Z"), at: key)
-        let datePattern = "MM/dd/yyyy"
-        let out = try EVYInterpreter.parseTextFromText("{\(formatDate(key, datePattern))}")
+        let out = try EVYInterpreter.parseTextFromText(
+            "{formatDate(\(key), \"MM/dd/yyyy\")}"
+        )
         XCTAssertEqual(out.value, "01/19/2024")
     }
 
@@ -148,25 +149,5 @@ final class EVYInterpreterTests: XCTestCase {
     private func uniqueKey(_ suffix: String) -> String {
         let randomId = UUID().uuidString.replacingOccurrences(of: "-", with: "_")
         return "evy_interpreter_tests_\(suffix)_\(randomId)"
-    }
-
-    private func formatDecimal(_ key: String, _ places: Int) -> String {
-        "formatDecimal(\(key), \(places))"
-    }
-
-    private func formatMetricLength(_ key: String) -> String {
-        "formatMetricLength(\(key))"
-    }
-
-    private func formatImperialLength(_ key: String) -> String {
-        "formatImperialLength(\(key))"
-    }
-
-    private func formatDuration(_ key: String) -> String {
-        "formatDuration(\(key))"
-    }
-
-    private func formatDate(_ key: String, _ pattern: String) -> String {
-        "formatDate(\(key), \"\(pattern)\")"
     }
 }

--- a/web/app/utils/evyFunctions.ts
+++ b/web/app/utils/evyFunctions.ts
@@ -5,53 +5,47 @@ export type EVYFunctionOutput = {
 };
 
 /** Web intentionally returns doc-shaped placeholders; real formatting runs on iOS. */
-export function evyCount(): EVYFunctionOutput {
+function evyCount(): EVYFunctionOutput {
 	return { value: "1" };
 }
 
-export function evyLength(): EVYFunctionOutput {
+function evyLength(): EVYFunctionOutput {
 	return { value: "1" };
 }
 
-export function evyFormatCurrency(): EVYFunctionOutput {
+function evyFormatCurrency(): EVYFunctionOutput {
 	return { value: "1.00", prefix: "$" };
 }
 
-export function evyFormatDimension(): EVYFunctionOutput {
+function evyFormatDimension(): EVYFunctionOutput {
 	return { value: "100", suffix: "mm" };
 }
 
-export function evyFormatWeight(): EVYFunctionOutput {
+function evyFormatWeight(): EVYFunctionOutput {
 	return { value: "500", suffix: "g" };
 }
 
-export function evyFormatAddress(): EVYFunctionOutput {
+function evyFormatAddress(): EVYFunctionOutput {
 	return { value: "1 Main Street, 2000\nSydney, NSW" };
 }
 
-export function evyFormatDecimalStub(): EVYFunctionOutput {
-	return { value: "20.04" };
-}
+const evyFormatDecimalStub = (): EVYFunctionOutput => ({ value: "20.04" });
+const evyFormatMetricLengthStub = (): EVYFunctionOutput => ({
+	value: "23.24",
+	suffix: "m",
+});
+const evyFormatImperialLengthStub = (): EVYFunctionOutput => ({
+	value: "13.88",
+	suffix: "ft",
+});
+const evyFormatDurationStub = (): EVYFunctionOutput => ({
+	value: "15 minutes",
+});
+const evyFormatDateStub = (): EVYFunctionOutput => ({
+	value: "01/19/2024",
+});
 
-export function evyFormatMetricLengthStub(): EVYFunctionOutput {
-	return { value: "23.24", suffix: "m" };
-}
-
-export function evyFormatImperialLengthStub(): EVYFunctionOutput {
-	return { value: "13.88", suffix: "ft" };
-}
-
-export function evyFormatDurationStub(): EVYFunctionOutput {
-	return { value: "15 minutes" };
-}
-
-export function evyFormatDateStub(): EVYFunctionOutput {
-	return { value: "01/19/2024" };
-}
-
-type Handler = (_args: string) => EVYFunctionOutput | null;
-
-const functionHandlers: Record<string, Handler> = {
+const functionHandlers: Record<string, () => EVYFunctionOutput | null> = {
 	count: evyCount,
 	length: evyLength,
 	formatCurrency: evyFormatCurrency,
@@ -67,11 +61,8 @@ const functionHandlers: Record<string, Handler> = {
 	buildAddress: () => null,
 };
 
-export function callFunction(
-	name: string,
-	_args = "",
-): EVYFunctionOutput | null {
+export function callFunction(name: string): EVYFunctionOutput | null {
 	const handler = functionHandlers[name];
 	if (!handler) return null;
-	return handler(_args);
+	return handler();
 }

--- a/web/app/utils/evyFunctions.ts
+++ b/web/app/utils/evyFunctions.ts
@@ -4,6 +4,7 @@ export type EVYFunctionOutput = {
 	suffix?: string;
 };
 
+/** Web intentionally returns doc-shaped placeholders; real formatting runs on iOS. */
 export function evyCount(): EVYFunctionOutput {
 	return { value: "1" };
 }
@@ -28,19 +29,49 @@ export function evyFormatAddress(): EVYFunctionOutput {
 	return { value: "1 Main Street, 2000\nSydney, NSW" };
 }
 
-const functionHandlers: Record<string, () => EVYFunctionOutput | null> = {
+export function evyFormatDecimalStub(): EVYFunctionOutput {
+	return { value: "20.04" };
+}
+
+export function evyFormatMetricLengthStub(): EVYFunctionOutput {
+	return { value: "23.24", suffix: "m" };
+}
+
+export function evyFormatImperialLengthStub(): EVYFunctionOutput {
+	return { value: "13.88", suffix: "ft" };
+}
+
+export function evyFormatDurationStub(): EVYFunctionOutput {
+	return { value: "15 minutes" };
+}
+
+export function evyFormatDateStub(): EVYFunctionOutput {
+	return { value: "01/19/2024" };
+}
+
+type Handler = (_args: string) => EVYFunctionOutput | null;
+
+const functionHandlers: Record<string, Handler> = {
 	count: evyCount,
 	length: evyLength,
 	formatCurrency: evyFormatCurrency,
 	formatDimension: evyFormatDimension,
 	formatWeight: evyFormatWeight,
 	formatAddress: evyFormatAddress,
+	formatDecimal: evyFormatDecimalStub,
+	formatMetricLength: evyFormatMetricLengthStub,
+	formatImperialLength: evyFormatImperialLengthStub,
+	formatDuration: evyFormatDurationStub,
+	formatDate: evyFormatDateStub,
 	buildCurrency: () => null,
 	buildAddress: () => null,
 };
 
-export function callFunction(name: string): EVYFunctionOutput | null {
+export function callFunction(
+	name: string,
+	_args = "",
+): EVYFunctionOutput | null {
 	const handler = functionHandlers[name];
 	if (!handler) return null;
-	return handler();
+	return handler(_args);
 }

--- a/web/app/utils/evyInterpreter.ts
+++ b/web/app/utils/evyInterpreter.ts
@@ -4,8 +4,8 @@ import { propPathToFriendlyLabel } from "./labelFormatting";
 const FUNCTION_WITH_BRACES = /\{([a-zA-Z_]+)\(([^)]*)\)\}/;
 const PROPS_PATTERN = /\{(?!")[^}^"]*(?!")\}/;
 
-function resolveFunction(functionName: string): string | null {
-	const result = callFunction(functionName);
+function resolveFunction(functionName: string, rawArgs: string): string | null {
+	const result = callFunction(functionName, rawArgs);
 	if (!result) return "";
 	return `${result.prefix ?? ""}${result.value}${result.suffix ?? ""}`;
 }
@@ -19,7 +19,8 @@ export function parseText(input: string): string {
 	while (safety++ < 50) {
 		const fnMatch = FUNCTION_WITH_BRACES.exec(text);
 		if (fnMatch) {
-			const resolved = resolveFunction(fnMatch[1]);
+			// Regex captures `[1]` as the function name and `[2]` as the raw text inside `(...)`.
+			const resolved = resolveFunction(fnMatch[1], fnMatch[2] ?? "");
 			if (resolved !== null) {
 				text = text.replace(fnMatch[0], resolved);
 				continue;

--- a/web/app/utils/evyInterpreter.ts
+++ b/web/app/utils/evyInterpreter.ts
@@ -4,8 +4,8 @@ import { propPathToFriendlyLabel } from "./labelFormatting";
 const FUNCTION_WITH_BRACES = /\{([a-zA-Z_]+)\(([^)]*)\)\}/;
 const PROPS_PATTERN = /\{(?!")[^}^"]*(?!")\}/;
 
-function resolveFunction(functionName: string, rawArgs: string): string | null {
-	const result = callFunction(functionName, rawArgs);
+function resolveFunction(functionName: string): string | null {
+	const result = callFunction(functionName);
 	if (!result) return "";
 	return `${result.prefix ?? ""}${result.value}${result.suffix ?? ""}`;
 }
@@ -19,8 +19,7 @@ export function parseText(input: string): string {
 	while (safety++ < 50) {
 		const fnMatch = FUNCTION_WITH_BRACES.exec(text);
 		if (fnMatch) {
-			// Regex captures `[1]` as the function name and `[2]` as the raw text inside `(...)`.
-			const resolved = resolveFunction(fnMatch[1], fnMatch[2] ?? "");
+			const resolved = resolveFunction(fnMatch[1]);
 			if (resolved !== null) {
 				text = text.replace(fnMatch[0], resolved);
 				continue;


### PR DESCRIPTION
## Summary

This change documents functions that already existed in code, implements the remaining documented SDData formatters on iOS, adds shared formatting helpers and tests in the API package, and keeps the web builder on doc-shaped stubs for those functions.

## Documentation

- Extended [`docs/evy/sddata/functions.md`](docs/evy/sddata/functions.md) with `length`, `formatDimension`, `formatWeight`, and builder functions (`buildCurrency`, `buildAddress`), aligned with current iOS behavior, without rewriting older aspirational sections.

## iOS

- Implemented `formatDecimal`, `formatMetricLength`, `formatImperialLength`, `formatDuration`, and `formatDate` in `EVYFunctions` and wired them in `EVYInterpreter`.
- Added `splitFunctionArguments` / quote-aware argument splitting and improved `watchTarget` for multi-argument calls (e.g. `formatDecimal(path, 2)`, `formatDate(path, pattern)`).
- Added unit tests in `EVYInterpreterTests`.

## API

- Added [`api/src/evyFunctions.ts`](api/src/evyFunctions.ts) with pure formatting helpers (decimal, lengths, duration, ISO date patterns, argument splitting) and [`api/src/tests/evyFunctions.test.ts`](api/src/tests/evyFunctions.test.ts).

## Web

- Registered stub outputs for the new function names in [`web/app/utils/evyFunctions.ts`](web/app/utils/evyFunctions.ts) so the builder can resolve templates without real formatting.

## JIRA

## Figma

## Stream video



Made with [Cursor](https://cursor.com)