### PR TITLE
[FEAT] Improve canvas wheel panning and page interior hit area

### DIFF
--- a/web/app/components/AppPage.tsx
+++ b/web/app/components/AppPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useRef } from "react";
 
 import { useDragContext, useFlowsContext } from "../state";
 import { usePageDropTarget } from "../hooks/usePageDropTarget";
+import { canvasPageInteriorDomProps } from "../utils/canvasPageInterior";
 import { findFlowById } from "../utils/flowHelpers";
 import { buildRowElements } from "./buildRowElements";
 import { baseTitleStyle, rounded24Style } from "./pageStyles";
@@ -82,6 +83,7 @@ export default function AppPage({ pageId }: { pageId: string }) {
 					{titleElement}
 					<div
 						className="evy-overflow-scroll evy-flex-1 evy-pt-4"
+						{...canvasPageInteriorDomProps}
 						ref={scrollableRef}
 					>
 						{rowElements}
@@ -99,6 +101,7 @@ export default function AppPage({ pageId }: { pageId: string }) {
 				<div
 					className="evy-overflow-scroll evy-h-full evy-pt-4 evy-bg-white"
 					style={rounded24Style}
+					{...canvasPageInteriorDomProps}
 					ref={scrollableRef}
 				>
 					{titleElement}

--- a/web/app/components/SecondarySheetPage.tsx
+++ b/web/app/components/SecondarySheetPage.tsx
@@ -4,6 +4,7 @@ import { useDragContext, useFlowsContext } from "../state";
 import { usePageDropTarget } from "../hooks/usePageDropTarget";
 import { buildRowElements } from "./buildRowElements";
 import { baseTitleStyle, rounded24Style } from "./pageStyles";
+import { canvasPageInteriorDomProps } from "../utils/canvasPageInterior";
 import { findFlowById } from "../utils/flowHelpers";
 import { findRowInPages } from "../utils/rowTree";
 
@@ -54,6 +55,7 @@ export default function SecondarySheetPage({
 			<div
 				className="evy-overflow-scroll evy-h-full evy-pt-4 evy-bg-white"
 				style={rounded24Style}
+				{...canvasPageInteriorDomProps}
 				ref={scrollableRef}
 			>
 				<div style={baseTitleStyle}>{title}</div>

--- a/web/app/hooks/useViewportGestures.ts
+++ b/web/app/hooks/useViewportGestures.ts
@@ -2,14 +2,16 @@ import type { RefObject } from "react";
 import { useEffect } from "react";
 
 import type { CameraState } from "./useCamera";
+import { CANVAS_PAGE_INTERIOR_SELECTOR } from "../utils/canvasPageInterior";
 import type { ScreenPoint } from "../utils/coordinates";
 
-/** Ctrl/trackpad zoom: `exp(-deltaY * sensitivity)` */
 const WHEEL_ZOOM_SENSITIVITY = 0.002;
 const MIN_PAN_SPEED_FOR_INERTIA = 0.2;
 const INERTIA_MULTIPLIER = 14;
 const INERTIA_DECAY = 0.88;
 const INERTIA_STOP_THRESHOLD = 0.4;
+/** After this idle gap, wheel over the page interior scrolls the page instead of the canvas. */
+const PAN_MOMENTUM_MS = 300;
 
 function viewportLocalPoint(
 	viewport: HTMLElement,
@@ -42,20 +44,21 @@ export function useViewportGestures({
 		const viewport = viewportRef.current;
 		if (!viewport) return;
 
-		const isInsidePageFrame = (target: EventTarget | null): boolean => {
+		const isInsidePageInterior = (target: EventTarget | null): boolean => {
 			if (!(target instanceof Element)) return false;
-			const frame = target.closest("[data-canvas-page-frame]");
-			return frame !== null && viewport.contains(frame);
+			const interior = target.closest(CANVAS_PAGE_INTERIOR_SELECTOR);
+			return interior !== null && viewport.contains(interior);
 		};
 
-		const onWheel = (event: WheelEvent) => {
-			const { x: localX, y: localY } = viewportLocalPoint(
-				viewport,
-				event.clientX,
-				event.clientY,
-			);
+		let lastPanTime = 0;
 
+		const onWheel = (event: WheelEvent) => {
 			if (event.ctrlKey || event.metaKey) {
+				const { x: localX, y: localY } = viewportLocalPoint(
+					viewport,
+					event.clientX,
+					event.clientY,
+				);
 				event.preventDefault();
 				const factor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
 				const nextScale = getCamera().scale * factor;
@@ -63,12 +66,16 @@ export function useViewportGestures({
 				return;
 			}
 
-			if (isInsidePageFrame(event.target)) {
+			const insidePage = isInsidePageInterior(event.target);
+			const withinMomentum = performance.now() - lastPanTime < PAN_MOMENTUM_MS;
+
+			if (insidePage && !withinMomentum) {
 				return;
 			}
 
 			event.preventDefault();
 			pan(-event.deltaX, -event.deltaY);
+			lastPanTime = performance.now();
 		};
 
 		viewport.addEventListener("wheel", onWheel, { passive: false });

--- a/web/app/utils/canvasPageInterior.ts
+++ b/web/app/utils/canvasPageInterior.ts
@@ -1,0 +1,13 @@
+/**
+ * DOM contract between phone page scroll surfaces and viewport wheel routing
+ * ({@link useViewportGestures}). Keep in sync with {@link CANVAS_PAGE_INTERIOR_SELECTOR}.
+ */
+export const CANVAS_PAGE_INTERIOR_ATTR = "data-canvas-page-interior" as const;
+
+export const CANVAS_PAGE_INTERIOR_SELECTOR =
+	`[${CANVAS_PAGE_INTERIOR_ATTR}]` as const;
+
+/** Spread onto the scroll root so the attribute name cannot drift from the selector. */
+export const canvasPageInteriorDomProps = {
+	[CANVAS_PAGE_INTERIOR_ATTR]: true,
+} as const;


### PR DESCRIPTION
## Summary

This change improves how the builder viewport handles two-finger / wheel panning when the cursor moves over a phone preview:

- **Narrow hit-testing** to the actual scrollable page surface (white card interior) via a shared `data-canvas-page-interior` marker in `canvasPageInterior.ts`, applied on `AppPage` and `SecondarySheetPage` scroll roots. Bezel, outer padding, and non-scroll chrome still behave like canvas space for wheel routing.
- **300ms pan momentum**: after an active canvas pan, wheel events over the page interior keep panning the canvas until the user pauses for `PAN_MOMENTUM_MS`, then native page scrolling can take over.
- **Hot path**: `viewportLocalPoint` (and `getBoundingClientRect`) runs only on Ctrl/Cmd zoom, not on every wheel tick.

## Testing

- `cd web && bun run lint && bun run build && bun run test` (Playwright: 69 passed)

## JIRA



## Figma



## Stream video



Made with [Cursor](https://cursor.com)