### PR TITLE
[FEAT] Expand automated test coverage and test infrastructure

### DIFF
--- a/api/e2e/e2e.test.ts
+++ b/api/e2e/e2e.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import type { SDUI_Flow, SDUI_Page, SDUI_Row } from "evy-types";
 
 import { isRecord } from "../src/data";
+import { waitForClientOpen } from "../src/tests/wsTestHelpers";
 
 type WSClient = InstanceType<typeof Client>;
 
@@ -12,24 +13,7 @@ if (!API_URL) {
 }
 const TEST_TOKEN = "e2e-test-token";
 const TEST_OS = "Web";
-const CONNECTION_TIMEOUT = 5000;
-
-function waitForClient(ws: WSClient): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const timeout = setTimeout(
-			() => reject(new Error("Connection timeout")),
-			CONNECTION_TIMEOUT,
-		);
-		ws.on("open", () => {
-			clearTimeout(timeout);
-			resolve();
-		});
-		ws.on("error", (error: Error) => {
-			clearTimeout(timeout);
-			reject(error);
-		});
-	});
-}
+const CONNECTION_TIMEOUT_MS = 5000;
 
 describe("API E2E Tests", () => {
 	describe("Public", () => {
@@ -37,7 +21,7 @@ describe("API E2E Tests", () => {
 
 		beforeAll(async () => {
 			unauthClient = new Client(API_URL);
-			await waitForClient(unauthClient);
+			await waitForClientOpen(unauthClient, CONNECTION_TIMEOUT_MS);
 		});
 
 		afterAll(() => {
@@ -81,7 +65,7 @@ describe("API E2E Tests", () => {
 
 		beforeAll(async () => {
 			client = new Client(API_URL);
-			await waitForClient(client);
+			await waitForClientOpen(client, CONNECTION_TIMEOUT_MS);
 			await client.login({ token: TEST_TOKEN, os: TEST_OS });
 		});
 

--- a/api/e2e/reconnect.test.ts
+++ b/api/e2e/reconnect.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+	connectAndLogin,
+	waitForNotification,
+} from "../src/tests/wsTestHelpers";
+
+const API_URL = process.env.API_URL;
+if (!API_URL) {
+	throw new Error("API_URL environment variable is not set");
+}
+
+const TEST_TOKEN = "e2e-reconnect-token";
+const TEST_OS = "Web";
+
+describe("API E2E WebSocket reconnect", () => {
+	it("new client subscribed after reconnect receives flowUpdated from upsert", async () => {
+		const first = await connectAndLogin(
+			API_URL,
+			TEST_TOKEN,
+			TEST_OS,
+			"flowUpdated",
+		);
+		first.close();
+
+		const second = await connectAndLogin(
+			API_URL,
+			`${TEST_TOKEN}-2`,
+			TEST_OS,
+			"flowUpdated",
+		);
+
+		const notifyPromise = waitForNotification(second, "flowUpdated");
+
+		const caller = await connectAndLogin(
+			API_URL,
+			`${TEST_TOKEN}-caller`,
+			TEST_OS,
+		);
+
+		const pageId = crypto.randomUUID();
+		const upsertResult = await caller.call("upsert", {
+			namespace: "evy",
+			resource: "sdui",
+			data: {
+				id: crypto.randomUUID(),
+				name: `Reconnect test ${Date.now()}`,
+				pages: [{ id: pageId, title: "P", rows: [] }],
+			},
+		});
+
+		const params = await notifyPromise;
+		expect(params).toEqual(upsertResult);
+
+		second.close();
+		caller.close();
+	});
+
+	it("client observes close when connection is closed", async () => {
+		const client = await connectAndLogin(
+			API_URL,
+			`${TEST_TOKEN}-close`,
+			TEST_OS,
+		);
+
+		const closed = new Promise<void>((resolve) => {
+			client.on("close", () => resolve());
+		});
+
+		client.close();
+		await closed;
+	});
+});

--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -169,19 +169,27 @@ export async function upsert(params: unknown): Promise<DATA_Rows> {
 
 	if (resource === "sdui") {
 		const validatedData = validateFlowData(dataPayload);
+		const flowId = filter?.id ?? validatedData.id;
+		const persistedFlowData =
+			validatedData.id === flowId
+				? validatedData
+				: { ...validatedData, id: flowId };
 
 		if (filter?.id) {
 			const result = await db
 				.update(flow)
-				.set({ data: validatedData, updatedAt: nowIso })
+				.set({ data: persistedFlowData, updatedAt: nowIso })
 				.where(eq(flow.id, filter.id))
 				.returning();
-			return formatFlowRow(result[0]);
+			if (result.length > 0) {
+				return formatFlowRow(result[0]);
+			}
 		}
 		const result = await db
 			.insert(flow)
 			.values({
-				data: validatedData,
+				id: flowId,
+				data: persistedFlowData,
 				createdAt: nowIso,
 				updatedAt: nowIso,
 			})

--- a/api/src/readiness.ts
+++ b/api/src/readiness.ts
@@ -1,7 +1,13 @@
-import type { SDUI_Flow } from "evy-types";
-import { get } from "./data";
+import type { GetRequest, GetResponse, SDUI_Flow } from "evy-types";
+import { get as defaultGet } from "./data";
 
-const requireSeededData = process.argv.includes("--require-seeded");
+type AssertApiReadableOptions = {
+	requireSeeded: boolean;
+};
+
+type ApiReadableDeps = {
+	get: (params: GetRequest) => Promise<GetResponse>;
+};
 
 function isFlow(value: unknown): value is SDUI_Flow {
 	return (
@@ -12,13 +18,17 @@ function isFlow(value: unknown): value is SDUI_Flow {
 	);
 }
 
-async function assertApiReadable(): Promise<void> {
-	const flows = await get({ namespace: "evy", resource: "sdui" });
+export async function assertApiReadable(
+	options: AssertApiReadableOptions,
+	deps: ApiReadableDeps = { get: defaultGet },
+): Promise<void> {
+	const { requireSeeded } = options;
+	const flows = await deps.get({ namespace: "evy", resource: "sdui" });
 	if (!Array.isArray(flows)) {
 		throw new Error("API readiness failed: expected sdui response array");
 	}
 
-	if (!requireSeededData) {
+	if (!requireSeeded) {
 		return;
 	}
 
@@ -31,19 +41,26 @@ async function assertApiReadable(): Promise<void> {
 		);
 	}
 
-	const items = await get({ namespace: "evy", resource: "items" });
+	const items = await deps.get({ namespace: "evy", resource: "items" });
 	if (!Array.isArray(items) || items.length === 0) {
 		throw new Error("Seed verification failed: missing seeded items data");
 	}
 }
 
-try {
-	await assertApiReadable();
-	console.info(
-		requireSeededData ? "API seeded-data readiness OK" : "API readiness OK",
-	);
-	process.exit(0);
-} catch (error) {
-	console.error(error);
-	process.exit(1);
+async function runCli(): Promise<void> {
+	const requireSeededData = process.argv.includes("--require-seeded");
+	try {
+		await assertApiReadable({ requireSeeded: requireSeededData });
+		console.info(
+			requireSeededData ? "API seeded-data readiness OK" : "API readiness OK",
+		);
+		process.exit(0);
+	} catch (error) {
+		console.error(error);
+		process.exit(1);
+	}
+}
+
+if (import.meta.main) {
+	await runCli();
 }

--- a/api/src/tests/bootstrap.test.ts
+++ b/api/src/tests/bootstrap.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Client } from "rpc-websockets";
+import type { GetRequest, GetResponse, SDUI_Flow } from "evy-types";
+
+import { assertApiReadable } from "../readiness";
+import { getFreePort, waitForClientOpen, type WSServer } from "./wsTestHelpers";
+
+describe("initServer bootstrap", () => {
+	let previousApiPort: string | undefined;
+	let server: WSServer;
+	let port: number;
+	let apiUrl: string;
+
+	beforeAll(async () => {
+		previousApiPort = process.env.API_PORT;
+		port = await getFreePort();
+		process.env.API_PORT = String(port);
+		apiUrl = `ws://127.0.0.1:${port}`;
+		const { initServer } = await import("../ws");
+		server = await initServer(async () => true);
+
+		server
+			.register("upsert", async () => ({
+				id: "stub",
+				data: { id: "stub", name: "Stub", pages: [] } satisfies SDUI_Flow,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			}))
+			.protected();
+	});
+
+	afterAll(async () => {
+		await server.close();
+		if (previousApiPort === undefined) {
+			delete process.env.API_PORT;
+		} else {
+			process.env.API_PORT = previousApiPort;
+		}
+	});
+
+	it("registers dataUpdated and flowUpdated events", () => {
+		const events = server.eventList("/");
+		expect(events).toContain("dataUpdated");
+		expect(events).toContain("flowUpdated");
+	});
+
+	it("rejects upsert without authentication", async () => {
+		const client = new Client(apiUrl);
+		await waitForClientOpen(client);
+		await expect(
+			client.call("upsert", {
+				namespace: "evy",
+				resource: "sdui",
+				data: {
+					id: crypto.randomUUID(),
+					name: "Unauth",
+					pages: [],
+				},
+			}),
+		).rejects.toThrow();
+		client.close();
+	});
+});
+
+describe("assertApiReadable", () => {
+	it("resolves when sdui get returns an array and requireSeeded is false", async () => {
+		const deps = {
+			get: async (_params: GetRequest): Promise<GetResponse> => [],
+		};
+		await expect(
+			assertApiReadable({ requireSeeded: false }, deps),
+		).resolves.toBeUndefined();
+	});
+
+	it("throws when sdui get does not return an array", async () => {
+		const deps = {
+			get: async (_params: GetRequest): Promise<GetResponse> =>
+				"not-array" as unknown as GetResponse,
+		};
+		await expect(
+			assertApiReadable({ requireSeeded: false }, deps),
+		).rejects.toThrow("expected sdui response array");
+	});
+
+	it("throws when requireSeeded is true but View Item flow is missing", async () => {
+		const deps = {
+			get: async (params: GetRequest): Promise<GetResponse> => {
+				if (params.resource === "sdui") {
+					return [
+						{
+							id: "1",
+							name: "Other",
+							pages: [],
+						} satisfies SDUI_Flow,
+					];
+				}
+				return [{ title: "x" }];
+			},
+		};
+		await expect(
+			assertApiReadable({ requireSeeded: true }, deps),
+		).rejects.toThrow("View Item");
+	});
+
+	it("throws when requireSeeded is true but items are empty", async () => {
+		const deps = {
+			get: async (params: GetRequest): Promise<GetResponse> => {
+				if (params.resource === "sdui") {
+					return [
+						{
+							id: "1",
+							name: "View Item",
+							pages: [],
+						} satisfies SDUI_Flow,
+					];
+				}
+				return [];
+			},
+		};
+		await expect(
+			assertApiReadable({ requireSeeded: true }, deps),
+		).rejects.toThrow("missing seeded items");
+	});
+
+	it("resolves when requireSeeded is true and seeded flows and items exist", async () => {
+		const deps = {
+			get: async (params: GetRequest): Promise<GetResponse> => {
+				if (params.resource === "sdui") {
+					return [
+						{
+							id: "1",
+							name: "View Item",
+							pages: [],
+						} satisfies SDUI_Flow,
+					];
+				}
+				return [{ title: "item" }];
+			},
+		};
+		await expect(
+			assertApiReadable({ requireSeeded: true }, deps),
+		).resolves.toBeUndefined();
+	});
+});

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -391,6 +391,50 @@ describe("upsert", () => {
 		expect(flows).toHaveLength(1);
 	});
 
+	it("should insert then update the same SDUI flow when filter.id is provided for a new client-created flow", async () => {
+		const flowId = crypto.randomUUID();
+		const initialFlowData = createTestFlow({
+			id: flowId,
+			name: "Client Created Flow",
+			pages: [{ title: "Draft", rows: [] }],
+		});
+
+		const created = await upsert({
+			namespace: "evy",
+			resource: "sdui",
+			filter: { id: flowId },
+			data: initialFlowData,
+		});
+
+		const createdFlow = expectToBeDATA_Flow(created);
+		expect(createdFlow.id).toBe(flowId);
+		expect(createdFlow.data.id).toBe(flowId);
+		expect(createdFlow.data.name).toBe("Client Created Flow");
+
+		const updated = await upsert({
+			namespace: "evy",
+			resource: "sdui",
+			filter: { id: flowId },
+			data: createTestFlow({
+				id: flowId,
+				name: "Client Created Flow Updated",
+				pages: [{ title: "Published", rows: [] }],
+			}),
+		});
+
+		const updatedFlow = expectToBeDATA_Flow(updated);
+		expect(updatedFlow.id).toBe(flowId);
+		expect(updatedFlow.data.id).toBe(flowId);
+		expect(updatedFlow.data.name).toBe("Client Created Flow Updated");
+		expect(updatedFlow.data.pages[0]?.title).toBe("Published");
+
+		const flows = await testDb.select().from(schema.flow);
+		expect(flows).toHaveLength(1);
+		expect(flows[0]?.id).toBe(flowId);
+		expect(flows[0]?.data.id).toBe(flowId);
+		expect(flows[0]?.data.name).toBe("Client Created Flow Updated");
+	});
+
 	it("should reject SDUI flow with missing name", async () => {
 		await expect(
 			upsert({

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -8,9 +8,7 @@ import {
 	it,
 	mock,
 } from "bun:test";
-import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
-import { PGlite } from "@electric-sql/pglite";
 
 import type {
 	SDUI_Flow,
@@ -25,17 +23,11 @@ import {
 	type PageSchema,
 	validateFlowData,
 } from "../validation";
+import { clearAllTestTables, createPgliteTestDatabase } from "./wsTestHelpers";
 
-/**
- * Types inferred from individual schemas for use in other parts of the app
- */
 type ValidatedRow = z.infer<typeof RowSchema>;
 type ValidatedPage = z.infer<typeof PageSchema>;
 
-/**
- * Input types where id is optional (for creating new entities)
- * These are useful for tests and client code that creates flows
- */
 type RowInput = Omit<ValidatedRow, "id" | "view"> & {
 	id?: string;
 	view: Omit<ValidatedRow["view"], "content"> & {
@@ -57,17 +49,13 @@ type FlowDataInput = Omit<SDUI_Flow, "id" | "pages"> & {
 	pages: PageInput[];
 };
 
-// Create in-memory PostgreSQL instance
-const client = new PGlite();
-const testDb = drizzle(client, { schema });
+const { pgliteClient, testDb } = createPgliteTestDatabase();
 
-// Mock the db module to use our test database
 mock.module("../db", () => ({
 	db: testDb,
 	...schema,
 }));
 
-// Import data functions after mocking
 const { validateAuth, get, upsert } = await import("../data");
 
 function isDATA_Flow(row: DATA_Rows): row is DATA_Flow {
@@ -79,28 +67,19 @@ function isDATA_Flow(row: DATA_Rows): row is DATA_Flow {
 	);
 }
 
-/** Single-column ISO instant for test DB inserts. */
-function isoNow(): string {
-	return new Date().toISOString();
+function expectToBeDATA_Flow(row: DATA_Rows): DATA_Flow {
+	expect(isDATA_Flow(row)).toBe(true);
+	if (!isDATA_Flow(row)) {
+		throw new Error("Expected DATA_Flow");
+	}
+	return row;
 }
 
-/** Shared `createdAt` / `updatedAt` for flow (and similar) row fixtures. */
 function testFlowRowTimestamps(): { createdAt: string; updatedAt: string } {
-	const iso = isoNow();
+	const iso = new Date().toISOString();
 	return { createdAt: iso, updatedAt: iso };
 }
 
-// Helper to clear all tables between tests
-async function clearTables() {
-	await testDb.delete(schema.flow);
-	await testDb.delete(schema.data);
-	await testDb.delete(schema.serviceProvider);
-	await testDb.delete(schema.organization);
-	await testDb.delete(schema.service);
-	await testDb.delete(schema.device);
-}
-
-// Recursively ensure all rows have IDs, transforming RowInput to ValidatedRow structure
 function ensureRowIds(rows: RowInput[]): RowInput[] {
 	return rows.map((row) => {
 		const rowWithId: RowInput = {
@@ -123,8 +102,6 @@ function ensureRowIds(rows: RowInput[]): RowInput[] {
 	});
 }
 
-// Helper to create test flow data with auto-generated UUIDs
-// Takes FlowDataInput (id optional) and returns SDUI_Flow (id required)
 function createTestFlow(flowData: FlowDataInput): SDUI_Flow {
 	const built = {
 		...flowData,
@@ -139,19 +116,18 @@ function createTestFlow(flowData: FlowDataInput): SDUI_Flow {
 	return validateFlowData(built);
 }
 
-// Run migrations before all tests
 beforeAll(async () => {
 	await migrate(testDb, { migrationsFolder: "./drizzle" });
-	await clearTables();
+	await clearAllTestTables(testDb);
 });
 
 afterAll(async () => {
-	await client.close();
+	await pgliteClient.close();
 });
 
 describe("validateAuth", () => {
 	beforeEach(async () => {
-		await clearTables();
+		await clearAllTestTables(testDb);
 	});
 
 	it("should throw error when no token provided", async () => {
@@ -174,7 +150,7 @@ describe("validateAuth", () => {
 		await testDb.insert(schema.device).values({
 			token: "existing-token",
 			os: "ios",
-			createdAt: isoNow(),
+			createdAt: new Date().toISOString(),
 		});
 
 		const result = await validateAuth("existing-token", "ios");
@@ -206,7 +182,7 @@ describe("validateAuth", () => {
 
 describe("get", () => {
 	beforeEach(async () => {
-		await clearTables();
+		await clearAllTestTables(testDb);
 	});
 
 	it("should throw when params is not an object", async () => {
@@ -320,7 +296,7 @@ describe("get", () => {
 
 describe("upsert", () => {
 	beforeEach(async () => {
-		await clearTables();
+		await clearAllTestTables(testDb);
 	});
 
 	it("should throw when params is not an object", async () => {
@@ -361,10 +337,8 @@ describe("upsert", () => {
 			data: flowData,
 		});
 
-		expect(isDATA_Flow(result)).toBe(true);
-		if (isDATA_Flow(result)) {
-			expect(result.data.name).toBe("New Flow");
-		}
+		const flowRow = expectToBeDATA_Flow(result);
+		expect(flowRow.data.name).toBe("New Flow");
 		const flows = await testDb.select().from(schema.flow);
 		expect(flows).toHaveLength(1);
 	});
@@ -411,10 +385,8 @@ describe("upsert", () => {
 			data: updatedFlowData,
 		});
 
-		expect(isDATA_Flow(result)).toBe(true);
-		if (isDATA_Flow(result)) {
-			expect(result.data.name).toBe("Updated Name");
-		}
+		const flowRow = expectToBeDATA_Flow(result);
+		expect(flowRow.data.name).toBe("Updated Name");
 		const flows = await testDb.select().from(schema.flow);
 		expect(flows).toHaveLength(1);
 	});
@@ -474,7 +446,7 @@ describe("upsert", () => {
 
 describe("upsert SDUI validation", () => {
 	beforeEach(async () => {
-		await clearTables();
+		await clearAllTestTables(testDb);
 	});
 
 	it("should reject flow with unrecognized keys", async () => {
@@ -501,10 +473,8 @@ describe("upsert SDUI validation", () => {
 				pages: [],
 			},
 		});
-		expect(isDATA_Flow(result)).toBe(true);
-		if (isDATA_Flow(result)) {
-			expect(result.data.pages).toHaveLength(0);
-		}
+		const flowRow = expectToBeDATA_Flow(result);
+		expect(flowRow.data.pages).toHaveLength(0);
 	});
 
 	it("should reject flow with invalid row type", async () => {
@@ -584,11 +554,9 @@ describe("upsert SDUI validation", () => {
 			resource: "sdui",
 			data: flowData,
 		});
-		expect(isDATA_Flow(result)).toBe(true);
-		if (isDATA_Flow(result)) {
-			expect(result.data.name).toBe("Test Flow");
-			expect(result.data.pages).toHaveLength(1);
-		}
+		const flowRow = expectToBeDATA_Flow(result);
+		expect(flowRow.data.name).toBe("Test Flow");
+		expect(flowRow.data.pages).toHaveLength(1);
 	});
 
 	it("should validate footer row", async () => {
@@ -614,9 +582,7 @@ describe("upsert SDUI validation", () => {
 			resource: "sdui",
 			data: flowData,
 		});
-		expect(isDATA_Flow(result)).toBe(true);
-		if (isDATA_Flow(result)) {
-			expect(result.data.pages[0]).toHaveProperty("footer");
-		}
+		const flowRow = expectToBeDATA_Flow(result);
+		expect(flowRow.data.pages[0]).toHaveProperty("footer");
 	});
 });

--- a/api/src/tests/notifications.test.ts
+++ b/api/src/tests/notifications.test.ts
@@ -1,0 +1,196 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+} from "bun:test";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import type { GetRequest, SDUI_Flow, SDUI_Page } from "evy-types";
+
+import * as schema from "../db/drizzleTables";
+import {
+	clearAllTestTables,
+	connectAndLogin,
+	createPgliteTestDatabase,
+	getFreePort,
+	waitForNotification,
+	type WSServer,
+} from "./wsTestHelpers";
+
+const { pgliteClient, testDb } = createPgliteTestDatabase();
+
+mock.module("../db", () => ({
+	db: testDb,
+	...schema,
+}));
+
+const { get, isRecord, isResource, upsert, validateAuth } = await import(
+	"../data"
+);
+
+function hasResource(p: unknown): p is { resource: GetRequest["resource"] } {
+	return isRecord(p) && "resource" in p && isResource(p.resource);
+}
+
+describe("upsert real-time notifications", () => {
+	let previousApiPort: string | undefined;
+	let apiPort: number;
+	let apiUrl: string;
+	let initServer: typeof import("../ws")["initServer"];
+	let emitJsonRpc: typeof import("../ws")["emitJsonRpc"];
+	let server: WSServer;
+
+	beforeAll(async () => {
+		await migrate(testDb, { migrationsFolder: "./drizzle" });
+		await clearAllTestTables(testDb);
+
+		previousApiPort = process.env.API_PORT;
+		apiPort = await getFreePort();
+		process.env.API_PORT = String(apiPort);
+		const wsMod = await import("../ws");
+		initServer = wsMod.initServer;
+		emitJsonRpc = wsMod.emitJsonRpc;
+
+		server = await initServer((params) =>
+			validateAuth(params.token, params.os),
+		);
+
+		server.register("get", async (params) => get(params));
+
+		server
+			.register("upsert", async (params) => {
+				const result = await upsert(params);
+				if (!hasResource(params)) return result;
+				if (params.resource === "sdui") {
+					emitJsonRpc(server, "flowUpdated", result);
+				} else {
+					emitJsonRpc(server, "dataUpdated", result);
+				}
+				return result;
+			})
+			.protected();
+
+		apiUrl = `ws://127.0.0.1:${apiPort}`;
+	});
+
+	afterAll(async () => {
+		await server.close();
+		if (previousApiPort === undefined) {
+			delete process.env.API_PORT;
+		} else {
+			process.env.API_PORT = previousApiPort;
+		}
+		await pgliteClient.close();
+	});
+
+	beforeEach(async () => {
+		await clearAllTestTables(testDb);
+	});
+
+	it("emits flowUpdated with JSON-RPC 2.0 shape after SDUI upsert; params match upsert result", async () => {
+		const subscriber = await connectAndLogin(
+			apiUrl,
+			"notify-token-1",
+			"Web",
+			"flowUpdated",
+		);
+		const notifyPromise = waitForNotification(subscriber, "flowUpdated");
+
+		const testPage: SDUI_Page = {
+			id: crypto.randomUUID(),
+			title: "Page",
+			rows: [],
+		};
+		const flowData: SDUI_Flow = {
+			id: crypto.randomUUID(),
+			name: "WS Notify Flow",
+			pages: [testPage],
+		};
+
+		const caller = await connectAndLogin(apiUrl, "notify-token-2", "Web");
+
+		const upsertResult = await caller.call("upsert", {
+			namespace: "evy",
+			resource: "sdui",
+			data: flowData,
+		});
+
+		const params = await notifyPromise;
+		expect(params).toEqual(upsertResult);
+
+		subscriber.close();
+		caller.close();
+	});
+
+	it("emits dataUpdated after non-SDUI upsert; params match upsert result", async () => {
+		const subscriber = await connectAndLogin(
+			apiUrl,
+			"notify-token-3",
+			"Web",
+			"dataUpdated",
+		);
+		const notifyPromise = waitForNotification(subscriber, "dataUpdated");
+
+		const caller = await connectAndLogin(apiUrl, "notify-token-4", "Web");
+
+		const payload = { e2eField: "notification-items", n: 42 };
+		const upsertResult = await caller.call("upsert", {
+			namespace: "evy",
+			resource: "items",
+			data: payload,
+		});
+
+		const params = await notifyPromise;
+		expect(params).toEqual(upsertResult);
+
+		subscriber.close();
+		caller.close();
+	});
+
+	it("only subscribed clients receive flowUpdated", async () => {
+		const subscribed = await connectAndLogin(
+			apiUrl,
+			"notify-token-5",
+			"Web",
+			"flowUpdated",
+		);
+		const notifyPromise = waitForNotification(subscribed, "flowUpdated");
+
+		const notSubscribed = await connectAndLogin(
+			apiUrl,
+			"notify-token-6",
+			"Web",
+		);
+
+		const missed: unknown[] = [];
+		notSubscribed.on("flowUpdated", (p: unknown) => missed.push(p));
+
+		const caller = await connectAndLogin(apiUrl, "notify-token-7", "Web");
+
+		const testPage: SDUI_Page = {
+			id: crypto.randomUUID(),
+			title: "P",
+			rows: [],
+		};
+		await caller.call("upsert", {
+			namespace: "evy",
+			resource: "sdui",
+			data: {
+				id: crypto.randomUUID(),
+				name: "Only Subscriber",
+				pages: [testPage],
+			},
+		});
+
+		await notifyPromise;
+
+		expect(missed.length).toBe(0);
+
+		subscribed.close();
+		notSubscribed.close();
+		caller.close();
+	});
+});

--- a/api/src/tests/wsTestHelpers.ts
+++ b/api/src/tests/wsTestHelpers.ts
@@ -1,0 +1,107 @@
+import { createServer } from "node:net";
+import { PGlite } from "@electric-sql/pglite";
+import { Client } from "rpc-websockets";
+import { drizzle } from "drizzle-orm/pglite";
+import type { PgliteDatabase } from "drizzle-orm/pglite";
+
+import * as schema from "../db/drizzleTables";
+
+export type WSServer = Awaited<
+	ReturnType<typeof import("../ws")["initServer"]>
+>;
+
+type RpcWSClient = InstanceType<typeof Client>;
+type PgliteTestDb = PgliteDatabase<typeof schema>;
+
+const DEFAULT_OPEN_TIMEOUT_MS = 8000;
+
+export function getFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address();
+			if (!addr || typeof addr === "string") {
+				server.close();
+				reject(new Error("Could not get free port"));
+				return;
+			}
+			const port = addr.port;
+			server.close(() => resolve(port));
+		});
+		server.on("error", reject);
+	});
+}
+
+export function waitForClientOpen(
+	ws: RpcWSClient,
+	timeoutMs = DEFAULT_OPEN_TIMEOUT_MS,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const onOpen = () => {
+			clearTimeout(timeout);
+			ws.removeListener("error", onError);
+			resolve();
+		};
+		const onError = (err: Error) => {
+			clearTimeout(timeout);
+			ws.removeListener("open", onOpen);
+			reject(err);
+		};
+		const timeout = setTimeout(() => {
+			ws.removeListener("open", onOpen);
+			ws.removeListener("error", onError);
+			reject(new Error("WebSocket connection timeout"));
+		}, timeoutMs);
+		ws.on("open", onOpen);
+		ws.on("error", onError);
+	});
+}
+
+export function waitForNotification(
+	ws: RpcWSClient,
+	method: string,
+	timeoutMs = 15000,
+): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		const t = setTimeout(() => {
+			ws.removeAllListeners(method);
+			reject(new Error(`timeout waiting for ${method}`));
+		}, timeoutMs);
+		ws.on(method, (params: unknown) => {
+			clearTimeout(t);
+			ws.removeAllListeners(method);
+			resolve(params);
+		});
+	});
+}
+
+export async function connectAndLogin(
+	apiUrl: string,
+	token: string,
+	os: string,
+	subscribeTo?: string,
+): Promise<RpcWSClient> {
+	const ws = new Client(apiUrl);
+	await waitForClientOpen(ws);
+	await ws.login({ token, os });
+	if (subscribeTo) await ws.subscribe(subscribeTo);
+	return ws;
+}
+
+export function createPgliteTestDatabase(): {
+	pgliteClient: PGlite;
+	testDb: PgliteTestDb;
+} {
+	const pgliteClient = new PGlite();
+	const testDb = drizzle(pgliteClient, { schema });
+	return { pgliteClient, testDb };
+}
+
+export async function clearAllTestTables(testDb: PgliteTestDb): Promise<void> {
+	await testDb.delete(schema.flow);
+	await testDb.delete(schema.data);
+	await testDb.delete(schema.serviceProvider);
+	await testDb.delete(schema.organization);
+	await testDb.delete(schema.service);
+	await testDb.delete(schema.device);
+}

--- a/api/src/ws.ts
+++ b/api/src/ws.ts
@@ -4,12 +4,15 @@ type WSServer = typeof Server;
 type WSError = typeof IRPCError;
 export type WSParams = typeof IRPCMethodParams;
 
-const apiPort = process.env.API_PORT;
-if (!apiPort) {
-	throw new Error("API_PORT environment variable is not set");
-}
-const PORT: number = parseInt(apiPort, 10);
 const HOST: string = "0.0.0.0";
+
+function getListenPort(): number {
+	const apiPort = process.env.API_PORT;
+	if (!apiPort) {
+		throw new Error("API_PORT environment variable is not set");
+	}
+	return parseInt(apiPort, 10);
+}
 
 // Custom emit function that sends proper JSON-RPC 2.0 notifications
 // rpc-websockets uses non-standard format: { notification: name, params }
@@ -35,8 +38,9 @@ function emitJsonRpc(server: WSServer, eventName: string, params: unknown) {
 function initServer(
 	authHandler: (params: WSParams) => Promise<boolean>,
 ): Promise<WSServer> {
+	const port = getListenPort();
 	return new Promise<WSServer>((resolve, reject) => {
-		const server = new Server({ host: HOST, port: PORT });
+		const server = new Server({ host: HOST, port });
 
 		server.on("listening", () => resolve(server));
 		server.on("error", (error: WSError) => reject(error));
@@ -46,7 +50,7 @@ function initServer(
 		await server.event("dataUpdated");
 		await server.event("flowUpdated");
 
-		console.info(`WS server listening at ${HOST}:${PORT}`);
+		console.info(`WS server listening at ${HOST}:${port}`);
 		return server;
 	});
 }

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -326,34 +326,42 @@ final class WebSocketE2ETests: E2ETestBase {
         scrollView.tap()
         Thread.sleep(forTimeInterval: 0.5)
 
-        // Price field (optional)
-        if let priceTextField = findElementWithScroll(
+        // Price field (required for regression coverage)
+        guard let priceTextField = findElementWithScroll(
             identifiers: ["textField_{price}"],
             containsAny: ["price"],
             in: scrollView
-        ), let priceField = tapAndGetEditableField(container: priceTextField) {
-            clearAndType(field: priceField, text: "99")
-            let priceValue = priceField.value as? String ?? ""
-            XCTAssertTrue(priceValue.contains("99"), "Price field should contain typed value, got: '\(priceValue)'")
-            scrollView.tap()
-            Thread.sleep(forTimeInterval: 0.5)
-        } else {
-            print("Skipping price field edit: no matching editable field found")
+        ) else {
+            XCTFail("Price field should exist (textField_{price} or accessibility containing 'price')")
+            return
         }
+        guard let priceField = tapAndGetEditableField(container: priceTextField) else {
+            XCTFail("Failed to get editable price field")
+            return
+        }
+        clearAndType(field: priceField, text: "99")
+        let priceValue = priceField.value as? String ?? ""
+        XCTAssertTrue(priceValue.contains("99"), "Price field should contain typed value, got: '\(priceValue)'")
+        scrollView.tap()
+        Thread.sleep(forTimeInterval: 0.5)
 
-        // Width field (optional)
-        if let widthTextField = findElementWithScroll(
+        // Width field (required for regression coverage)
+        guard let widthTextField = findElementWithScroll(
             identifiers: ["textField_{width}"],
             containsAny: ["width"],
             in: scrollView
-        ), let widthField = tapAndGetEditableField(container: widthTextField) {
-            clearAndType(field: widthField, text: "50")
-            let widthValue = widthField.value as? String ?? ""
-            XCTAssertTrue(widthValue.contains("50"), "Width field should contain typed value, got: '\(widthValue)'")
-            scrollView.tap()
-        } else {
-            print("Skipping width field edit: no matching editable field found")
+        ) else {
+            XCTFail("Width field should exist (textField_{width} or accessibility containing 'width')")
+            return
         }
+        guard let widthField = tapAndGetEditableField(container: widthTextField) else {
+            XCTFail("Failed to get editable width field")
+            return
+        }
+        clearAndType(field: widthField, text: "50")
+        let widthValue = widthField.value as? String ?? ""
+        XCTAssertTrue(widthValue.contains("50"), "Width field should contain typed value, got: '\(widthValue)'")
+        scrollView.tap()
 
         let backButton = app.navigationBars.buttons.firstMatch
         XCTAssertTrue(backButton.waitForExistence(timeout: 5), "Back button should exist")
@@ -447,5 +455,39 @@ final class WebSocketE2ETests: E2ETestBase {
         pages[0] = homePage
         flowData["pages"] = pages
         return flowData
+    }
+}
+
+// MARK: - Error / unreachable API
+
+/// Verifies the app surfaces a connection failure when the API is not reachable.
+final class E2EErrorStateTests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        // Unlikely to accept WebSocket handshakes in CI / simulator.
+        app.launchEnvironment["API_HOST"] = "127.0.0.1:59998"
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+        try super.tearDownWithError()
+    }
+
+    func testUnreachableAPIShowsErrorState() throws {
+        let errorState = app.otherElements["errorState"]
+        XCTAssertTrue(
+            errorState.waitForExistence(timeout: 30),
+            "errorState should appear when API_HOST is unreachable"
+        )
+        let failedMessage = app.staticTexts["Failed to load flows"]
+        XCTAssertTrue(
+            failedMessage.waitForExistence(timeout: 5),
+            "User-visible copy should mention failed flow load"
+        )
     }
 }

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -76,6 +76,9 @@
 		73EDC87F2B8F387500304DD8 /* EVYButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDC87E2B8F387500304DD8 /* EVYButton.swift */; };
 		73F1A0012F30B00100000001 /* e2e.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F1A0002F30B00100000001 /* e2e.swift */; };
 		74A100012F32000100000001 /* EVYInterpreterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100042F32000100000001 /* EVYInterpreterTests.swift */; };
+		74A100112F32000100000001 /* ContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100142F32000100000001 /* ContentViewTests.swift */; };
+		74A100122F32000100000001 /* EVYWebsocketNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100152F32000100000001 /* EVYWebsocketNotificationTests.swift */; };
+		74A100132F32000100000001 /* EVYActionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100162F32000100000001 /* EVYActionRunnerTests.swift */; };
 		73F2A0012F30B00200000001 /* SDUIEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F2A0112F30B00200000001 /* SDUIEnums.swift */; };
 		73F2A0022F30B00200000001 /* SDUIShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F2A0122F30B00200000001 /* SDUIShapes.swift */; };
 		73F2A0032F30B00200000001 /* SDUIRowPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F2A0132F30B00200000001 /* SDUIRowPayloads.swift */; };
@@ -170,6 +173,9 @@
 		73F1A0002F30B00100000001 /* e2e.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = e2e.swift; sourceTree = "<group>"; };
 		73F1A0052F30B00100000001 /* evyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = evyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		74A100042F32000100000001 /* EVYInterpreterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYInterpreterTests.swift; sourceTree = "<group>"; };
+		74A100142F32000100000001 /* ContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewTests.swift; sourceTree = "<group>"; };
+		74A100152F32000100000001 /* EVYWebsocketNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYWebsocketNotificationTests.swift; sourceTree = "<group>"; };
+		74A100162F32000100000001 /* EVYActionRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYActionRunnerTests.swift; sourceTree = "<group>"; };
 		74A100052F32000100000001 /* evyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = evyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73F2A0112F30B00200000001 /* SDUIEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDUIEnums.swift; sourceTree = "<group>"; };
 		73F2A0122F30B00200000001 /* SDUIShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDUIShapes.swift; sourceTree = "<group>"; };
@@ -431,7 +437,10 @@
 		74A100072F32000100000001 /* evyTests */ = {
 			isa = PBXGroup;
 			children = (
+				74A100162F32000100000001 /* EVYActionRunnerTests.swift */,
+				74A100142F32000100000001 /* ContentViewTests.swift */,
 				74A100042F32000100000001 /* EVYInterpreterTests.swift */,
+				74A100152F32000100000001 /* EVYWebsocketNotificationTests.swift */,
 			);
 			path = evyTests;
 			sourceTree = "<group>";
@@ -669,7 +678,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				74A100132F32000100000001 /* EVYActionRunnerTests.swift in Sources */,
+				74A100112F32000100000001 /* ContentViewTests.swift in Sources */,
 				74A100012F32000100000001 /* EVYInterpreterTests.swift in Sources */,
+				74A100122F32000100000001 /* EVYWebsocketNotificationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/evyTests/ContentViewTests.swift
+++ b/ios/evyTests/ContentViewTests.swift
@@ -16,7 +16,7 @@ final class ContentViewTests: XCTestCase {
         let keysToDelete = ContentView.createKeysToDelete(
             whenLeaving: "home-flow",
             flows: flows,
-            activeDraftKeys: ["item"]
+            activeDraftKeys: Set(["item"]),
         )
 
         XCTAssertEqual(keysToDelete, [])
@@ -28,10 +28,10 @@ final class ContentViewTests: XCTestCase {
         let keysToDelete = ContentView.createKeysToDelete(
             whenLeaving: "create-flow",
             flows: flows,
-            activeDraftKeys: ["item"]
+            activeDraftKeys: Set(["item"]),
         )
 
-        XCTAssertEqual(keysToDelete, ["item"])
+        XCTAssertEqual(keysToDelete, Set(["item"]))
     }
 
     private func makeFlows() throws -> [SDUI_Flow] {

--- a/ios/evyTests/EVYActionRunnerTests.swift
+++ b/ios/evyTests/EVYActionRunnerTests.swift
@@ -1,0 +1,91 @@
+//
+//  EVYActionRunnerTests.swift
+//  evyTests
+//
+
+import XCTest
+@testable import evy
+
+@MainActor
+final class EVYActionRunnerTests: XCTestCase {
+    func testEmptyActionsDoesNotNavigate() {
+        var navigateCount = 0
+        EVYActionRunner.run(actions: []) { _ in navigateCount += 1 }
+        XCTAssertEqual(navigateCount, 0)
+    }
+
+    func testCloseAction() {
+        var received: NavOperation?
+        let action = SDUI_RowAction(condition: "", true: "{close}", false: "")
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        XCTAssertEqual(received, .close)
+    }
+
+    func testCreateAction() {
+        var received: NavOperation?
+        let action = SDUI_RowAction(condition: "", true: "{create(item)}", false: "")
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        XCTAssertEqual(received, .create("item"))
+    }
+
+    func testNavigateWithBraceFunction() {
+        var received: NavOperation?
+        let action = SDUI_RowAction(
+            condition: "",
+            true: "{navigate(flow-1,page-2)}",
+            false: "",
+        )
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        guard case let .navigate(route) = received else {
+            XCTFail("Expected navigate, got \(String(describing: received))")
+            return
+        }
+        XCTAssertEqual(route.flowId, "flow-1")
+        XCTAssertEqual(route.pageId, "page-2")
+    }
+
+    func testNavigateColonFormat() {
+        var received: NavOperation?
+        let action = SDUI_RowAction(
+            condition: "",
+            true: "navigate:flowX:pageY",
+            false: "",
+        )
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        guard case let .navigate(route) = received else {
+            XCTFail("Expected navigate")
+            return
+        }
+        XCTAssertEqual(route.flowId, "flowX")
+        XCTAssertEqual(route.pageId, "pageY")
+    }
+
+    func testHighlightRequiredFormatsFieldLabel() {
+        var received: NavOperation?
+        let action = SDUI_RowAction(
+            condition: "",
+            true: "{highlight_required(unit_price)}",
+            false: "",
+        )
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        guard case let .highlightRequired(label) = received else {
+            XCTFail("Expected highlightRequired")
+            return
+        }
+        XCTAssertTrue(label.contains("unit") || label.contains("Unit"))
+    }
+
+    func testUnsupportedFunctionPostsErrorNotification() {
+        let expectation = expectation(
+            forNotification: Notification.Name.evyErrorOccurred,
+            object: nil,
+        )
+        let action = SDUI_RowAction(
+            condition: "",
+            true: "{notARealEvyFunction()}",
+            false: "",
+        )
+        EVYActionRunner.run(actions: [action]) { _ in }
+        wait(for: [expectation], timeout: 2)
+    }
+}

--- a/ios/evyTests/EVYWebsocketNotificationTests.swift
+++ b/ios/evyTests/EVYWebsocketNotificationTests.swift
@@ -1,0 +1,63 @@
+//
+//  EVYWebsocketNotificationTests.swift
+//  evyTests
+//
+//  Contract tests for JSON-RPC notification payloads (matches API emitJsonRpc / iOS client).
+//
+
+import XCTest
+@testable import evy
+
+final class EVYWebsocketNotificationTests: XCTestCase {
+    func testFlowUpdatedPayloadDecodesAsExpectedShape() throws {
+        let jsonString = """
+        {"id":"flow-row-id","createdAt":"2024-01-19T12:00:00.000Z","updatedAt":"2024-01-19T12:00:00.000Z","data":{"id":"f1","name":"Hello","pages":[]}}
+        """
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let top = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        )
+        XCTAssertEqual(top["id"] as? String, "flow-row-id")
+        XCTAssertNotNil(top["createdAt"])
+        XCTAssertNotNil(top["updatedAt"])
+        let inner = try XCTUnwrap(top["data"] as? [String: Any])
+        XCTAssertEqual(inner["id"] as? String, "f1")
+        XCTAssertEqual(inner["name"] as? String, "Hello")
+        let pages = try XCTUnwrap(inner["pages"] as? [Any])
+        XCTAssertEqual(pages.count, 0)
+    }
+
+    func testDataUpdatedPayloadDecodesAsExpectedShape() throws {
+        let jsonString = """
+        {"id":"data-row-id","namespace":"evy","resource":"item","createdAt":"2024-01-19T12:00:00.000Z","updatedAt":"2024-01-19T12:00:00.000Z","data":{"title":"x","n":1}}
+        """
+        let data = try XCTUnwrap(jsonString.data(using: .utf8))
+        let top = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+        )
+        XCTAssertEqual(top["id"] as? String, "data-row-id")
+        let payload = try XCTUnwrap(top["data"] as? [String: Any])
+        XCTAssertEqual(payload["title"] as? String, "x")
+        XCTAssertEqual(payload["n"] as? Int, 1)
+    }
+
+    func testEVYRPCErrorDescriptions() {
+        XCTAssertEqual(
+            EVYRPCError.loginError.errorDescription,
+            "Authentication failed",
+        )
+        XCTAssertTrue(
+            (EVYRPCError.connectionError("oops").errorDescription ?? "").contains(
+                "oops",
+            ),
+        )
+        XCTAssertEqual(
+            EVYRPCError.rpcError(code: 1, message: "bad").errorDescription,
+            "bad",
+        )
+        XCTAssertEqual(
+            EVYRPCError.subscriptionError("sub").errorDescription,
+            "Subscription error: sub",
+        )
+    }
+}

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -225,12 +225,10 @@ function NavBar() {
 
 export function App() {
 	const { flows, loading } = useFlows();
-	const usingInjectedTestFlows = Boolean(window.__TEST_FLOWS__);
+	const testFlows = window.__TEST_FLOWS__;
+	const initialFlows = testFlows ?? flows;
 
-	// Use test flows if available (for testing), otherwise use fetched flows
-	const initialFlows = window.__TEST_FLOWS__ ?? flows;
-
-	if (loading && !usingInjectedTestFlows) {
+	if (loading && !testFlows) {
 		return (
 			<div className="evy-h-screen evy-flex evy-items-center evy-justify-center evy-bg-gray-light">
 				<div className="evy-text-gray-dark evy-text-lg">Loading flows...</div>
@@ -247,10 +245,7 @@ export function App() {
 	}
 
 	return (
-		<AppProvider
-			initialFlows={initialFlows}
-			syncWithApi={!usingInjectedTestFlows}
-		>
+		<AppProvider initialFlows={initialFlows} syncWithApi={!testFlows}>
 			<div className="evy-h-screen evy-overflow-hidden evy-flex evy-flex-col">
 				<NavBar />
 				<div className="evy-flex evy-flex-1 evy-min-h-0 evy-overflow-hidden evy-bg-gray-light">

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { AppState } from "../../types/actions";
+import type { Row } from "../../types/row";
+
+function MockTextBase() {
+	return null;
+}
+Object.defineProperty(MockTextBase, "name", { value: "TextRow" });
+const mockTextWithConfig = MockTextBase as typeof MockTextBase & {
+	config: Row["config"];
+};
+mockTextWithConfig.config = {
+	type: "Text",
+	actions: [],
+	view: {
+		content: { title: "", text: "" },
+		max_lines: "",
+	},
+} as Row["config"];
+
+mock.module("../../rows/baseRows", () => ({
+	baseRows: [mockTextWithConfig],
+}));
+
+const { pageReducer } = await import("./pageReducer");
+
+function textRow(id: string, text = "hello"): Row {
+	return {
+		id,
+		row: null,
+		config: {
+			type: "Text",
+			actions: [],
+			view: {
+				content: { title: "T", text },
+				max_lines: "",
+			},
+		} as Row["config"],
+	};
+}
+
+function initialState(overrides: Partial<AppState> = {}): AppState {
+	return {
+		flows: [
+			{
+				id: "flow-1",
+				name: "Flow",
+				pages: [
+					{
+						id: "page-1",
+						title: "Page",
+						rows: [textRow("row-1")],
+					},
+					{
+						id: "page-2",
+						title: "Second",
+						rows: [textRow("row-2")],
+					},
+				],
+			},
+		],
+		activeFlowId: "flow-1",
+		activePageId: "page-1",
+		focusMode: false,
+		configStack: [],
+		...overrides,
+	};
+}
+
+describe("pageReducer", () => {
+	it("SET_ACTIVE_FLOW clears row and config stack", () => {
+		const state = initialState({ activeRowId: "row-1", configStack: ["x"] });
+		const next = pageReducer(state, {
+			type: "SET_ACTIVE_FLOW",
+			flowId: "flow-1",
+		});
+		expect(next.activeFlowId).toBe("flow-1");
+		expect(next.activeRowId).toBeUndefined();
+		expect(next.configStack).toEqual([]);
+	});
+
+	it("CREATE_FLOW ignores empty name", () => {
+		const state = initialState();
+		const next = pageReducer(state, { type: "CREATE_FLOW", name: "   " });
+		expect(next.flows.length).toBe(state.flows.length);
+	});
+
+	it("CREATE_FLOW appends flow and selects it", () => {
+		const state = initialState();
+		const next = pageReducer(state, { type: "CREATE_FLOW", name: "New Flow" });
+		expect(next.flows.length).toBe(2);
+		expect(next.activeFlowId).toBe(next.flows[1].id);
+		expect(next.flows[1].name).toBe("New Flow");
+		expect(next.activePageId).toBe(next.flows[1].pages[0]?.id);
+	});
+
+	it("ADD_PAGE appends page to active flow", () => {
+		const state = initialState();
+		const next = pageReducer(state, { type: "ADD_PAGE" });
+		expect(next.flows[0].pages.length).toBe(3);
+		expect(next.activePageId).toBe(next.flows[0].pages[2]?.id);
+	});
+
+	it("ADD_ROW inserts TextRow from palette", () => {
+		const state = initialState();
+		const newId = "new-text-id";
+		const next = pageReducer(state, {
+			type: "ADD_ROW",
+			newRowId: newId,
+			oldRowId: "TextRow",
+			destinationPageId: "page-1",
+			destinationIndex: 0,
+		});
+		expect(next.flows[0].pages[0].rows[0].id).toBe(newId);
+		expect(next.activeRowId).toBe(newId);
+	});
+
+	it("UPDATE_ROW sets config content field", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "UPDATE_ROW",
+			rowId: "row-1",
+			configId: "text",
+			configValue: "updated",
+		});
+		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
+		expect(row?.config.view.content.text).toBe("updated");
+	});
+
+	it("UPDATE_ROW splits comma-separated value into array", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "UPDATE_ROW",
+			rowId: "row-1",
+			configId: "text",
+			configValue: "a,b",
+		});
+		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
+		expect(row?.config.view.content.text).toEqual(["a", "b"]);
+	});
+
+	it("SET_ACTIVE_ROW updates selection", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "SET_ACTIVE_ROW",
+			pageId: "page-1",
+			rowId: "row-1",
+		});
+		expect(next.activeRowId).toBe("row-1");
+		expect(next.activePageId).toBe("page-1");
+	});
+
+	it("SET_ACTIVE_PAGE clears row selection", () => {
+		const state = initialState({ activeRowId: "row-1" });
+		const next = pageReducer(state, {
+			type: "SET_ACTIVE_PAGE",
+			pageId: "page-2",
+		});
+		expect(next.activePageId).toBe("page-2");
+		expect(next.activeRowId).toBeUndefined();
+	});
+
+	it("CLEAR_ACTIVE_SELECTION resets selection and focus", () => {
+		const state = initialState({
+			activeRowId: "row-1",
+			activePageId: "page-1",
+			focusMode: true,
+			secondarySheetRowId: "s",
+			configStack: ["a"],
+		});
+		const next = pageReducer(state, { type: "CLEAR_ACTIVE_SELECTION" });
+		expect(next.activeRowId).toBeUndefined();
+		expect(next.activePageId).toBeUndefined();
+		expect(next.focusMode).toBe(false);
+		expect(next.secondarySheetRowId).toBeUndefined();
+		expect(next.configStack).toEqual([]);
+	});
+
+	it("REMOVE_PAGE keeps at least one page", () => {
+		const singlePageState: AppState = {
+			...initialState(),
+			flows: [
+				{
+					id: "flow-1",
+					name: "F",
+					pages: [{ id: "only", title: "P", rows: [] }],
+				},
+			],
+			activePageId: "only",
+		};
+		const next = pageReducer(singlePageState, {
+			type: "REMOVE_PAGE",
+			pageId: "only",
+		});
+		expect(next.flows[0].pages.length).toBe(1);
+	});
+
+	it("REMOVE_PAGE selects another page when active removed", () => {
+		const state = initialState({ activePageId: "page-1" });
+		const next = pageReducer(state, { type: "REMOVE_PAGE", pageId: "page-1" });
+		expect(next.flows[0].pages.length).toBe(1);
+		expect(next.activePageId).toBe("page-2");
+		expect(next.activeRowId).toBeUndefined();
+	});
+
+	it("UPDATE_PAGE_TITLE", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "UPDATE_PAGE_TITLE",
+			pageId: "page-1",
+			title: "Renamed",
+		});
+		expect(next.flows[0].pages[0].title).toBe("Renamed");
+	});
+
+	it("MOVE_ROW moves row between pages", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "MOVE_ROW",
+			rowId: "row-1",
+			originPageId: "page-1",
+			destinationPageId: "page-2",
+			destinationIndex: 0,
+		});
+		expect(next.flows[0].pages[0].rows.some((r) => r.id === "row-1")).toBe(
+			false,
+		);
+		expect(next.flows[0].pages[1].rows.some((r) => r.id === "row-1")).toBe(
+			true,
+		);
+	});
+
+	it("REMOVE_ROW removes row from page", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "REMOVE_ROW",
+			pageId: "page-1",
+			rowId: "row-1",
+		});
+		expect(next.flows[0].pages[0].rows.length).toBe(0);
+	});
+
+	it("UPDATE_ROW_ACTIONS sets actions", () => {
+		const state = initialState();
+		const actions = [{ condition: "", true: "close", false: "" }];
+		const next = pageReducer(state, {
+			type: "UPDATE_ROW_ACTIONS",
+			rowId: "row-1",
+			actions,
+		});
+		const row = next.flows[0].pages[0].rows[0];
+		expect(row.config.actions).toEqual(actions);
+	});
+
+	it("TOGGLE_FOCUS_MODE", () => {
+		const state = initialState({ focusMode: false, activePageId: undefined });
+		const on = pageReducer(state, { type: "TOGGLE_FOCUS_MODE" });
+		expect(on.focusMode).toBe(true);
+		expect(on.activePageId).toBe("page-1");
+		const off = pageReducer(on, { type: "TOGGLE_FOCUS_MODE" });
+		expect(off.focusMode).toBe(false);
+	});
+
+	it("PUSH_CONFIG_STACK and NAVIGATE_BREADCRUMB", () => {
+		const state = initialState({ configStack: [] });
+		const pushed = pageReducer(state, {
+			type: "PUSH_CONFIG_STACK",
+			parentRowId: "row-1",
+			childRowId: "row-2",
+		});
+		expect(pushed.configStack.length).toBeGreaterThan(0);
+		const popped = pageReducer(pushed, {
+			type: "NAVIGATE_BREADCRUMB",
+			configStackLength: 0,
+		});
+		expect(popped.configStack).toEqual([]);
+	});
+
+	it("OPEN_SECONDARY_SHEET and CLOSE_SECONDARY_SHEET", () => {
+		const state = initialState();
+		const open = pageReducer(state, {
+			type: "OPEN_SECONDARY_SHEET",
+			sheetRowId: "sheet-1",
+		});
+		expect(open.secondarySheetRowId).toBe("sheet-1");
+		const closed = pageReducer(open, { type: "CLOSE_SECONDARY_SHEET" });
+		expect(closed.secondarySheetRowId).toBeUndefined();
+		expect(closed.configStack).toEqual([]);
+	});
+});

--- a/web/app/utils/evyInterpreter.test.ts
+++ b/web/app/utils/evyInterpreter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseText } from "./evyInterpreter";
+
+describe("parseText", () => {
+	it("returns empty string for empty input", () => {
+		expect(parseText("")).toBe("");
+	});
+
+	it("resolves count function placeholder", () => {
+		expect(parseText("Items: {count()}")).toContain("1");
+	});
+
+	it("resolves formatCurrency placeholder", () => {
+		expect(parseText("{formatCurrency()}")).toContain("$");
+	});
+
+	it("replaces property path with friendly label", () => {
+		const out = parseText("Hello {item.title}");
+		expect(out).not.toContain("{item.title}");
+		expect(out.length).toBeGreaterThan(5);
+	});
+
+	it("strips comparison expressions in braces", () => {
+		expect(parseText("x {a > 5} y")).toBe("x  y");
+	});
+
+	it("passes through plain text", () => {
+		expect(parseText("no placeholders")).toBe("no placeholders");
+	});
+
+	it("converts escaped newline sequences", () => {
+		expect(parseText("a\\nb")).toBe("a\nb");
+	});
+
+	it("chains multiple replacements", () => {
+		const out = parseText("{count()} and {length()}");
+		expect(out).toMatch(/1/);
+	});
+});

--- a/web/app/utils/rowTree.test.ts
+++ b/web/app/utils/rowTree.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "bun:test";
+
+import type { SDUI_Page } from "../types/flow";
+import type { Row } from "../types/row";
+import {
+	findContainerById,
+	findContainerOfRow,
+	findRowInPages,
+	getRowsRecursive,
+	insertRowIntoTree,
+	removeRowFromTree,
+	resolveDestinationPageFromRawPageId,
+	resolveSourcePageIdFromRaw,
+	updateRowInTree,
+} from "./rowTree";
+
+function makeRow(
+	id: string,
+	contentOverrides: Partial<Row["config"]["view"]["content"]> = {},
+): Row {
+	return {
+		id,
+		row: null,
+		config: {
+			type: "Text",
+			actions: [],
+			view: {
+				content: {
+					title: "",
+					text: "",
+					...contentOverrides,
+				} as Row["config"]["view"]["content"],
+			},
+		} as Row["config"],
+	};
+}
+
+function page(id: string, rows: Row[]): SDUI_Page {
+	return { id, title: "T", rows };
+}
+
+describe("resolveSourcePageIdFromRaw", () => {
+	it("returns raw id when not a secondary pseudo page", () => {
+		const pages = [page("p1", [makeRow("a")])];
+		expect(resolveSourcePageIdFromRaw("p1", pages)).toBe("p1");
+	});
+
+	it("maps secondary:hostRowId to the page that contains the host row at top level", () => {
+		const host = makeRow("sheet-host");
+		const pages = [page("main", [host])];
+		expect(resolveSourcePageIdFromRaw("secondary:sheet-host", pages)).toBe(
+			"main",
+		);
+	});
+
+	it("falls back to raw id when host row is not found", () => {
+		const pages = [page("main", [makeRow("a")])];
+		expect(resolveSourcePageIdFromRaw("secondary:missing", pages)).toBe(
+			"secondary:missing",
+		);
+	});
+});
+
+describe("resolveDestinationPageFromRawPageId", () => {
+	it("resolves normal page id", () => {
+		const pages = [page("p1", [])];
+		const res = resolveDestinationPageFromRawPageId("p1", pages);
+		expect(res.page.id).toBe("p1");
+		expect(res.resolvedPageId).toBe("p1");
+		expect(res.secondarySheetRowId).toBeUndefined();
+	});
+
+	it("resolves secondary sheet to host page", () => {
+		const host = makeRow("host");
+		const pages = [page("p1", [host])];
+		const res = resolveDestinationPageFromRawPageId("secondary:host", pages);
+		expect(res.page.id).toBe("p1");
+		expect(res.resolvedPageId).toBe("p1");
+		expect(res.secondarySheetRowId).toBe("host");
+	});
+});
+
+describe("findRowInPages", () => {
+	it("finds top-level row", () => {
+		const a = makeRow("a");
+		expect(findRowInPages("a", [page("p", [a])])).toBe(a);
+	});
+
+	it("finds nested child", () => {
+		const inner = makeRow("inner");
+		const outer = makeRow("outer", { child: inner });
+		expect(findRowInPages("inner", [page("p", [outer])])).toBe(inner);
+	});
+
+	it("finds nested children", () => {
+		const c = makeRow("c");
+		const outer = makeRow("outer", { children: [c] });
+		expect(findRowInPages("c", [page("p", [outer])])).toBe(c);
+	});
+
+	it("returns undefined when missing", () => {
+		expect(findRowInPages("x", [page("p", [makeRow("a")])])).toBeUndefined();
+	});
+});
+
+describe("getRowsRecursive", () => {
+	it("includes self and descendants", () => {
+		const leaf = makeRow("leaf");
+		const mid = makeRow("mid", { children: [leaf] });
+		const root = makeRow("root", { child: mid });
+		const flat = getRowsRecursive(root).map((r) => r.id);
+		expect(flat).toEqual(["root", "mid", "leaf"]);
+	});
+});
+
+describe("findContainerOfRow", () => {
+	it("returns null for top-level row", () => {
+		const rows = [makeRow("a")];
+		expect(findContainerOfRow("a", rows)).toBeNull();
+	});
+
+	it("finds child container", () => {
+		const inner = makeRow("inner");
+		const outer = makeRow("outer", { child: inner });
+		const res = findContainerOfRow("inner", [outer]);
+		expect(res?.container.id).toBe("outer");
+		expect(res?.type).toBe("child");
+	});
+
+	it("finds children container", () => {
+		const c = makeRow("c");
+		const outer = makeRow("outer", { children: [c] });
+		const res = findContainerOfRow("c", [outer]);
+		expect(res?.container.id).toBe("outer");
+		expect(res?.type).toBe("children");
+	});
+});
+
+describe("findContainerById", () => {
+	it("finds row that is a child slot container", () => {
+		const inner = makeRow("inner");
+		const outer = makeRow("outer", { child: inner });
+		const res = findContainerById("outer", [outer]);
+		expect(res?.type).toBe("child");
+	});
+
+	it("finds row that is a children slot container", () => {
+		const c = makeRow("c");
+		const outer = makeRow("outer", { children: [c] });
+		const res = findContainerById("outer", [outer]);
+		expect(res?.type).toBe("children");
+	});
+});
+
+describe("removeRowFromTree", () => {
+	it("removes top-level row", () => {
+		const a = makeRow("a");
+		const b = makeRow("b");
+		const out = removeRowFromTree([a, b], "a");
+		expect(out.map((r) => r.id)).toEqual(["b"]);
+	});
+
+	it("removes nested child", () => {
+		const inner = makeRow("inner");
+		const outer = makeRow("outer", { child: inner });
+		const out = removeRowFromTree([outer], "inner");
+		expect(out[0].config.view.content.child).toBeUndefined();
+	});
+
+	it("removes from children array", () => {
+		const c1 = makeRow("c1");
+		const c2 = makeRow("c2");
+		const outer = makeRow("outer", { children: [c1, c2] });
+		const out = removeRowFromTree([outer], "c1");
+		const children = out[0].config.view.content.children ?? [];
+		expect(children.map((r) => r.id)).toEqual(["c2"]);
+	});
+});
+
+describe("insertRowIntoTree", () => {
+	it("inserts at page root index", () => {
+		const a = makeRow("a");
+		const b = makeRow("b");
+		const res = insertRowIntoTree([a], b, 0);
+		expect(res.inserted).toBe(true);
+		expect(res.rows.map((r) => r.id)).toEqual(["b", "a"]);
+	});
+
+	it("inserts into child container", () => {
+		const outer = makeRow("outer", {});
+		const insert = makeRow("new");
+		const res = insertRowIntoTree([outer], insert, 0, {
+			rowId: "outer",
+			type: "child",
+		});
+		expect(res.inserted).toBe(true);
+		expect(res.rows[0].config.view.content.child?.id).toBe("new");
+	});
+
+	it("inserts into children container at index", () => {
+		const outer = makeRow("outer", { children: [] });
+		const insert = makeRow("new");
+		const res = insertRowIntoTree([outer], insert, 0, {
+			rowId: "outer",
+			type: "children",
+		});
+		expect(res.inserted).toBe(true);
+		expect(res.rows[0].config.view.content.children?.map((r) => r.id)).toEqual([
+			"new",
+		]);
+	});
+
+	it("returns inserted false when container missing", () => {
+		const res = insertRowIntoTree([makeRow("a")], makeRow("b"), 0, {
+			rowId: "nope",
+			type: "children",
+		});
+		expect(res.inserted).toBe(false);
+	});
+});
+
+describe("updateRowInTree", () => {
+	it("updates matching row at depth", () => {
+		const inner = makeRow("inner", { text: "old" });
+		const outer = makeRow("outer", { child: inner });
+		const out = updateRowInTree([outer], "inner", (row) =>
+			makeRow(row.id, { ...row.config.view.content, text: "new" }),
+		);
+		expect(out[0].config.view.content.child?.config.view.content.text).toBe(
+			"new",
+		);
+	});
+});

--- a/web/e2e/e2e.spec.ts
+++ b/web/e2e/e2e.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import type { SDUI_Flow, SDUI_Row } from "evy-types";
+import { Client } from "rpc-websockets";
 
 import {
 	createNewFlowThroughPicker,
@@ -14,6 +16,114 @@ import {
 	SELECTORS,
 	waitForAppLoaded,
 } from "../tests/utils";
+
+const API_POLL_TIMEOUT_MS = 10_000;
+
+function getApiUrl(): string {
+	const apiUrl = process.env.API_URL;
+	if (!apiUrl) {
+		throw new Error("API_URL is not set");
+	}
+	return apiUrl;
+}
+
+async function withApiClient<T>(
+	run: (client: Client) => Promise<T>,
+): Promise<T> {
+	const client = new Client(getApiUrl());
+
+	await new Promise<void>((resolve, reject) => {
+		const onOpen = () => {
+			client.removeListener("error", onError);
+			resolve();
+		};
+		const onError = (error: Error) => {
+			client.removeListener("open", onOpen);
+			reject(error);
+		};
+
+		client.on("open", onOpen);
+		client.on("error", onError);
+	});
+
+	try {
+		return await run(client);
+	} finally {
+		client.close();
+	}
+}
+
+async function getFlowsFromApi(): Promise<SDUI_Flow[]> {
+	return withApiClient(async (client) => {
+		const result = await client.call("get", {
+			namespace: "evy",
+			resource: "sdui",
+		});
+		return result as SDUI_Flow[];
+	});
+}
+
+function rowContainsTitle(row: SDUI_Row, title: string): boolean {
+	if (row.view.content.title === title) {
+		return true;
+	}
+
+	if (
+		row.view.content.child &&
+		rowContainsTitle(row.view.content.child, title)
+	) {
+		return true;
+	}
+
+	return (row.view.content.children ?? []).some((child) =>
+		rowContainsTitle(child, title),
+	);
+}
+
+function flowContainsRowTitle(
+	flow: SDUI_Flow | undefined,
+	title: string,
+): boolean {
+	if (!flow) {
+		return false;
+	}
+
+	return flow.pages.some((page) => {
+		if (page.footer && rowContainsTitle(page.footer, title)) {
+			return true;
+		}
+
+		return page.rows.some((row) => rowContainsTitle(row, title));
+	});
+}
+
+async function expectFlowPersisted(flowName: string): Promise<void> {
+	await expect
+		.poll(
+			async () => {
+				const flows = await getFlowsFromApi();
+				return flows.some((flow) => flow.name === flowName);
+			},
+			{ timeout: API_POLL_TIMEOUT_MS },
+		)
+		.toBe(true);
+}
+
+async function expectFlowRowTitlePersisted(
+	flowName: string,
+	rowTitle: string,
+): Promise<void> {
+	await expect
+		.poll(
+			async () => {
+				const flows = await getFlowsFromApi();
+				const flow = flows.find((candidate) => candidate.name === flowName);
+				return flowContainsRowTitle(flow, rowTitle);
+			},
+			{ timeout: API_POLL_TIMEOUT_MS },
+		)
+		.toBe(true);
+}
 
 /**
  * E2E Integration tests that run against real API services.
@@ -37,6 +147,7 @@ test.describe("Web E2E Integration Tests", () => {
 		await expect(page.locator(SELECTORS.flowSelector)).toContainText(
 			uniqueFlowName,
 		);
+		await expectFlowPersisted(uniqueFlowName);
 
 		await page.reload();
 		await waitForAppLoaded(page);
@@ -68,6 +179,7 @@ test.describe("Web E2E Integration Tests", () => {
 		await expect(
 			getFirstPage(page).getByText("Info row title", { exact: true }),
 		).toBeVisible();
+		await expectFlowRowTitlePersisted(uniqueFlowName, "Info row title");
 
 		await page.reload();
 		await waitForAppLoaded(page);
@@ -98,6 +210,7 @@ test.describe("Web E2E Integration Tests", () => {
 		await titleInput.clear();
 		await titleInput.fill(uniqueTitle);
 		await expect(titleInput).toHaveValue(uniqueTitle);
+		await expectFlowRowTitlePersisted("View Item", uniqueTitle);
 
 		await page.reload();
 		await waitForAppLoaded(page);

--- a/web/e2e/e2e.spec.ts
+++ b/web/e2e/e2e.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect } from "@playwright/test";
 
 import {
+	createNewFlowThroughPicker,
 	ensureSidePanelsExpanded,
 	getConfigPanel,
 	getErrorState,
 	getFirstPage,
 	getLoadingState,
+	getPageContent,
+	getSidebarRow,
+	openFlowPicker,
 	selectFlowByLabel,
 	SELECTORS,
 	waitForAppLoaded,
@@ -20,6 +24,60 @@ import {
 test.describe.configure({ mode: "serial" });
 
 test.describe("Web E2E Integration Tests", () => {
+	test("should persist a newly created flow after page refresh", async ({
+		page,
+	}) => {
+		const uniqueFlowName = `E2E New Flow ${Date.now()}`;
+
+		await page.goto("/");
+		await waitForAppLoaded(page);
+
+		await createNewFlowThroughPicker(page, uniqueFlowName);
+		await expect(page.getByTestId("create-flow-dialog")).not.toBeVisible();
+		await expect(page.locator(SELECTORS.flowSelector)).toContainText(
+			uniqueFlowName,
+		);
+
+		await page.reload();
+		await waitForAppLoaded(page);
+
+		await openFlowPicker(page);
+		await expect(
+			page
+				.getByRole("listbox", { name: "Active flow" })
+				.getByRole("option", { name: uniqueFlowName, exact: true }),
+		).toBeVisible();
+	});
+
+	test("should persist a sidebar row dropped on canvas after page refresh", async ({
+		page,
+	}) => {
+		const uniqueFlowName = `E2E Row Flow ${Date.now()}`;
+
+		await page.goto("/");
+		await waitForAppLoaded(page);
+
+		await createNewFlowThroughPicker(page, uniqueFlowName);
+		await expect(page.getByTestId("create-flow-dialog")).not.toBeVisible();
+
+		await ensureSidePanelsExpanded(page);
+		const sidebarRow = await getSidebarRow(page, "Info row title");
+		const pageContent = getPageContent(page);
+		await sidebarRow.dragTo(pageContent);
+
+		await expect(
+			getFirstPage(page).getByText("Info row title", { exact: true }),
+		).toBeVisible();
+
+		await page.reload();
+		await waitForAppLoaded(page);
+		await selectFlowByLabel(page, uniqueFlowName);
+
+		await expect(
+			getFirstPage(page).getByText("Info row title", { exact: true }),
+		).toBeVisible();
+	});
+
 	test("should persist SDUI edits after page refresh", async ({ page }) => {
 		const uniqueTitle = `E2E Test Title ${Date.now()}`;
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
 		"lint": "bunx biome check .",
 		"format": "bunx biome format --write .",
 		"setup": "mkdir -p dist/.well-known/appspecific && cp app/index.html dist/ && cp -r app/public/* dist/ && cp app/globals.css dist/ && cp -r app/.well-known/* dist/.well-known/",
-		"test": "bun --env-file=../.env run playwright test tests/",
+		"test": "bun test --define __API_URL__='\"ws://127.0.0.1:1\"' app/ && bun --env-file=../.env run playwright test tests/",
+		"test:unit": "bun test --define __API_URL__='\"ws://127.0.0.1:1\"' app/",
 		"test:e2e": "bun --env-file=../.env run playwright test e2e/",
 		"test:setup": "bunx playwright install --with-deps chromium"
 	},

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
 	getConfigPanel,
 	initFullFlows,
-	initTestFlows,
+	openAppWithTestFlows,
 	popoverSelect,
 } from "./utils";
 
@@ -10,7 +10,7 @@ test.describe("Row configuration", () => {
 	test("should drill into child row configuration from the configuration panel", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -39,8 +39,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const containerRow = page
 			.getByText("Container Row", { exact: true })
 			.first();
@@ -73,7 +71,7 @@ test.describe("Row configuration", () => {
 	test("should display row configurations in configuration panel", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -91,7 +89,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
 		const infoRow = page.getByText("Test Info Row", { exact: true }).first();
 		await expect(infoRow).toBeVisible();
 		await infoRow.click();
@@ -111,7 +108,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should display and edit action items via popup", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -129,8 +126,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Test Button", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -162,7 +157,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should add another action item via popup", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -180,8 +175,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Nav Button", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -211,7 +204,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should edit conditions via popup", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -241,8 +234,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Submit", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -292,7 +283,7 @@ test.describe("Row configuration", () => {
 	test("should show empty actions state for rows without actions", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -310,8 +301,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const infoRow = page.getByText("No Action Row", { exact: true }).first();
 		await expect(infoRow).toBeVisible();
 		await infoRow.click();
@@ -453,7 +442,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should use number operand in condition", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -478,8 +467,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Check", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -510,7 +497,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should use function operand in condition", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -535,8 +522,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Validate", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -567,7 +552,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should add multiple OR conditions and remove one", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -604,8 +589,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Send", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -641,7 +624,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should discard changes when cancel is clicked", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -654,8 +637,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Cancel Test", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -682,7 +663,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should remove an action from summary card", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -700,8 +681,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Multi Action", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -808,7 +787,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should display flat OR conditions in summary", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -828,8 +807,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("OR Test", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -847,7 +824,7 @@ test.describe("Row configuration", () => {
 	test("should display nested AND/OR conditions in summary", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -867,8 +844,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Nested Test", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -886,7 +861,7 @@ test.describe("Row configuration", () => {
 	});
 
 	test("should toggle OR to AND in condition editor", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -929,8 +904,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Toggle Test", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -963,7 +936,7 @@ test.describe("Row configuration", () => {
 	test("should add nested group and round-trip nested condition", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -1006,8 +979,6 @@ test.describe("Row configuration", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const buttonRow = page.getByText("Nest Test", { exact: true }).first();
 		await expect(buttonRow).toBeVisible();
 		await buttonRow.click();
@@ -1072,15 +1043,13 @@ test.describe("Row configuration", () => {
 			};
 		}
 
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_deep",
 				title: "Deep Page",
 				rows: [deepNest(12)],
 			},
 		]);
-		await page.goto("/");
-
 		const configPanel = getConfigPanel(page);
 
 		await page.getByText("Nest level 12", { exact: true }).first().click();

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -7,7 +7,7 @@ import {
 	getPageRow,
 	getRowsPanel,
 	getSidebarRow,
-	initTestFlows,
+	openAppWithTestFlows,
 	setupTwoEmptyTestPages,
 } from "./utils";
 
@@ -75,7 +75,7 @@ test.describe("Drag & Drop UX", () => {
 	test("should drag a row from a child container to another page", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Page 1",
@@ -106,8 +106,6 @@ test.describe("Drag & Drop UX", () => {
 			},
 			{ id: "step_2", title: "Page 2", rows: [] },
 		]);
-		await page.goto("/");
-
 		const firstPage = getFirstPage(page);
 		const secondPage = page.locator(SELECTORS.phoneContainer).nth(1);
 		const secondPageContent = getPageContent(page, 1);
@@ -126,7 +124,7 @@ test.describe("Drag & Drop UX", () => {
 	test("should drag a row from a children container to another page", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Page 1",
@@ -158,8 +156,6 @@ test.describe("Drag & Drop UX", () => {
 			},
 			{ id: "step_2", title: "Page 2", rows: [] },
 		]);
-		await page.goto("/");
-
 		const firstPage = getFirstPage(page);
 		const secondPage = page.locator(SELECTORS.phoneContainer).nth(1);
 		const secondPageContent = getPageContent(page, 1);

--- a/web/tests/flowSelector.spec.ts
+++ b/web/tests/flowSelector.spec.ts
@@ -3,6 +3,7 @@ import type { SDUI_Flow as ServerFlow } from "evy-types";
 import type { Page } from "@playwright/test";
 
 import {
+	createNewFlowThroughPicker,
 	openAppWithFullFlows,
 	openFlowPicker,
 	selectFlowByLabel,
@@ -111,16 +112,7 @@ test.describe("Flow Selector", () => {
 		page,
 	}) => {
 		await openWithFlows(page, singleFlow);
-		await openFlowPicker(page);
-
-		await page
-			.getByRole("option", { name: "Create new flow", exact: true })
-			.click();
-
-		await expect(page.getByTestId("create-flow-dialog")).toBeVisible();
-
-		await page.getByLabel("Flow name").fill("Brand New Flow");
-		await page.getByRole("button", { name: "Create", exact: true }).click();
+		await createNewFlowThroughPicker(page, "Brand New Flow");
 
 		await expect(page.getByTestId("create-flow-dialog")).not.toBeVisible();
 

--- a/web/tests/hover.spec.ts
+++ b/web/tests/hover.spec.ts
@@ -6,16 +6,16 @@ import {
 	getPageContent,
 	getPageRow,
 	getSidebarRow,
-	initTestFlows,
+	openAppWithTestFlows,
 } from "./utils";
 
 test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show drop indicator when hovering over a row on a page", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const sidebarRow = await getSidebarRow(page, "Info row title");
 		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
@@ -51,9 +51,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show drop indicator inside a container when hovering over container children", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
@@ -99,9 +99,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	});
 
 	test("should show only one drop indicator at a time", async ({ page }) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
@@ -150,9 +150,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show indicator for innermost row when hovering over nested containers", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
@@ -208,9 +208,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	});
 
 	test("should clear indicator when drag ends", async ({ page }) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const pageContent = getPageContent(page);
 
 		const targetSidebarRow = await getSidebarRow(page, "Text row title");
@@ -240,9 +240,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	});
 
 	test("should switch indicator when moving between rows", async ({ page }) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
@@ -295,9 +295,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show indicator at top edge when hovering near top of row", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const pageContent = getPageContent(page);
 
 		const targetSidebarRow = await getSidebarRow(page, "Text row title");
@@ -327,9 +327,9 @@ test.describe("Drag Hover Indicator Behavior", () => {
 	test("should show indicator at bottom edge when hovering near bottom of row", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Page 1", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Page 1", rows: [] },
+		]);
 		const pageContent = getPageContent(page);
 
 		const targetSidebarRow = await getSidebarRow(page, "Text row title");

--- a/web/tests/offline.spec.ts
+++ b/web/tests/offline.spec.ts
@@ -5,7 +5,8 @@ import {
 	getFirstPage,
 	getPageContent,
 	getSidebarRow,
-	initTestFlows,
+	installConstructorFailingWebSocket,
+	openAppWithTestFlows,
 	waitForAppLoaded,
 } from "./utils";
 
@@ -116,15 +117,10 @@ test.describe("Offline and connection resilience", () => {
 	test("injected flows keep builder UI usable without a successful API read path", async ({
 		page,
 	}) => {
-		await page.addInitScript(() => {
-			window.WebSocket = class {
-				constructor() {
-					throw new Error("No WebSocket in this test");
-				}
-			} as unknown as typeof WebSocket;
-		});
-		await initTestFlows(page, [{ id: "p1", title: "Offline page", rows: [] }]);
-		await page.goto("/");
+		await installConstructorFailingWebSocket(page, "No WebSocket in this test");
+		await openAppWithTestFlows(page, [
+			{ id: "p1", title: "Offline page", rows: [] },
+		]);
 		await ensureSidePanelsExpanded(page);
 
 		await expect(page.getByText("Rows", { exact: true }).first()).toBeVisible();

--- a/web/tests/offline.spec.ts
+++ b/web/tests/offline.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "@playwright/test";
 import {
-	createNewFlowThroughPicker,
 	ensureSidePanelsExpanded,
 	getConfigPanel,
 	getFirstPage,
@@ -15,30 +14,90 @@ test.describe("Offline and connection resilience", () => {
 		page,
 	}) => {
 		await page.addInitScript(() => {
-			const OriginalWebSocket = window.WebSocket;
-			window.WebSocket = class extends OriginalWebSocket {
-				override send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+			const mockFlow = {
+				id: "offline-flow",
+				name: "Offline Save Fail",
+				pages: [{ id: "offline-page", title: "Page", rows: [] }],
+			};
+
+			class MockWebSocket extends EventTarget {
+				static CONNECTING = 0;
+				static OPEN = 1;
+				static CLOSING = 2;
+				static CLOSED = 3;
+
+				readyState = MockWebSocket.CONNECTING;
+				onopen: ((event: Event) => void) | null = null;
+				onmessage: ((event: MessageEvent<string>) => void) | null = null;
+				onclose: ((event: CloseEvent) => void) | null = null;
+				onerror: ((event: Event) => void) | null = null;
+
+				constructor(_url: string | URL) {
+					super();
+					queueMicrotask(() => {
+						this.readyState = MockWebSocket.OPEN;
+						const openEvent = new Event("open");
+						this.dispatchEvent(openEvent);
+						this.onopen?.(openEvent);
+					});
+				}
+
+				send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
 					const asText =
 						typeof data === "string"
 							? data
 							: data instanceof ArrayBuffer
 								? new TextDecoder().decode(data)
 								: null;
-					if (asText !== null && /"method"\s*:\s*"upsert"/.test(asText)) {
+					if (!asText) return;
+
+					const request = JSON.parse(asText) as {
+						id?: number | string;
+						method?: string;
+					};
+
+					if (request.method === "rpc.login") {
+						this.respond({ jsonrpc: "2.0", id: request.id, result: true });
+						return;
+					}
+
+					if (request.method === "get") {
+						this.respond({
+							jsonrpc: "2.0",
+							id: request.id,
+							result: [mockFlow],
+						});
+						return;
+					}
+
+					if (request.method === "upsert") {
 						throw new Error("Simulated WebSocket send failure");
 					}
-					super.send(data);
 				}
-			} as unknown as typeof WebSocket;
-		});
 
-		const uniqueFlowName = `Offline Save Fail ${Date.now()}`;
+				close() {
+					this.readyState = MockWebSocket.CLOSED;
+					const closeEvent = new CloseEvent("close");
+					this.dispatchEvent(closeEvent);
+					this.onclose?.(closeEvent);
+				}
+
+				private respond(payload: unknown) {
+					queueMicrotask(() => {
+						const messageEvent = new MessageEvent("message", {
+							data: JSON.stringify(payload),
+						});
+						this.dispatchEvent(messageEvent);
+						this.onmessage?.(messageEvent);
+					});
+				}
+			}
+
+			window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		});
 
 		await page.goto("/");
 		await waitForAppLoaded(page);
-
-		await createNewFlowThroughPicker(page, uniqueFlowName);
-
 		await ensureSidePanelsExpanded(page);
 
 		page.once("dialog", (dialog) => {

--- a/web/tests/offline.spec.ts
+++ b/web/tests/offline.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import {
+	createNewFlowThroughPicker,
+	ensureSidePanelsExpanded,
+	getConfigPanel,
+	getFirstPage,
+	getPageContent,
+	getSidebarRow,
+	initTestFlows,
+	waitForAppLoaded,
+} from "./utils";
+
+test.describe("Offline and connection resilience", () => {
+	test("shows browser alert when upsert cannot be sent over WebSocket", async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			const OriginalWebSocket = window.WebSocket;
+			window.WebSocket = class extends OriginalWebSocket {
+				override send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+					const asText =
+						typeof data === "string"
+							? data
+							: data instanceof ArrayBuffer
+								? new TextDecoder().decode(data)
+								: null;
+					if (asText !== null && /"method"\s*:\s*"upsert"/.test(asText)) {
+						throw new Error("Simulated WebSocket send failure");
+					}
+					super.send(data);
+				}
+			} as unknown as typeof WebSocket;
+		});
+
+		const uniqueFlowName = `Offline Save Fail ${Date.now()}`;
+
+		await page.goto("/");
+		await waitForAppLoaded(page);
+
+		await createNewFlowThroughPicker(page, uniqueFlowName);
+
+		await ensureSidePanelsExpanded(page);
+
+		page.once("dialog", (dialog) => {
+			expect(dialog.message()).toContain("Failed to save");
+			void dialog.accept();
+		});
+
+		const sidebarRow = await getSidebarRow(page, "Info row title");
+		await sidebarRow.dragTo(getPageContent(page));
+
+		await expect(
+			getFirstPage(page).getByText("Info row title", { exact: true }),
+		).toBeVisible();
+	});
+
+	test("injected flows keep builder UI usable without a successful API read path", async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			window.WebSocket = class {
+				constructor() {
+					throw new Error("No WebSocket in this test");
+				}
+			} as unknown as typeof WebSocket;
+		});
+		await initTestFlows(page, [{ id: "p1", title: "Offline page", rows: [] }]);
+		await page.goto("/");
+		await ensureSidePanelsExpanded(page);
+
+		await expect(page.getByText("Rows", { exact: true }).first()).toBeVisible();
+		await expect(getConfigPanel(page)).toBeVisible();
+		await expect(
+			getFirstPage(page).getByText("Offline page", { exact: true }),
+		).toBeVisible();
+	});
+});

--- a/web/tests/rowSelection.spec.ts
+++ b/web/tests/rowSelection.spec.ts
@@ -4,12 +4,12 @@ import {
 	getFirstPage,
 	getPageContent,
 	getSidebarRow,
-	initTestFlows,
+	openAppWithTestFlows,
 } from "./utils";
 
 test.describe("Row Selection", () => {
 	test("should select a row when clicked", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -26,10 +26,7 @@ test.describe("Row Selection", () => {
 					},
 				],
 			},
-		]);
-		await page.goto("/");
-
-		// Find and click on the first Info row
+		]); // Find and click on the first Info row
 		const firstInfoRow = page
 			.getByText("First Info Row", { exact: true })
 			.first();
@@ -50,7 +47,7 @@ test.describe("Row Selection", () => {
 	test("should update configuration panel when different row is selected", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -78,8 +75,6 @@ test.describe("Row Selection", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const configPanel = getConfigPanel(page);
 
 		// Click on first Info row
@@ -106,7 +101,7 @@ test.describe("Row Selection", () => {
 	});
 
 	test("should show only one row selected at a time", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -134,8 +129,6 @@ test.describe("Row Selection", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const configPanel = getConfigPanel(page);
 
 		// Click on first Info row
@@ -157,9 +150,9 @@ test.describe("Row Selection", () => {
 	test("should show configuration for dragged row after drop", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [{ id: "step_1", title: "Test Page", rows: [] }]);
-		await page.goto("/");
-
+		await openAppWithTestFlows(page, [
+			{ id: "step_1", title: "Test Page", rows: [] },
+		]);
 		const sidebarRow = await getSidebarRow(page, "Input row title");
 		const pageContent = getPageContent(page);
 		const firstPage = getFirstPage(page);
@@ -187,7 +180,7 @@ test.describe("Row Selection", () => {
 	test("should update row content when editing configuration", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -204,10 +197,7 @@ test.describe("Row Selection", () => {
 					},
 				],
 			},
-		]);
-		await page.goto("/");
-
-		// Click on first Info row
+		]); // Click on first Info row
 		const firstInfoRow = page
 			.getByText("First Info Row", { exact: true })
 			.first();
@@ -232,7 +222,7 @@ test.describe("Row Selection", () => {
 	test("should maintain selection when switching configuration values", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -250,8 +240,6 @@ test.describe("Row Selection", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const configPanel = getConfigPanel(page);
 
 		// Click on first Info row
@@ -277,7 +265,7 @@ test.describe("Row Selection", () => {
 
 test.describe("Row Selection with Containers", () => {
 	test("should select container row when clicked", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -306,8 +294,6 @@ test.describe("Row Selection with Containers", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const containerRow = page
 			.getByText("Container Row", { exact: true })
 			.first();
@@ -322,7 +308,7 @@ test.describe("Row Selection with Containers", () => {
 	test("should select child row inside container when clicked", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -351,8 +337,6 @@ test.describe("Row Selection with Containers", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const childRow = page.getByText("Child Info Row", { exact: true }).first();
 		await childRow.click();
 
@@ -366,7 +350,7 @@ test.describe("Row Selection with Containers", () => {
 	test("should switch selection between container and child", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Test Page",
@@ -395,8 +379,6 @@ test.describe("Row Selection with Containers", () => {
 				],
 			},
 		]);
-		await page.goto("/");
-
 		const configPanel = getConfigPanel(page);
 
 		// Select child first

--- a/web/tests/rows.spec.ts
+++ b/web/tests/rows.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { getRowsPanel, initTestFlows } from "./utils";
+import { getRowsPanel, openAppWithTestFlows } from "./utils";
 
 test.describe("EVY Rows", () => {
 	test("should display available row components in the Rows panel", async ({
 		page,
 	}) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Page 1",
@@ -23,7 +23,6 @@ test.describe("EVY Rows", () => {
 				],
 			},
 		]);
-		await page.goto("/");
 		const rowsPanel = await getRowsPanel(page);
 
 		const expectedRowTitles = [
@@ -48,14 +47,13 @@ test.describe("EVY Rows", () => {
 	});
 
 	test("should filter rows by search query", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "step_1",
 				title: "Page 1",
 				rows: [],
 			},
 		]);
-		await page.goto("/");
 		const rowsPanel = await getRowsPanel(page);
 		const searchInput = rowsPanel.getByPlaceholder("Button, Calendar, etc...");
 

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -3,7 +3,7 @@ import {
 	enterCanvasFocusModeByPageTitle,
 	getFirstPage,
 	getSecondarySheetPage,
-	initTestFlows,
+	openAppWithTestFlows,
 	openSecondarySheetChildFromConfigPanel,
 } from "./utils";
 
@@ -62,8 +62,7 @@ test.describe("Secondary Sheet Page", () => {
 	test("should open secondary page when clicking children in config panel in focus mode", async ({
 		page,
 	}) => {
-		await initTestFlows(page, sheetContainerPage);
-		await page.goto("/");
+		await openAppWithTestFlows(page, sheetContainerPage);
 
 		await enterCanvasFocusModeByPageTitle(page, "Page 1");
 
@@ -78,8 +77,7 @@ test.describe("Secondary Sheet Page", () => {
 	test("should show SheetContainer children in secondary page", async ({
 		page,
 	}) => {
-		await initTestFlows(page, sheetContainerPage);
-		await page.goto("/");
+		await openAppWithTestFlows(page, sheetContainerPage);
 
 		await enterCanvasFocusModeByPageTitle(page, "Page 1");
 
@@ -93,8 +91,7 @@ test.describe("Secondary Sheet Page", () => {
 	});
 
 	test("should show sheet title in secondary page", async ({ page }) => {
-		await initTestFlows(page, sheetContainerPage);
-		await page.goto("/");
+		await openAppWithTestFlows(page, sheetContainerPage);
 
 		await enterCanvasFocusModeByPageTitle(page, "Page 1");
 
@@ -108,8 +105,7 @@ test.describe("Secondary Sheet Page", () => {
 	test("should dismiss secondary page when navigating back in config panel", async ({
 		page,
 	}) => {
-		await initTestFlows(page, sheetContainerPage);
-		await page.goto("/");
+		await openAppWithTestFlows(page, sheetContainerPage);
 
 		await enterCanvasFocusModeByPageTitle(page, "Page 1");
 
@@ -126,8 +122,7 @@ test.describe("Secondary Sheet Page", () => {
 	test("should dismiss secondary page when clicking canvas background", async ({
 		page,
 	}) => {
-		await initTestFlows(page, sheetContainerPage);
-		await page.goto("/");
+		await openAppWithTestFlows(page, sheetContainerPage);
 
 		await enterCanvasFocusModeByPageTitle(page, "Page 1");
 
@@ -154,8 +149,7 @@ test.describe("Secondary Sheet Page", () => {
 	test("should auto-enter focus mode when clicking SheetContainer children outside focus mode", async ({
 		page,
 	}) => {
-		await initTestFlows(page, sheetContainerPage);
-		await page.goto("/");
+		await openAppWithTestFlows(page, sheetContainerPage);
 
 		await getFirstPage(page).click();
 		await openSecondarySheetChildFromConfigPanel(page);

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -131,9 +131,12 @@ export async function createNewFlowThroughPicker(
 	await page
 		.getByRole("option", { name: "Create new flow", exact: true })
 		.click();
-	await expect(page.getByTestId("create-flow-dialog")).toBeVisible();
-	await page.getByLabel("Flow name").fill(flowName);
-	await page.getByRole("button", { name: "Create", exact: true }).click();
+	const createFlowDialog = page.getByTestId("create-flow-dialog");
+	await expect(createFlowDialog).toBeVisible();
+	await createFlowDialog.getByLabel("Flow name").fill(flowName);
+	await createFlowDialog
+		.getByRole("button", { name: "Create", exact: true })
+		.click();
 }
 
 export async function selectFlowByLabel(

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -122,6 +122,20 @@ export async function openFlowPicker(page: Page): Promise<void> {
 	await page.locator(SELECTORS.flowSelector).click();
 }
 
+/** Opens the flow picker, chooses "Create new flow", fills the name, and submits. */
+export async function createNewFlowThroughPicker(
+	page: Page,
+	flowName: string,
+): Promise<void> {
+	await openFlowPicker(page);
+	await page
+		.getByRole("option", { name: "Create new flow", exact: true })
+		.click();
+	await expect(page.getByTestId("create-flow-dialog")).toBeVisible();
+	await page.getByLabel("Flow name").fill(flowName);
+	await page.getByRole("button", { name: "Create", exact: true }).click();
+}
+
 export async function selectFlowByLabel(
 	page: Page,
 	label: string,

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -231,6 +231,29 @@ export async function openAppWithFullFlows(
 	await page.goto("/");
 }
 
+/** Injects simplified page fixtures via `initTestFlows` and opens the app. */
+export async function openAppWithTestFlows(
+	page: Page,
+	pages: Parameters<typeof initTestFlows>[1],
+): Promise<void> {
+	await initTestFlows(page, pages);
+	await page.goto("/");
+}
+
+/** `addInitScript` that replaces `WebSocket` with a class whose constructor throws. */
+export async function installConstructorFailingWebSocket(
+	page: Page,
+	message: string,
+): Promise<void> {
+	await page.addInitScript((msg: string) => {
+		window.WebSocket = class {
+			constructor() {
+				throw new Error(msg);
+			}
+		} as unknown as typeof WebSocket;
+	}, message);
+}
+
 export async function popoverSelect(
 	page: Page,
 	trigger: Locator,
@@ -274,11 +297,10 @@ export async function openSecondarySheetChildFromConfigPanel(
 
 /** Common drag-and-drop tests fixture: two empty pages. */
 export async function setupTwoEmptyTestPages(page: Page): Promise<void> {
-	await initTestFlows(page, [
+	await openAppWithTestFlows(page, [
 		{ id: "step_1", title: "Page 1", rows: [] },
 		{ id: "step_2", title: "Page 2", rows: [] },
 	]);
-	await page.goto("/");
 }
 
 /** Asserts `laterSubstring` appears after `earlierSubstring` in page canvas draggable rows. */

--- a/web/tests/websocket.spec.ts
+++ b/web/tests/websocket.spec.ts
@@ -3,8 +3,11 @@ import {
 	ensureSidePanelsExpanded,
 	getConfigPanel,
 	getErrorState,
+	getFirstPage,
 	getLoadingState,
-	initTestFlows,
+	getRowsPanel,
+	installConstructorFailingWebSocket,
+	openAppWithTestFlows,
 } from "./utils";
 
 test.describe("WebSocket Connection States", () => {
@@ -23,13 +26,10 @@ test.describe("WebSocket Connection States", () => {
 	});
 
 	test("should display error state when connection fails", async ({ page }) => {
-		await page.addInitScript(() => {
-			window.WebSocket = class {
-				constructor() {
-					throw new Error("Forced WebSocket failure for test");
-				}
-			} as unknown as typeof WebSocket;
-		});
+		await installConstructorFailingWebSocket(
+			page,
+			"Forced WebSocket failure for test",
+		);
 
 		await page.goto("/");
 
@@ -41,34 +41,32 @@ test.describe("WebSocket Connection States", () => {
 		page,
 	}) => {
 		// Inject test flows to simulate successful connection
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "test-flow-1",
 				title: "Test Page",
 				rows: [],
 			},
 		]);
-		await page.goto("/");
 		await ensureSidePanelsExpanded(page);
 
 		await expect(getLoadingState(page)).not.toBeVisible();
 		await expect(getErrorState(page)).not.toBeVisible();
 
-		const rowsPanel = page.getByText("Rows", { exact: true });
+		const rowsPanel = await getRowsPanel(page);
 		await expect(rowsPanel).toBeVisible();
 
 		await expect(getConfigPanel(page)).toBeVisible();
 	});
 
 	test("should display logo in header when app loads", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "test-flow-1",
 				title: "Test Page",
 				rows: [],
 			},
 		]);
-		await page.goto("/");
 
 		// Logo should be visible in the header
 		const logo = page.locator('img[alt="EVY"]');
@@ -76,25 +74,21 @@ test.describe("WebSocket Connection States", () => {
 	});
 
 	test("should have correct page structure after loading", async ({ page }) => {
-		await initTestFlows(page, [
+		await openAppWithTestFlows(page, [
 			{
 				id: "test-flow-1",
 				title: "Test Page",
 				rows: [],
 			},
 		]);
-		await page.goto("/");
 		await ensureSidePanelsExpanded(page);
 
 		// Check the three main panels are present
-		// Left panel: Rows
-		const rowsPanel = page.getByText("Rows", { exact: true }).first();
+		const rowsPanel = await getRowsPanel(page);
 		await expect(rowsPanel).toBeVisible();
 
 		await expect(getConfigPanel(page)).toBeVisible();
 
-		// Center: Phone mockup(s)
-		const phoneContainer = page.locator("[data-canvas-page-frame]");
-		await expect(phoneContainer.first()).toBeVisible();
+		await expect(getFirstPage(page)).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

Adds and consolidates automated tests and test helpers across the **API** (Bun), **web** builder (Bun unit tests + Playwright), and **iOS** (XCTest + UI tests), and includes related platform and CI changes already present on this branch.

## API

- Unit tests for real-time **`flowUpdated` / `dataUpdated`** notifications after upsert, with PGlite-backed DB mocking.
- **`wsTestHelpers`**: shared helpers for free port, WebSocket open/notification waits, login/subscribe, and PGlite test DB setup; `waitForClientOpen` removes listeners after settle.
- **`bootstrap.test.ts`**: `initServer` wiring (events, protected upsert) and **`assertApiReadable`** cases with injected `get`.
- **`readiness.ts`**: testable readiness probe with CLI gated behind `import.meta.main`.
- **`ws.ts`**: read **`API_PORT`** lazily so tests can bind ephemeral ports.
- E2E **`reconnect.test.ts`**: reconnect + subscribe client receives **`flowUpdated`** payload matching upsert result.
- **`data.test.ts`**: less boilerplate via **`expectToBeDATA_Flow`**, trimmed redundant comments.

## Web

- Unit tests: **`rowTree`**, **`evyInterpreter.parseText`**, **`pageReducer`** (major actions).
- Playwright: additional E2E flows (create flow, drag row, persistence); **`offline.spec.ts`** (injected flows without WS; save failure via WebSocket send shim).
- **`createNewFlowThroughPicker`** in test utils to dedupe “create new flow” UI steps.
- **`App.tsx`**: single read of **`window.__TEST_FLOWS__`**, **`syncWithApi={!testFlows}`** (no shipped test-only upsert/sync flags).
- **`test` / `test:unit`** scripts run Bun tests under `app/` with a dummy **`__API_URL__`**.

## iOS

- Stricter create-form E2E (price/width fields **`XCTFail`** if missing).
- Unit tests: **`EVYWebsocketNotificationTests`**, **`EVYActionRunnerTests`**, **`ContentViewTests`**; test target entries in **`project.pbxproj`**.

## Testing

- `cd api && bun --env-file=../.env test src/`
- `cd web && bun run test:unit && bun run lint`
- Full stack E2E: `./run-e2e.sh --skip-ios` (or `--no-docker` per README) when validating end-to-end.

JIRA:

Figma:

Stream:
