### PR TITLE
[FEAT] readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,14 @@ Resource routing, `flowUpdated` / `dataUpdated`, and gRPC forwarding are covered
   - [Data models](./docs/evy/sddata/data.md)
   - [Functions](./docs/evy/sddata/functions.md)
   - [Server Driven UI](./docs/evy/sdui/readme.md)
-- Marketplace
+  - [API](./api/README.md)
+  - [iOS](./ios/README.md)
+  - [Web](./web/README.md)
+  - [Android](./android/README.md) (placeholder; no app in this repo yet)
+- [Marketplace](./services/marketplace/README.md)
   - [Data models](./docs/services/marketplace/data.md)
   - [Example data](./docs/services/service_data.json)
   - [Example UI flow for view & create item pages](./docs/services/service_sdui.json)
-- [API](./api/README.md)
-- [Marketplace service](./services/marketplace/README.md)
-- [iOS](./ios/README.md)
-- [Web](./web/README.md)
-- [Android](./android/README.md) (placeholder; no app in this repo yet)
 
 ## Shared type system
 


### PR DESCRIPTION
## Summary

Reorganizes the documentation index in the root README so platform links (API, iOS, Web, Android) sit under a single nested list, and turns the Marketplace entry into a proper link to `./services/marketplace/README.md` alongside its existing docs.

## Changes

- Nest API, iOS, Web, and Android README links as sub-bullets for clearer hierarchy.
- Replace the plain "Marketplace" bullet with `[Marketplace](./services/marketplace/README.md)` and remove duplicate standalone links that were listed again below.

JIRA: 

Figma: 

Stream: 

Made with [Cursor](https://cursor.com)