### PR TITLE
[FEAT] Canvas dot grid morphs toward cursor

### DIFF
--- a/web/app/components/CanvasViewport.tsx
+++ b/web/app/components/CanvasViewport.tsx
@@ -3,22 +3,17 @@ import type {
 	MouseEvent as ReactMouseEvent,
 	ReactNode,
 } from "react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
+import {
+	type CursorPosition,
+	drawDotField,
+	GRID_BASE_SIZE_PX,
+} from "./canvasDotField";
 import { useCamera } from "../hooks/useCamera";
 import { useFocusPanOnEnter } from "../hooks/useFocusPanOnEnter";
 import { useViewportGestures } from "../hooks/useViewportGestures";
 import { CameraContext } from "../state/contexts/CameraContext";
-
-const GRID_BASE_SIZE_PX = 12;
-
-const GRID_BACKGROUND_IMAGE = `
-	radial-gradient(circle, var(--color-evy-gray-medium) 1px, transparent 1px)
-`;
-
-const GRID_HIGHLIGHT_BACKGROUND_IMAGE = `
-	radial-gradient(circle, var(--color-evy-gray-dark) 1px, transparent 1px)
-`;
 
 const worldStyle: CSSProperties = {
 	transformOrigin: "0 0",
@@ -59,33 +54,126 @@ export function CanvasViewport({
 	useFocusPanOnEnter(focusMode, activePageId, panToElement);
 
 	const contentMeasureRef = useRef<HTMLDivElement | null>(null);
-	const highlightRef = useRef<HTMLDivElement | null>(null);
+	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const cursorRef = useRef<CursorPosition>(null);
+	const camRef = useRef(getCamera());
+	const disableMorphRef = useRef(false);
+	const requestRepaintRef = useRef<() => void>(() => {});
+
+	const cam = getCamera();
+	camRef.current = cam;
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+		const syncReducedMotion = () => {
+			disableMorphRef.current = mediaQuery.matches;
+			requestRepaintRef.current();
+		};
+		disableMorphRef.current = mediaQuery.matches;
+		mediaQuery.addEventListener("change", syncReducedMotion);
+		return () => {
+			mediaQuery.removeEventListener("change", syncReducedMotion);
+		};
+	}, []);
 
 	useEffect(() => {
 		const viewport = viewportRef.current;
-		const highlight = highlightRef.current;
-		if (!viewport || !highlight) return;
+		const canvas = canvasRef.current;
+		if (!viewport || !canvas) {
+			return;
+		}
+
+		let rafId: number | null = null;
+
+		const paintDotField = () => {
+			const cssWidth = canvas.clientWidth;
+			const cssHeight = canvas.clientHeight;
+			if (cssWidth <= 0 || cssHeight <= 0) {
+				return;
+			}
+
+			const devicePixelRatio = window.devicePixelRatio || 1;
+			canvas.width = Math.round(cssWidth * devicePixelRatio);
+			canvas.height = Math.round(cssHeight * devicePixelRatio);
+
+			const context = canvas.getContext("2d");
+			if (!context) {
+				return;
+			}
+
+			context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+
+			const style = getComputedStyle(viewport);
+			const currentCam = camRef.current;
+			const gridSize = GRID_BASE_SIZE_PX * currentCam.scale;
+
+			drawDotField({
+				ctx: context,
+				cssWidth,
+				cssHeight,
+				gridSize,
+				offsetX: currentCam.offsetX,
+				offsetY: currentCam.offsetY,
+				cursor: cursorRef.current,
+				backgroundColor: style.getPropertyValue("--color-evy-light").trim(),
+				colorMedium: style.getPropertyValue("--color-evy-gray-medium").trim(),
+				colorDark: style.getPropertyValue("--color-evy-gray-dark").trim(),
+				disableMorph: disableMorphRef.current,
+			});
+		};
+
+		const schedulePaint = () => {
+			if (rafId != null) {
+				return;
+			}
+			rafId = requestAnimationFrame(() => {
+				rafId = null;
+				paintDotField();
+			});
+		};
+
+		requestRepaintRef.current = schedulePaint;
+
+		const resizeObserver = new ResizeObserver(() => {
+			schedulePaint();
+		});
+		resizeObserver.observe(viewport);
 
 		const onMove = (event: MouseEvent) => {
-			const rect = viewport.getBoundingClientRect();
-			highlight.style.setProperty(
-				"--mouse-x",
-				`${event.clientX - rect.left}px`,
-			);
-			highlight.style.setProperty("--mouse-y", `${event.clientY - rect.top}px`);
+			const rect = canvas.getBoundingClientRect();
+			cursorRef.current = {
+				x: event.clientX - rect.left,
+				y: event.clientY - rect.top,
+			};
+			schedulePaint();
 		};
+
 		const onLeave = () => {
-			highlight.style.setProperty("--mouse-x", "-300px");
-			highlight.style.setProperty("--mouse-y", "-300px");
+			cursorRef.current = null;
+			schedulePaint();
 		};
 
 		viewport.addEventListener("mousemove", onMove);
 		viewport.addEventListener("mouseleave", onLeave);
+
+		schedulePaint();
+
 		return () => {
+			resizeObserver.disconnect();
 			viewport.removeEventListener("mousemove", onMove);
 			viewport.removeEventListener("mouseleave", onLeave);
+			requestRepaintRef.current = () => {};
+			if (rafId != null) {
+				cancelAnimationFrame(rafId);
+			}
 		};
 	}, [viewportRef]);
+
+	// Repaint when camera pan/zoom changes (canvas reads camRef; effect deps tie to camera state).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — schedule paint on camera updates
+	useLayoutEffect(() => {
+		requestRepaintRef.current();
+	}, [cam.offsetX, cam.offsetY, cam.scale]);
 
 	const handleFitToView = useCallback(() => {
 		const content = contentMeasureRef.current;
@@ -113,26 +201,6 @@ export function CanvasViewport({
 		[onBackgroundClick],
 	);
 
-	const cam = getCamera();
-	const gridSize = GRID_BASE_SIZE_PX * cam.scale;
-	const gridStyle: CSSProperties = {
-		backgroundColor: "var(--color-evy-light)",
-		backgroundImage: GRID_BACKGROUND_IMAGE,
-		backgroundSize: `${gridSize}px ${gridSize}px`,
-		backgroundPosition: `${cam.offsetX}px ${cam.offsetY}px`,
-		opacity: 1,
-	};
-
-	const highlightGridStyle: CSSProperties = {
-		backgroundImage: GRID_HIGHLIGHT_BACKGROUND_IMAGE,
-		backgroundSize: `${gridSize}px ${gridSize}px`,
-		backgroundPosition: `${cam.offsetX}px ${cam.offsetY}px`,
-		WebkitMaskImage:
-			"radial-gradient(circle 80px at var(--mouse-x, -300px) var(--mouse-y, -300px), black 0%, transparent 100%)",
-		maskImage:
-			"radial-gradient(circle 80px at var(--mouse-x, -300px) var(--mouse-y, -300px), black 0%, transparent 100%)",
-	};
-
 	return (
 		<CameraContext.Provider value={camera}>
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: Canvas viewport clears selection on empty click */}
@@ -143,16 +211,10 @@ export function CanvasViewport({
 				className="evy-relative evy-flex-1 evy-min-h-0 evy-overflow-hidden evy-p-4"
 				onClick={handleBackgroundLayerClick}
 			>
-				<div
-					className="evy-pointer-events-none evy-absolute evy-inset-0"
-					style={gridStyle}
+				<canvas
+					ref={canvasRef}
+					className="evy-pointer-events-none evy-absolute evy-inset-0 evy-block evy-h-full evy-w-full"
 					data-canvas-grid
-					aria-hidden
-				/>
-				<div
-					ref={highlightRef}
-					className="evy-pointer-events-none evy-absolute evy-inset-0"
-					style={highlightGridStyle}
 					aria-hidden
 				/>
 				{/* biome-ignore lint/a11y/noStaticElementInteractions: Transformed world layer hit target */}

--- a/web/app/components/canvasDotField.ts
+++ b/web/app/components/canvasDotField.ts
@@ -1,0 +1,115 @@
+/** Grid spacing in CSS pixels at scale 1.0 (matches prior CSS background). */
+export const GRID_BASE_SIZE_PX = 12;
+
+export const MORPH_RADIUS_PX = 100;
+/** Max shift as a fraction of `gridSize` when falloff is 1. */
+export const MORPH_STRENGTH = 0.45;
+export const DOT_BASE_RADIUS = 1;
+export const DOT_HOVER_RADIUS = 1.4;
+
+export type CursorPosition = { x: number; y: number } | null;
+
+export type DrawDotFieldParams = {
+	ctx: CanvasRenderingContext2D;
+	cssWidth: number;
+	cssHeight: number;
+	gridSize: number;
+	offsetX: number;
+	offsetY: number;
+	cursor: CursorPosition;
+	backgroundColor: string;
+	colorMedium: string;
+	colorDark: string;
+	disableMorph: boolean;
+};
+
+/** Interpolate theme colors (oklch / CSS Color 4) for canvas fill. */
+function mixDotColor(medium: string, dark: string, t: number): string {
+	const u = Math.min(1, Math.max(0, t));
+	if (u <= 0) {
+		return medium;
+	}
+	if (u >= 1) {
+		return dark;
+	}
+	return `color-mix(in oklch, ${medium}, ${dark} ${u * 100}%)`;
+}
+
+/**
+ * Paints the dotted canvas background in CSS pixel space.
+ * Caller must set `ctx` transform so one unit = one CSS px (e.g. scale by 1/dpr after sizing buffer).
+ */
+export function drawDotField(params: DrawDotFieldParams): void {
+	const {
+		ctx,
+		cssWidth,
+		cssHeight,
+		gridSize,
+		offsetX,
+		offsetY,
+		cursor,
+		backgroundColor,
+		colorMedium,
+		colorDark,
+		disableMorph,
+	} = params;
+
+	ctx.fillStyle = backgroundColor;
+	ctx.fillRect(0, 0, cssWidth, cssHeight);
+
+	if (gridSize <= 0 || cssWidth <= 0 || cssHeight <= 0) {
+		return;
+	}
+
+	const half = gridSize / 2;
+	const iStart = Math.ceil((0 - offsetX - half) / gridSize);
+	const iEnd = Math.floor((cssWidth - offsetX - half) / gridSize);
+	const jStart = Math.ceil((0 - offsetY - half) / gridSize);
+	const jEnd = Math.floor((cssHeight - offsetY - half) / gridSize);
+
+	const cursorX = cursor?.x ?? Number.POSITIVE_INFINITY;
+	const cursorY = cursor?.y ?? Number.POSITIVE_INFINITY;
+	const hasCursor = cursor !== null;
+
+	const R = MORPH_RADIUS_PX;
+
+	for (let j = jStart; j <= jEnd; j++) {
+		for (let i = iStart; i <= iEnd; i++) {
+			const baseX = offsetX + i * gridSize + half;
+			const baseY = offsetY + j * gridSize + half;
+
+			let influence = 0;
+			let dx = 0;
+			let dy = 0;
+			let d = 0;
+			if (hasCursor) {
+				dx = cursorX - baseX;
+				dy = cursorY - baseY;
+				d = Math.hypot(dx, dy);
+				if (d < R && d > 1e-6) {
+					const t = 1 - d / R;
+					influence = t * t;
+				} else if (d <= 1e-6) {
+					influence = 1;
+				}
+			}
+
+			let drawX = baseX;
+			let drawY = baseY;
+			if (!disableMorph && hasCursor && influence > 0 && d > 1e-6) {
+				const pull = influence * MORPH_STRENGTH * gridSize;
+				drawX += (dx / d) * pull;
+				drawY += (dy / d) * pull;
+			}
+
+			const colorT = Math.sqrt(influence);
+			ctx.fillStyle = mixDotColor(colorMedium, colorDark, colorT);
+
+			const radius =
+				DOT_BASE_RADIUS + (DOT_HOVER_RADIUS - DOT_BASE_RADIUS) * influence;
+			ctx.beginPath();
+			ctx.arc(drawX, drawY, radius, 0, Math.PI * 2);
+			ctx.fill();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the CSS radial-gradient dot grid behind the builder canvas with a `<canvas>` layer. Dots shift toward the pointer with distance-based falloff and blend from `--color-evy-gray-medium` to `--color-evy-gray-dark` near the cursor (replacing the old mask highlight). `prefers-reduced-motion: reduce` disables displacement but keeps the color cue.

## Changes

- **`web/app/components/canvasDotField.ts`** — `drawDotField()`: grid iteration aligned with camera `offsetX` / `offsetY` / `gridSize`, pull strength and radius falloff, oklch `color-mix` for theme colors.
- **`web/app/components/CanvasViewport.tsx`** — single `data-canvas-grid` canvas, `ResizeObserver` + `requestAnimationFrame` repaints, cursor and camera via refs (no per-mousemove React updates).

## Testing

- `bun run lint`, `bun run build`, and `bun run test` in `web/`.

### JIRA


### Figma


### Stream



Made with [Cursor](https://cursor.com)