### PR TITLE
[BUG] Fix sheet child auto-focus from config panel

### DIFF
--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -43,9 +43,13 @@ jobs:
               if: steps.setup.outputs.has-changes == 'true'
               run: bun run build
 
-            - name: Run Tests
+            - name: Run unit tests
               if: steps.setup.outputs.has-changes == 'true'
-              run: bun run test
+              run: bun run test:unit
+
+            - name: Run integration tests
+              if: steps.setup.outputs.has-changes == 'true'
+              run: bun run test:integration
 
             - name: Upload test results
               uses: actions/upload-artifact@v7

--- a/web/app/components/PopoverSelect.tsx
+++ b/web/app/components/PopoverSelect.tsx
@@ -186,11 +186,12 @@ export function PopoverSelect({
 				onMouseEnter={handleTriggerPointerEnter}
 				onMouseLeave={handleTriggerPointerLeave}
 				onClick={() => {
-					if (isOpen) {
-						close();
-					} else {
-						open();
-					}
+					// With hover-open, pointer hover may open the menu before click; toggling
+					// closed here races with Playwright (hover → click) and flakes tests.
+					if (openOnHover) {
+						if (!isOpen) open();
+					} else if (isOpen) close();
+					else open();
 				}}
 				className={
 					variant === "breadcrumb"

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -40,6 +40,24 @@ function textRow(id: string, text = "hello"): Row {
 	};
 }
 
+function sheetRow(id: string, child: Row, children: Row[] = []): Row {
+	return {
+		id,
+		row: null,
+		config: {
+			type: "SheetContainer",
+			actions: [],
+			view: {
+				content: {
+					title: "Sheet",
+					child,
+					children,
+				},
+			},
+		} as Row["config"],
+	};
+}
+
 function initialState(overrides: Partial<AppState> = {}): AppState {
 	return {
 		flows: [
@@ -275,6 +293,41 @@ describe("pageReducer", () => {
 			configStackLength: 0,
 		});
 		expect(popped.configStack).toEqual([]);
+	});
+
+	it("PUSH_CONFIG_STACK auto-enters focus mode for SheetContainer child", () => {
+		const state = initialState({
+			activePageId: undefined,
+			focusMode: false,
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [
+								sheetRow("sheet-1", textRow("sheet-child"), [
+									textRow("sheet-list-child"),
+								]),
+							],
+						},
+					],
+				},
+			],
+		});
+
+		const next = pageReducer(state, {
+			type: "PUSH_CONFIG_STACK",
+			parentRowId: "sheet-1",
+			childRowId: "sheet-child",
+		});
+
+		expect(next.focusMode).toBe(true);
+		expect(next.activePageId).toBe("page-1");
+		expect(next.secondarySheetRowId).toBe("sheet-1");
+		expect(next.configStack).toEqual(["sheet-child"]);
 	});
 
 	it("OPEN_SECONDARY_SHEET and CLOSE_SECONDARY_SHEET", () => {

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -367,17 +367,18 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			const parentRow = findRowInPages(action.parentRowId, flow.pages);
 			if (!parentRow) return state;
 
-			const isSheetChild =
+			const isSheetNestedRow =
 				parentRow.config.type === "SheetContainer" &&
-				parentRow.config.view.content.children?.some(
-					(c) => c.id === action.childRowId,
-				);
+				(parentRow.config.view.content.child?.id === action.childRowId ||
+					parentRow.config.view.content.children?.some(
+						(c) => c.id === action.childRowId,
+					));
 
 			let nextFocusMode = state.focusMode;
 			let nextActivePageId = state.activePageId;
 			let nextSecondarySheetRowId = state.secondarySheetRowId;
 
-			if (isSheetChild) {
+			if (isSheetNestedRow) {
 				if (!state.focusMode) {
 					nextFocusMode = true;
 					nextActivePageId = state.activePageId ?? flow.pages[0]?.id;

--- a/web/package.json
+++ b/web/package.json
@@ -11,8 +11,9 @@
 		"lint": "bunx biome check .",
 		"format": "bunx biome format --write .",
 		"setup": "mkdir -p dist/.well-known/appspecific && cp app/index.html dist/ && cp -r app/public/* dist/ && cp app/globals.css dist/ && cp -r app/.well-known/* dist/.well-known/",
-		"test": "bun test --define __API_URL__='\"ws://127.0.0.1:1\"' app/ && bun --env-file=../.env run playwright test tests/",
+		"test": "bun run test:unit && bun run test:integration",
 		"test:unit": "bun test --define __API_URL__='\"ws://127.0.0.1:1\"' app/",
+		"test:integration": "bun --env-file=../.env run playwright test tests/",
 		"test:e2e": "bun --env-file=../.env run playwright test e2e/",
 		"test:setup": "bunx playwright install --with-deps chromium"
 	},

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -2,14 +2,21 @@ import { defineConfig } from "@playwright/test";
 
 if (!process.env.WEB_PORT) throw new Error("WEB_PORT is required");
 const url = `http://localhost:${process.env.WEB_PORT}`;
+const timeout = 30_000;
 
 export default defineConfig({
-	timeout: 10000,
-	retries: process.env.CI ? 1 : 0,
+	timeout,
+	expect: { timeout },
+	retries: 1,
 	fullyParallel: true,
 	workers: 4,
 	reporter: [["line"], ["html", { open: "never" }]],
-	use: { baseURL: url },
+	use: {
+		baseURL: url,
+		screenshot: "only-on-failure",
+		trace: "on-first-retry",
+		video: "retain-on-failure",
+	},
 	projects: [
 		{
 			name: "chromium",
@@ -22,6 +29,7 @@ export default defineConfig({
 	webServer: {
 		command: "bun run dev",
 		url,
-		reuseExistingServer: true, // If server not reachable at url it will still do command
+		reuseExistingServer: true,
+		timeout,
 	},
 });

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -238,16 +238,15 @@ test.describe("Drag & Drop UX", () => {
 
 		const firstRow = pageRows.first();
 		const secondRow = pageRows.nth(1);
+		await secondRow.scrollIntoViewIfNeeded();
 		const secondRowBox = await secondRow.boundingBox();
-
-		if (secondRowBox) {
-			await firstRow.dragTo(secondRow, {
-				targetPosition: {
-					x: secondRowBox.width / 2,
-					y: secondRowBox.height - 5,
-				},
-			});
-		}
+		expect(secondRowBox).not.toBeNull();
+		await firstRow.dragTo(secondRow, {
+			targetPosition: {
+				x: secondRowBox.width / 2,
+				y: secondRowBox.height - 5,
+			},
+		});
 
 		await expect(
 			firstPage.getByText("Text row title", { exact: true }),
@@ -265,7 +264,6 @@ test.describe("Drag & Drop UX", () => {
 
 	test("should drag a row from position 2 to 1 on a page", async ({ page }) => {
 		await setupTwoEmptyTestPages(page);
-		await page.waitForLoadState("networkidle");
 		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
@@ -298,13 +296,12 @@ test.describe("Drag & Drop UX", () => {
 
 		const firstRow = pageRows.first();
 		const secondRow = pageRows.nth(1);
+		await firstRow.scrollIntoViewIfNeeded();
 		const firstRowBox = await firstRow.boundingBox();
-
-		if (firstRowBox) {
-			await secondRow.dragTo(firstRow, {
-				targetPosition: { x: firstRowBox.width / 2, y: 5 },
-			});
-		}
+		expect(firstRowBox).not.toBeNull();
+		await secondRow.dragTo(firstRow, {
+			targetPosition: { x: firstRowBox.width / 2, y: 5 },
+		});
 
 		await expect(
 			firstPage.getByText("Text row title", { exact: true }),
@@ -403,24 +400,23 @@ test.describe("Drag & Drop UX", () => {
 		).toBeVisible();
 
 		const pageRow = getPageRow(page, "Info row title");
+		await pageRow.scrollIntoViewIfNeeded();
 		const rowBox = await pageRow.boundingBox();
+		expect(rowBox).not.toBeNull();
+		await page.mouse.move(
+			rowBox.x + rowBox.width / 2,
+			rowBox.y + rowBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			rowBox.x + rowBox.width / 2 + 10,
+			rowBox.y + rowBox.height / 2 + 10,
+		);
 
-		if (rowBox) {
-			await page.mouse.move(
-				rowBox.x + rowBox.width / 2,
-				rowBox.y + rowBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				rowBox.x + rowBox.width / 2 + 10,
-				rowBox.y + rowBox.height / 2 + 10,
-			);
+		const deleteOverlay = page.getByRole("button", { name: "Delete" });
+		await expect(deleteOverlay).toBeVisible();
 
-			const deleteOverlay = page.getByRole("button", { name: "Delete" });
-			await expect(deleteOverlay).toBeVisible();
-
-			await page.mouse.up();
-		}
+		await page.mouse.up();
 	});
 
 	test("should drag and drop every single row type into a page", async ({

--- a/web/tests/hover.spec.ts
+++ b/web/tests/hover.spec.ts
@@ -29,23 +29,25 @@ test.describe("Drag Hover Indicator Behavior", () => {
 
 		const pageRow = getPageRow(page, "Text row title");
 
+		await sidebarRow.scrollIntoViewIfNeeded();
+		await pageRow.scrollIntoViewIfNeeded();
 		const sidebarBox = await sidebarRow.boundingBox();
 		const rowBox = await pageRow.boundingBox();
+		expect(sidebarBox).not.toBeNull();
+		expect(rowBox).not.toBeNull();
 
-		if (sidebarBox && rowBox) {
-			await page.mouse.move(
-				sidebarBox.x + sidebarBox.width / 2,
-				sidebarBox.y + sidebarBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				rowBox.x + rowBox.width / 2,
-				rowBox.y + rowBox.height / 2,
-			);
+		await page.mouse.move(
+			sidebarBox.x + sidebarBox.width / 2,
+			sidebarBox.y + sidebarBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			rowBox.x + rowBox.width / 2,
+			rowBox.y + rowBox.height / 2,
+		);
 
-			await expect(getDropIndicator(page)).toBeVisible();
-			await page.mouse.up();
-		}
+		await expect(getDropIndicator(page)).toBeVisible();
+		await page.mouse.up();
 	});
 
 	test("should show drop indicator inside a container when hovering over container children", async ({
@@ -79,23 +81,25 @@ test.describe("Drag Hover Indicator Behavior", () => {
 		const dragRow = await getSidebarRow(page, "Text row title");
 		const childRow = getPageRow(page, "Info row title");
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await childRow.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const childBox = await childRow.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(childBox).not.toBeNull();
 
-		if (dragBox && childBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				childBox.x + childBox.width / 2,
-				childBox.y + childBox.height / 2,
-			);
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			childBox.x + childBox.width / 2,
+			childBox.y + childBox.height / 2,
+		);
 
-			await expect(getDropIndicator(page).first()).toBeVisible();
-			await page.mouse.up();
-		}
+		await expect(getDropIndicator(page).first()).toBeVisible();
+		await page.mouse.up();
 	});
 
 	test("should show only one drop indicator at a time", async ({ page }) => {
@@ -118,33 +122,37 @@ test.describe("Drag Hover Indicator Behavior", () => {
 		const firstPageRow = pageRows.first();
 		const secondPageRow = pageRows.nth(1);
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await firstPageRow.scrollIntoViewIfNeeded();
+		await secondPageRow.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const firstRowBox = await firstPageRow.boundingBox();
 		const secondRowBox = await secondPageRow.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(firstRowBox).not.toBeNull();
+		expect(secondRowBox).not.toBeNull();
 
-		if (dragBox && firstRowBox && secondRowBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
 
-			await page.mouse.move(
-				firstRowBox.x + firstRowBox.width / 2,
-				firstRowBox.y + firstRowBox.height / 2,
-			);
+		await page.mouse.move(
+			firstRowBox.x + firstRowBox.width / 2,
+			firstRowBox.y + firstRowBox.height / 2,
+		);
 
-			const indicators = getDropIndicator(page);
-			expect(await indicators.count()).toBe(1);
+		const indicators = getDropIndicator(page);
+		expect(await indicators.count()).toBe(1);
 
-			await page.mouse.move(
-				secondRowBox.x + secondRowBox.width / 2,
-				secondRowBox.y + secondRowBox.height / 2,
-			);
+		await page.mouse.move(
+			secondRowBox.x + secondRowBox.width / 2,
+			secondRowBox.y + secondRowBox.height / 2,
+		);
 
-			expect(await indicators.count()).toBe(1);
-			await page.mouse.up();
-		}
+		expect(await indicators.count()).toBe(1);
+		await page.mouse.up();
 	});
 
 	test("should show indicator for innermost row when hovering over nested containers", async ({
@@ -186,25 +194,27 @@ test.describe("Drag Hover Indicator Behavior", () => {
 		const dragRow = await getSidebarRow(page, "Text row title");
 		const childRowElement = getPageRow(page, "Info row title");
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await childRowElement.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const childBox = await childRowElement.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(childBox).not.toBeNull();
 
-		if (dragBox && childBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				childBox.x + childBox.width / 2,
-				childBox.y + childBox.height / 2,
-			);
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			childBox.x + childBox.width / 2,
+			childBox.y + childBox.height / 2,
+		);
 
-			await expect(getDropIndicator(page).first()).toBeVisible();
-			expect(await getDropIndicator(page).count()).toBe(1);
+		await expect(getDropIndicator(page).first()).toBeVisible();
+		expect(await getDropIndicator(page).count()).toBe(1);
 
-			await page.mouse.up();
-		}
+		await page.mouse.up();
 	});
 
 	test("should clear indicator when drag ends", async ({ page }) => {
@@ -219,24 +229,26 @@ test.describe("Drag Hover Indicator Behavior", () => {
 		const pageRow = getPageRow(page, "Text row title");
 		const dragRow = await getSidebarRow(page, "Info row title");
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await pageRow.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const rowBox = await pageRow.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(rowBox).not.toBeNull();
 
-		if (dragBox && rowBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				rowBox.x + rowBox.width / 2,
-				rowBox.y + rowBox.height / 2,
-			);
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			rowBox.x + rowBox.width / 2,
+			rowBox.y + rowBox.height / 2,
+		);
 
-			await expect(getDropIndicator(page)).toBeVisible();
-			await page.mouse.up();
-			await expect(getDropIndicator(page)).not.toBeVisible();
-		}
+		await expect(getDropIndicator(page)).toBeVisible();
+		await page.mouse.up();
+		await expect(getDropIndicator(page)).not.toBeVisible();
 	});
 
 	test("should switch indicator when moving between rows", async ({ page }) => {
@@ -261,35 +273,39 @@ test.describe("Drag Hover Indicator Behavior", () => {
 			.filter({ hasText: "Text row title" })
 			.first();
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await firstPageRow.scrollIntoViewIfNeeded();
+		await secondPageRow.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const firstRowBox = await firstPageRow.boundingBox();
 		const secondRowBox = await secondPageRow.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(firstRowBox).not.toBeNull();
+		expect(secondRowBox).not.toBeNull();
 
-		if (dragBox && firstRowBox && secondRowBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
 
-			await page.mouse.move(
-				firstRowBox.x + firstRowBox.width / 2,
-				firstRowBox.y + firstRowBox.height / 2,
-			);
+		await page.mouse.move(
+			firstRowBox.x + firstRowBox.width / 2,
+			firstRowBox.y + firstRowBox.height / 2,
+		);
 
-			const indicator = getDropIndicator(page);
-			await expect(indicator.first()).toBeVisible();
+		const indicator = getDropIndicator(page);
+		await expect(indicator.first()).toBeVisible();
 
-			await page.mouse.move(
-				secondRowBox.x + secondRowBox.width / 2,
-				secondRowBox.y + secondRowBox.height / 2,
-			);
+		await page.mouse.move(
+			secondRowBox.x + secondRowBox.width / 2,
+			secondRowBox.y + secondRowBox.height / 2,
+		);
 
-			await expect(indicator.first()).toBeVisible();
-			expect(await indicator.count()).toBe(1);
+		await expect(indicator.first()).toBeVisible();
+		expect(await indicator.count()).toBe(1);
 
-			await page.mouse.up();
-		}
+		await page.mouse.up();
 	});
 
 	test("should show indicator at top edge when hovering near top of row", async ({
@@ -306,22 +322,24 @@ test.describe("Drag Hover Indicator Behavior", () => {
 		const pageRow = getPageRow(page, "Text row title");
 		const dragRow = await getSidebarRow(page, "Info row title");
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await pageRow.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const rowBox = await pageRow.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(rowBox).not.toBeNull();
 
-		if (dragBox && rowBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(rowBox.x + rowBox.width / 2, rowBox.y + 10);
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(rowBox.x + rowBox.width / 2, rowBox.y + 10);
 
-			const topIndicator = page.locator(SELECTORS.topIndicator);
-			await expect(topIndicator.first()).toBeVisible();
+		const topIndicator = page.locator(SELECTORS.topIndicator);
+		await expect(topIndicator.first()).toBeVisible();
 
-			await page.mouse.up();
-		}
+		await page.mouse.up();
 	});
 
 	test("should show indicator at bottom edge when hovering near bottom of row", async ({
@@ -338,24 +356,26 @@ test.describe("Drag Hover Indicator Behavior", () => {
 		const pageRow = getPageRow(page, "Text row title");
 		const dragRow = await getSidebarRow(page, "Info row title");
 
+		await dragRow.scrollIntoViewIfNeeded();
+		await pageRow.scrollIntoViewIfNeeded();
 		const dragBox = await dragRow.boundingBox();
 		const rowBox = await pageRow.boundingBox();
+		expect(dragBox).not.toBeNull();
+		expect(rowBox).not.toBeNull();
 
-		if (dragBox && rowBox) {
-			await page.mouse.move(
-				dragBox.x + dragBox.width / 2,
-				dragBox.y + dragBox.height / 2,
-			);
-			await page.mouse.down();
-			await page.mouse.move(
-				rowBox.x + rowBox.width / 2,
-				rowBox.y + rowBox.height - 10,
-			);
+		await page.mouse.move(
+			dragBox.x + dragBox.width / 2,
+			dragBox.y + dragBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(
+			rowBox.x + rowBox.width / 2,
+			rowBox.y + rowBox.height - 10,
+		);
 
-			const bottomIndicator = page.locator(SELECTORS.bottomIndicator);
-			await expect(bottomIndicator.first()).toBeVisible();
+		const bottomIndicator = page.locator(SELECTORS.bottomIndicator);
+		await expect(bottomIndicator.first()).toBeVisible();
 
-			await page.mouse.up();
-		}
+		await page.mouse.up();
 	});
 });

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -133,15 +133,15 @@ test.describe("Secondary Sheet Page", () => {
 
 		// Click canvas background away from side panels (they overlay the viewport edges).
 		const canvas = page.getByTestId("canvas-viewport");
+		await canvas.scrollIntoViewIfNeeded();
 		const canvasBox = await canvas.boundingBox();
-		if (canvasBox) {
-			await canvas.click({
-				position: {
-					x: canvasBox.width / 2,
-					y: Math.min(120, canvasBox.height / 2),
-				},
-			});
-		}
+		expect(canvasBox).not.toBeNull();
+		await canvas.click({
+			position: {
+				x: canvasBox.width / 2,
+				y: Math.min(120, canvasBox.height / 2),
+			},
+		});
 
 		await expect(getSecondarySheetPage(page)).toHaveCount(0);
 	});

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -161,4 +161,22 @@ test.describe("Secondary Sheet Page", () => {
 		const secondaryPage = getSecondarySheetPage(page);
 		await expect(secondaryPage).toHaveCSS("opacity", "1");
 	});
+
+	test("should auto-enter focus mode when clicking SheetContainer child outside focus mode", async ({
+		page,
+	}) => {
+		await openAppWithTestFlows(page, sheetContainerPage);
+
+		await getFirstPage(page).click();
+		await openSecondarySheetChildFromConfigPanel(page, {
+			firstChildButtonName: "Info",
+		});
+
+		const pageBreadcrumb = page.getByRole("button", {
+			name: "Select page Page 1",
+		});
+		await expect(pageBreadcrumb).toHaveAttribute("aria-current", "page");
+		const secondaryPage = getSecondarySheetPage(page);
+		await expect(secondaryPage).toHaveCSS("opacity", "1");
+	});
 });

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -119,7 +119,11 @@ export async function waitForAppLoaded(page: Page): Promise<void> {
 }
 
 export async function openFlowPicker(page: Page): Promise<void> {
-	await page.locator(SELECTORS.flowSelector).click();
+	const trigger = page.locator(SELECTORS.flowSelector);
+	await trigger.click();
+	await expect(
+		page.getByRole("listbox", { name: "Active flow" }),
+	).toBeVisible();
 }
 
 /** Opens the flow picker, chooses "Create new flow", fills the name, and submits. */


### PR DESCRIPTION
## Summary
- handle `SheetContainer.child` the same as `SheetContainer.children` when drilling in from the configuration panel so sheet children still auto-enter focus mode
- add reducer regression coverage for the single-child sheet path
- add Playwright coverage for opening a sheet child from the configuration panel outside focus mode

## Test plan
- [x] `bun test --define __API_URL__='\"ws://127.0.0.1:1\"' app/state/reducers/pageReducer.test.ts`
- [x] `bun --env-file=../.env run playwright test tests/secondarySheet.spec.ts`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test`

JIRA: 
Figma: 
Stream video: 

Made with [Cursor](https://cursor.com)