### PR TITLE
[FEAT] SDUI source attribute, web editing, and drag-drop improvements

### DIFF
--- a/api/e2e/e2e.test.ts
+++ b/api/e2e/e2e.test.ts
@@ -108,6 +108,7 @@ describe("API E2E Tests", () => {
 			const testRow: UI_Row = {
 				id: crypto.randomUUID(),
 				type: "Text",
+				source: "",
 				actions: [],
 				view: {
 					content: {

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -25,8 +25,9 @@ import { clearAllTestTables, createPgliteTestDatabase } from "./wsTestHelpers";
 type ValidatedRow = UI_Row;
 type ValidatedPage = UI_Page;
 
-type RowInput = Omit<ValidatedRow, "id" | "view"> & {
+type RowInput = Omit<ValidatedRow, "id" | "view" | "source"> & {
 	id?: string;
+	source?: string;
 	view: Omit<ValidatedRow["view"], "content"> & {
 		content: Omit<ValidatedRow["view"]["content"], "children" | "child"> & {
 			children?: RowInput[];
@@ -83,6 +84,7 @@ function ensureRowIds(rows: RowInput[]): RowInput[] {
 		const rowWithId: RowInput = {
 			...row,
 			id: crypto.randomUUID(),
+			source: row.source ?? "",
 			view: {
 				...row.view,
 				content: {

--- a/docs/evy/evy_sdui.json
+++ b/docs/evy/evy_sdui.json
@@ -10,6 +10,7 @@
 					{
 						"id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
 						"type": "ColumnContainer",
+						"source": "",
 						"view": {
 							"content": {
 								"title": "",
@@ -17,6 +18,7 @@
 									{
 										"id": "441c1433-446b-4682-854d-5d795ef52709",
 										"type": "Button",
+										"source": "",
 										"view": {
 											"content": {
 												"title": "",
@@ -34,6 +36,7 @@
 									{
 										"id": "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
 										"type": "Button",
+										"source": "",
 										"view": {
 											"content": {
 												"title": "",

--- a/docs/evy/sdui/readme.md
+++ b/docs/evy/sdui/readme.md
@@ -6,13 +6,15 @@
 
 UI flows (`UI_Flow`) only describe structure: `id`, `name`, and `pages`. Reference data (dropdown options, tags, durations, etc.) is not embedded inside the flow JSON.
 
-- Rows that need a data source set `view.data` to a string that typically references a variable or API/local source, for example:
-	- `"{conditions}"` — bind to data the client already has under that key
-	- `"{api:tags}"` — remote search / API-backed data
-	- `"local:address"` — client-local data source
-- That data is loaded separately via JSON-RPC `get` (`service` / `resource`); routing and persistence are described in [`api/README`](../../api/README.md). `evy` catalog data uses [`types/schema/data/data.schema.json`](../../../types/schema/data/data.schema.json); marketplace resources are served by the marketplace worker ([`services/marketplace`](../../services/marketplace/README.md)). Clients merge loaded data with flow state when rendering rows (e.g. Dropdown, InlinePicker, Search, InputList).
+- Each row declares a required **`source`** string at the row root (next to `destination`) describing where the row **reads** data from when rendering or editing:
+	- `"{item}"` — bind to the current flow entity / draft (e.g. listing fields, `{formatWeight(weight)}`, `{item.title}`).
+	- `"{conditions}"`, `"{selling_reasons}"`, `"{durations}"`, `"{areas}"`, `"{tags}"` — catalog or in-memory keys the client resolves to option lists.
+	- `"{api:tags}"` — remote search / API-backed data.
+	- `"local:address"` — client-local data source.
+	- `""` — no external read binding (e.g. pure navigation buttons, static Info).
+- That catalog/API/local data is loaded separately via JSON-RPC `get` (`service` / `resource`); routing and persistence are described in [`api/README`](../../api/README.md). `evy` catalog data uses [`types/schema/data/data.schema.json`](../../../types/schema/data/data.schema.json); marketplace resources are served by the marketplace worker ([`services/marketplace`](../../services/marketplace/README.md)). Clients merge loaded data with flow state when rendering rows (e.g. Dropdown, InlinePicker, Search, InputList).
 
-So a flow might reference “10 min, 20 min, 30 min” options via `view.data` and a variable like `{durations}`; the actual list of options lives in the data layer the app fetches, not inside the flow document.
+So a flow might reference “10 min, 20 min, 30 min” options via `source: "{durations}"` while the selected value is still written to a field via `destination`; the actual list of options lives in the data layer the app fetches, not inside the flow document.
 
 ## Flow
 
@@ -74,10 +76,10 @@ Rows are what are put into pages. They are the building block of the EVY server-
             // Additional keys per row type (label, value, placeholder, format, etc.)
             // See types/schema/sdui/row-content.spec.json for the full list per type.
         },
-        // Optional. A string (e.g. template or data reference) for rows that need data (dropdowns, search).
-        "data": "string",
-        "max_lines": "string"    // optional
+        "max_lines": "string"    // optional (e.g. Text)
     },
+    // Where the row reads option/list/entity data from (required string; use "" if unused).
+    "source": "string",
     // Where the input data is stored (optional, used by edit rows)
     "destination": "string",
 
@@ -188,4 +190,4 @@ Row types are defined in the schema (`types/schema/sdui/evy.schema.json`) and th
 
 Each row type’s `view.content` may include type-specific keys (e.g. `label`, `value`, `placeholder`, `format`). See `row-content.spec.json` for the exact keys per type.
 
-For list-backed rows (Dropdown, InlinePicker, Search, InputList, etc.), `format` is evaluated per item from `view.data`. Use `datum` as the placeholder for the current item in expressions, e.g. `{datum.value}` or `{datum.unit} {datum.street}, {datum.city}`.
+For list-backed rows (Dropdown, InlinePicker, Search, InputList, etc.), `format` is evaluated per item from the list resolved via `source`. Use `datum` as the placeholder for the current item in expressions, e.g. `{datum.value}` or `{datum.unit} {datum.street}, {datum.city}`.

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -17,7 +17,8 @@
 							},
 							"max_lines": ""
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					}
 				],
 				"footer": {
@@ -35,7 +36,8 @@
 							"false": "",
 							"true": "close"
 						}
-					]
+					],
+					"source": "{item}"
 				}
 			}
 		]
@@ -60,7 +62,8 @@
 							}
 						},
 						"destination": "{photo_ids}",
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					},
 					{
 						"id": "c3d4e5f6-a7b8-4c9d-8e1f-2a3b4c5d6e7f",
@@ -73,7 +76,8 @@
 							}
 						},
 						"destination": "{title}",
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					},
 					{
 						"id": "d4e5f6a7-b8c9-4d0e-8f2a-3b4c5d6e7f8a",
@@ -86,13 +90,13 @@
 							}
 						},
 						"destination": "{buildCurrency(price)}",
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					},
 					{
 						"id": "e5f6a7b8-c9d0-4e1f-8a3b-4c5d6e7f8a9b",
 						"type": "Dropdown",
 						"view": {
-							"data": "{conditions}",
 							"content": {
 								"title": "Condition",
 								"format": "{datum.value}",
@@ -100,13 +104,13 @@
 							}
 						},
 						"destination": "{condition}",
-						"actions": []
+						"actions": [],
+						"source": "{conditions}"
 					},
 					{
 						"id": "f6a7b8c9-d0e1-4f2a-8b4c-5d6e7f8a9b0c",
 						"type": "Dropdown",
 						"view": {
-							"data": "{selling_reasons}",
 							"content": {
 								"title": "Selling Reason",
 								"format": "{datum.value}",
@@ -114,7 +118,8 @@
 							}
 						},
 						"destination": "{selling_reason}",
-						"actions": []
+						"actions": [],
+						"source": "{selling_reasons}"
 					},
 					{
 						"id": "a7b8c9d0-e1f2-4a3b-8c5d-6e7f8a9b0c1d",
@@ -134,7 +139,8 @@
 											}
 										},
 										"destination": "{width}",
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									},
 									{
 										"id": "09a9f654-1c2c-42f8-9a6a-4608fc248478",
@@ -147,7 +153,8 @@
 											}
 										},
 										"destination": "{height}",
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									},
 									{
 										"id": "7484ce1a-0771-45d2-a1cf-8b1336cfd018",
@@ -160,12 +167,14 @@
 											}
 										},
 										"destination": "{length}",
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									}
 								]
 							}
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					},
 					{
 						"id": "6c48841c-079f-4c58-bab6-af96a87d7399",
@@ -177,21 +186,20 @@
 									"id": "2422c9ec-df63-4fde-9632-0fe159c0b40e",
 									"type": "InputList",
 									"view": {
-										"data": "{tags}",
 										"content": {
 											"title": "Tags",
 											"format": "{datum.value}",
 											"placeholder": "Search for tags"
 										}
 									},
-									"actions": []
+									"actions": [],
+									"source": "{tags}"
 								},
 								"children": [
 									{
 										"id": "8f8c442e-ee2d-4974-9ef1-29005f3311e6",
 										"type": "Search",
 										"view": {
-											"data": "{api:tags}",
 											"content": {
 												"title": "",
 												"format": "{datum.value}",
@@ -199,12 +207,14 @@
 											}
 										},
 										"destination": "{tags}",
-										"actions": []
+										"actions": [],
+										"source": "{api:tags}"
 									}
 								]
 							}
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					}
 				],
 				"title": "Create listing",
@@ -258,7 +268,8 @@
 							"false": "",
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,06b21b52-0845-468a-ace1-170a3b05f3a2)}"
 						}
-					]
+					],
+					"source": "{item}"
 				}
 			},
 			{
@@ -275,7 +286,8 @@
 							}
 						},
 						"destination": "{description}",
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					}
 				],
 				"title": "Describe item",
@@ -294,7 +306,8 @@
 							"false": "{highlight_required(description)}",
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,26dae81a-4122-4b5c-8396-a72a319ccd8b)}"
 						}
-					]
+					],
+					"source": "{item}"
 				}
 			},
 			{
@@ -323,7 +336,8 @@
 																"text": "Allow buyers to pick up the item"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222203",
@@ -343,14 +357,14 @@
 																		}
 																	},
 																	"destination": "{pickup_address}",
-																	"actions": []
+																	"actions": [],
+																	"source": "{item}"
 																},
 																"children": [
 																	{
 																		"id": "22222222-2222-4222-8222-222222222205",
 																		"type": "Search",
 																		"view": {
-																			"data": "local:address",
 																			"content": {
 																				"title": "",
 																				"format": "{datum.unit} {datum.street}, {datum.city} {datum.state} {datum.postcode}",
@@ -358,12 +372,14 @@
 																			}
 																		},
 																		"destination": "{address}",
-																		"actions": []
+																		"actions": [],
+																		"source": "local:address"
 																	}
 																]
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222206",
@@ -376,7 +392,8 @@
 															}
 														},
 														"destination": "{address_instructions}",
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222207",
@@ -387,7 +404,8 @@
 																"text": "When are you available for buyers to inspect or pick up this item"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222208",
@@ -400,13 +418,14 @@
 															}
 														},
 														"destination": "{pickup_timeslots}",
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													}
 												]
 											}
 										},
-
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									},
 									{
 										"id": "22222222-2222-4222-8222-222222222209",
@@ -424,7 +443,8 @@
 																"text": "Deliver directly to the buyer"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222211",
@@ -437,7 +457,8 @@
 															}
 														},
 														"destination": "{delivery_fee}",
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222212",
@@ -448,20 +469,21 @@
 																"text": "How long can you travel to deliver this item"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222213",
 														"type": "InlinePicker",
 														"view": {
-															"data": "{durations}",
 															"content": {
 																"title": "",
 																"format": "{datum.value}"
 															}
 														},
 														"destination": "{distance}",
-														"actions": []
+														"actions": [],
+														"source": "{durations}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222214",
@@ -472,7 +494,8 @@
 																"text": "When are you available to deliver this item"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222215",
@@ -485,13 +508,14 @@
 															}
 														},
 														"destination": "{delivery_timeslots}",
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													}
 												]
 											}
 										},
-
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									},
 									{
 										"id": "22222222-2222-4222-8222-222222222216",
@@ -509,7 +533,8 @@
 																"text": "Postal shipping at the buyer's expense"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222218",
@@ -522,7 +547,8 @@
 															}
 														},
 														"destination": "{shipping_source_postal_code}",
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222219",
@@ -533,20 +559,21 @@
 																"text": "Select how far you are willing to ship"
 															}
 														},
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222220",
 														"type": "InlinePicker",
 														"view": {
-															"data": "{areas}",
 															"content": {
 																"title": "",
 																"format": "{datum.value}"
 															}
 														},
 														"destination": "{shipping_destination_areas}",
-														"actions": []
+														"actions": [],
+														"source": "{areas}"
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222221",
@@ -559,19 +586,25 @@
 															}
 														},
 														"destination": "{weight}",
-														"actions": []
+														"actions": [],
+														"source": "{item}"
 													}
 												]
 											}
 										},
-
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									}
 								],
-								"segments": ["Pickup", "Delivery", "Shipping"]
+								"segments": [
+									"Pickup",
+									"Delivery",
+									"Shipping"
+								]
 							}
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					}
 				],
 				"title": "Pickup & delivery",
@@ -590,7 +623,8 @@
 							"false": "{highlight_required(pickup_timeslots)}",
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,25a3269b-344c-477d-89c8-b2f5426a5d91)}"
 						}
-					]
+					],
+					"source": "{item}"
 				}
 			},
 			{
@@ -605,7 +639,8 @@
 								"text": "Payment will be made by the buyers on pickup"
 							}
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					},
 					{
 						"id": "f2a3b4c5-d6e7-4f8a-9b0c-1d2e3f4a5b6c",
@@ -624,7 +659,8 @@
 											}
 										},
 										"destination": "{payment_cash}",
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									},
 									{
 										"id": "33333333-3333-4333-8333-333333333302",
@@ -636,12 +672,14 @@
 											}
 										},
 										"destination": "{payment_app}",
-										"actions": []
+										"actions": [],
+										"source": "{item}"
 									}
 								]
 							}
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					}
 				],
 				"title": "Payment options",
@@ -660,7 +698,8 @@
 							"false": "{highlight_required(payment_app)}",
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,857362ad-856f-465b-85a3-94bc8bb686cd)}"
 						}
-					]
+					],
+					"source": "{item}"
 				}
 			},
 			{
@@ -675,7 +714,8 @@
 								"text": "EVY is all about Data privacy. Your identity and profile information remains encrypted on your phone and inaccessible to anyone but you. However, the following information about your listing will be public:\n\n* Title & description\n* Photos\n* Condition & selling reason\n* Price\n* Dimension\n* Pickup address & schedule\n* Delivery schedule"
 							}
 						},
-						"actions": []
+						"actions": [],
+						"source": "{item}"
 					}
 				],
 				"title": "Sharing data publicly",
@@ -694,7 +734,8 @@
 							"false": "",
 							"true": "{create(item)}"
 						}
-					]
+					],
+					"source": "{item}"
 				}
 			}
 		]

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -65,6 +65,9 @@ private struct EVYPageBody: View {
         })
     }
 
+    /// Ensures a draft exists for each row `destination` binding in the active scope.
+    /// `row.source` describes where the row reads option/list data from (e.g. `{item}`, `{conditions}`, `local:address`);
+    /// it does not introduce a separate draft key — only `destination` does.
     @MainActor
     private func bootstrapDrafts(in page: UI_Page, scopeId: String?) {
         forEachRow(in: page) { row in

--- a/ios/evy/UI/EVYRow.swift
+++ b/ios/evy/UI/EVYRow.swift
@@ -37,23 +37,23 @@ struct EVYRow: View, Identifiable {
 	@ViewBuilder
 	private func rowView(for payload: UI_RowPayload) -> some View {
 		switch payload {
-		case .button(let v, _, let a): EVYButtonRow(view: v, actions: a)
-		case .calendar(let v, _, _): EVYCalendarRow(view: v)
-		case .columnContainer(let v, _, _): EVYColumnContainerRow(view: v)
-		case .dropdown(let v, let d, _): EVYDropdownRow(view: v, destination: d)
-		case .info(let v, _, _): EVYInfoRow(view: v)
-		case .inlinePicker(let v, let d, _): EVYInlinePickerRow(view: v, destination: d)
-		case .inputList(let v, _, _): EVYInputListRow(view: v)
-		case .input(let v, let d, _): EVYInputRow(view: v, destination: d)
-		case .listContainer(let v, _, _): EVYListContainerRow(view: v)
-		case .search(let v, let d, _): EVYSearchRow(view: v, destination: d)
-		case .selectPhoto(let v, let d, _): EVYSelectPhotoRow(view: v, destination: d)
-		case .selectSegmentContainer(let v, _, _): EVYSelectSegmentContainerRow(view: v)
-		case .sheetContainer(let v, _, _): EVYSheetContainerRow(view: v)
-		case .textAction(let v, _, let a): EVYTextActionRow(view: v, actions: a)
-		case .textArea(let v, let d, _): EVYTextAreaRow(view: v, destination: d)
-		case .text(let v, _, _): EVYTextRow(view: v)
-		case .textSelect(let v, let d, let a):
+		case .button(let v, _, _, let a): EVYButtonRow(view: v, actions: a)
+		case .calendar(let v, _, _, _): EVYCalendarRow(view: v)
+		case .columnContainer(let v, _, _, _): EVYColumnContainerRow(view: v)
+		case .dropdown(let v, let s, let d, _): EVYDropdownRow(view: v, source: s, destination: d)
+		case .info(let v, _, _, _): EVYInfoRow(view: v)
+		case .inlinePicker(let v, let s, let d, _): EVYInlinePickerRow(view: v, source: s, destination: d)
+		case .inputList(let v, let s, _, _): EVYInputListRow(view: v, source: s)
+		case .input(let v, _, let d, _): EVYInputRow(view: v, destination: d)
+		case .listContainer(let v, _, _, _): EVYListContainerRow(view: v)
+		case .search(let v, let s, let d, _): EVYSearchRow(view: v, source: s, destination: d)
+		case .selectPhoto(let v, _, let d, _): EVYSelectPhotoRow(view: v, destination: d)
+		case .selectSegmentContainer(let v, _, _, _): EVYSelectSegmentContainerRow(view: v)
+		case .sheetContainer(let v, _, _, _): EVYSheetContainerRow(view: v)
+		case .textAction(let v, _, _, let a): EVYTextActionRow(view: v, actions: a)
+		case .textArea(let v, _, let d, _): EVYTextAreaRow(view: v, destination: d)
+		case .text(let v, _, _, _): EVYTextRow(view: v)
+		case .textSelect(let v, _, let d, let a):
 			if let row = EVYTextSelectRow(view: v, destination: d, actions: a) {
 				row
 			} else {

--- a/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
@@ -11,10 +11,12 @@ struct EVYDropdownRow: View, EVYRowProtocol {
 	public static let JSONType = "Dropdown"
 
 	private let view: DropdownRowViewData
+	private let source: String
 	private let destination: String?
 
-	init(view: DropdownRowViewData, destination: String?) {
+	init(view: DropdownRowViewData, source: String, destination: String?) {
 		self.view = view
+		self.source = source
 		self.destination = destination
 	}
 
@@ -28,7 +30,7 @@ struct EVYDropdownRow: View, EVYRowProtocol {
 				EVYDropdown(
 					title: view.content.title,
 					placeholder: view.content.placeholder,
-					data: view.data ?? "",
+					data: source,
 					format: view.content.format,
 					destination: destination
 				)

--- a/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
@@ -11,10 +11,12 @@ struct EVYInlinePickerRow: View, EVYRowProtocol {
 	public static let JSONType = "InlinePicker"
 
 	private let view: InlinePickerRowViewData
+	private let source: String
 	private let destination: String?
 
-	init(view: InlinePickerRowViewData, destination: String?) {
+	init(view: InlinePickerRowViewData, source: String, destination: String?) {
 		self.view = view
+		self.source = source
 		self.destination = destination
 	}
 
@@ -27,7 +29,7 @@ struct EVYInlinePickerRow: View, EVYRowProtocol {
 			if let destination {
 				EVYInlinePicker(
 					title: view.content.title,
-					data: view.data ?? "",
+					data: source,
 					format: view.content.format,
 					destination: destination
 				)

--- a/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
@@ -11,11 +11,13 @@ struct EVYSearchRow: View, EVYRowProtocol {
 	public static let JSONType = "Search"
 
 	private let view: SearchRowViewData
+	private let source: String
 	private let destination: String?
 	@State private var showSheet = false
 
-	init(view: SearchRowViewData, destination: String?) {
+	init(view: SearchRowViewData, source: String, destination: String?) {
 		self.view = view
+		self.source = source
 		self.destination = destination
 	}
 
@@ -27,7 +29,7 @@ struct EVYSearchRow: View, EVYRowProtocol {
 			}
 			if let destination {
 				EVYSearch(
-					source: view.data ?? "",
+					source: source,
 					destination: destination,
 					placeholder: view.content.placeholder,
 					format: view.content.format

--- a/ios/evy/UI/Rows/View/EVYInputListRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInputListRow.swift
@@ -11,9 +11,11 @@ struct EVYInputListRow: View, EVYRowProtocol {
 	public static let JSONType = "InputList"
 
 	private let view: InputListRowViewData
+	private let source: String
 
-	init(view: InputListRowViewData) {
+	init(view: InputListRowViewData, source: String) {
 		self.view = view
+		self.source = source
 	}
 
 	var body: some View {
@@ -23,7 +25,7 @@ struct EVYInputListRow: View, EVYRowProtocol {
 					.padding(.vertical, Constants.padding)
 			}
 			EVYInputList(
-				data: view.data ?? "",
+				data: source,
 				format: view.content.format,
 				placeholder: view.content.placeholder
 			)

--- a/ios/evyTests/ContentViewTests.swift
+++ b/ios/evyTests/ContentViewTests.swift
@@ -60,6 +60,7 @@ final class ContentViewTests: XCTestCase {
                             [
                                 "id": "home-button",
                                 "type": "Button",
+                                "source": "",
                                 "view": [
                                     "content": [
                                         "title": "",
@@ -89,6 +90,7 @@ final class ContentViewTests: XCTestCase {
                             [
                                 "id": "title-row",
                                 "type": "Input",
+                                "source": "{item}",
                                 "view": [
                                     "content": [
                                         "title": "Title",
@@ -103,6 +105,7 @@ final class ContentViewTests: XCTestCase {
                         "footer": [
                             "id": "submit-button",
                             "type": "Button",
+                            "source": "{item}",
                             "view": [
                                 "content": [
                                     "title": "",

--- a/scripts/generate-swift-sdui.ts
+++ b/scripts/generate-swift-sdui.ts
@@ -171,13 +171,15 @@ public final class UI_Row: Codable {
     public let id: String
     public let type: EVYRowType
     public let view: UI_RowView
+    public let source: String
     public let destination: String?
     public let actions: [UI_RowAction]
 
-    public init(id: String, type: EVYRowType, view: UI_RowView, destination: String?, actions: [UI_RowAction]) {
+    public init(id: String, type: EVYRowType, view: UI_RowView, source: String, destination: String?, actions: [UI_RowAction]) {
         self.id = id
         self.type = type
         self.view = view
+        self.source = source
         self.destination = destination
         self.actions = actions
     }
@@ -186,6 +188,7 @@ public final class UI_Row: Codable {
         case id
         case type
         case view
+        case source
         case destination
         case actions
     }
@@ -195,6 +198,7 @@ public final class UI_Row: Codable {
         id = try container.decode(String.self, forKey: .id)
         type = try container.decode(EVYRowType.self, forKey: .type)
         view = try container.decode(UI_RowView.self, forKey: .view)
+        source = try container.decode(String.self, forKey: .source)
         destination = try container.decodeIfPresent(String.self, forKey: .destination)
         actions = try container.decodeIfPresent([UI_RowAction].self, forKey: .actions) ?? []
     }
@@ -204,6 +208,7 @@ public final class UI_Row: Codable {
         try container.encode(id, forKey: .id)
         try container.encode(type, forKey: .type)
         try container.encode(view, forKey: .view)
+        try container.encode(source, forKey: .source)
         try container.encodeIfPresent(destination, forKey: .destination)
         try container.encode(actions, forKey: .actions)
     }
@@ -458,7 +463,7 @@ function emitUIRowPayloads(rowSpec: RowSpec): string {
 		if (!spec) continue;
 		const viewDataName = `${rowType}RowViewData`;
 		payloadCases.push(
-			`    case ${rowTypeToEnumCase(rowType)}(${viewDataName}, String?, [UI_RowAction])`,
+			`    case ${rowTypeToEnumCase(rowType)}(${viewDataName}, String, String?, [UI_RowAction])`,
 		);
 	}
 
@@ -470,7 +475,7 @@ function emitUIRowPayloads(rowSpec: RowSpec): string {
 		const enumCase = rowTypeToEnumCase(rowType);
 		fromRowCases.push(`        case .${enumCase}:
             let viewData = try JSONDecoder().decode(${viewDataName}.self, from: JSONEncoder().encode(row.view))
-            return .${enumCase}(viewData, row.destination, row.actions)`);
+            return .${enumCase}(viewData, row.source, row.destination, row.actions)`);
 	}
 
 	return `// Generated from types/schema/sdui/evy.schema.json + row-content.spec.json - do not edit.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,13 +1,14 @@
 import { dirname, join } from "node:path";
-import { readFile } from "node:fs/promises";
+import { drizzle } from "drizzle-orm/postgres-js";
 import { fileURLToPath } from "node:url";
+import { migrate as migratePg } from "drizzle-orm/postgres-js/migrator";
+import { pgTable, jsonb, text, uuid, varchar } from "drizzle-orm/pg-core";
+import { readFile } from "node:fs/promises";
+import addFormats from "ajv-formats";
+import Ajv2020 from "ajv/dist/2020";
 import pluralize from "pluralize";
 import postgres from "postgres";
-import { pgTable, jsonb, text, uuid, varchar } from "drizzle-orm/pg-core";
-import { drizzle } from "drizzle-orm/postgres-js";
-import { migrate as migratePg } from "drizzle-orm/postgres-js/migrator";
-import Ajv2020 from "ajv/dist/2020";
-import addFormats from "ajv-formats";
+
 import { MARKETPLACE_SEED_KEYS } from "../services/marketplace/src/catalog";
 import { validateUiFlow } from "../types/validators";
 

--- a/types/schema/sdui/evy.schema.json
+++ b/types/schema/sdui/evy.schema.json
@@ -32,7 +32,7 @@
 		"UI_Row": {
 			"type": "object",
 			"additionalProperties": false,
-			"required": ["id", "type", "view", "actions"],
+			"required": ["id", "type", "view", "source", "actions"],
 			"properties": {
 				"id": { "type": "string", "format": "uuid" },
 				"type": {
@@ -63,10 +63,10 @@
 					"required": ["content"],
 					"properties": {
 						"content": { "$ref": "#/$defs/UI_RowContent" },
-						"data": { "type": "string" },
 						"max_lines": { "type": "string" }
 					}
 				},
+				"source": { "type": "string" },
 				"destination": { "type": "string" },
 				"actions": {
 					"type": "array",

--- a/types/schema/sdui/row-content.spec.json
+++ b/types/schema/sdui/row-content.spec.json
@@ -49,9 +49,6 @@
 		}
 	},
 	"Dropdown": {
-		"view": {
-			"data": "string"
-		},
 		"content": {
 			"title": "string",
 			"format": "string",
@@ -59,18 +56,12 @@
 		}
 	},
 	"InlinePicker": {
-		"view": {
-			"data": "string"
-		},
 		"content": {
 			"title": "string",
 			"format": "string"
 		}
 	},
 	"Search": {
-		"view": {
-			"data": "string"
-		},
 		"content": {
 			"title": "string",
 			"format": "string",
@@ -94,9 +85,6 @@
 		}
 	},
 	"InputList": {
-		"view": {
-			"data": "string"
-		},
 		"content": {
 			"title": "string",
 			"format": "string",

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -21,6 +21,48 @@ function isRowArray(value: unknown): value is Row[] {
 	return Array.isArray(value) && value.every(isRow);
 }
 
+function ConfigTextField({
+	id,
+	label,
+	value,
+	onChange,
+	placeholder,
+	ariaLabel,
+	labelClassName,
+	inputClassName = "evy-w-full evy-focus-visible:outline-none",
+	required,
+	fieldClassName = "evy-mb-2",
+}: {
+	id: string;
+	label: string;
+	value: string;
+	onChange: (next: string) => void;
+	placeholder?: string;
+	ariaLabel?: string;
+	labelClassName?: string;
+	inputClassName?: string;
+	required?: boolean;
+	fieldClassName?: string;
+}) {
+	return (
+		<div className={fieldClassName}>
+			<label htmlFor={id} className={labelClassName}>
+				{label}
+			</label>
+			<input
+				id={id}
+				type="text"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				placeholder={placeholder}
+				aria-label={ariaLabel}
+				className={inputClassName}
+				required={required}
+			/>
+		</div>
+	);
+}
+
 function ChildRowButton({
 	child,
 	onClick,
@@ -116,6 +158,20 @@ export function ConfigurationPanel() {
 		[activeRowId, dispatchRow],
 	);
 
+	const updateRowRoot = useCallback(
+		(field: "source" | "destination", value: string, targetRowId?: string) => {
+			const rowId = targetRowId || activeRowId;
+			if (!rowId) return;
+			dispatchRow({
+				type: "UPDATE_ROW_ROOT",
+				rowId,
+				field,
+				value,
+			});
+		},
+		[activeRowId, dispatchRow],
+	);
+
 	const updateRowActions = useCallback(
 		(nextActions: NonNullable<Row["config"]["actions"]>) => {
 			if (!currentConfigRow) return;
@@ -138,7 +194,7 @@ export function ConfigurationPanel() {
 				return 0;
 			});
 
-			return entries.map(([key, value]) => {
+			const contentElements = entries.map(([key, value]) => {
 				const uniqueId = `${configRow.id}-${key}`;
 
 				if (key === "child" || key === "children") {
@@ -178,23 +234,51 @@ export function ConfigurationPanel() {
 					);
 				}
 				return (
-					<div className="evy-mb-2" key={uniqueId}>
-						<label htmlFor={uniqueId}>{key}</label>
-						<input
-							id={uniqueId}
-							type="text"
-							value={String(value)}
-							onChange={(e) => {
-								updateRowContent(key, e.target.value, configRow.id);
-							}}
-							className="evy-w-full evy-focus-visible:outline-none"
-							required
-						/>
-					</div>
+					<ConfigTextField
+						key={uniqueId}
+						id={uniqueId}
+						label={key}
+						value={String(value)}
+						onChange={(next) => updateRowContent(key, next, configRow.id)}
+						required
+					/>
 				);
 			});
+
+			return [
+				...contentElements,
+				<div
+					className="evy-flex evy-flex-col evy-gap-3"
+					key={`${configRow.id}-bindings`}
+				>
+					<ConfigTextField
+						id={`${configRow.id}-source`}
+						label="Source"
+						value={configRow.config.source}
+						onChange={(next) => updateRowRoot("source", next, configRow.id)}
+						placeholder="Where the row reads data from"
+						ariaLabel="Row data source"
+						labelClassName="evy-text-sm evy-font-medium evy-text-black"
+						inputClassName="evy-w-full evy-mt-1 evy-focus-visible:outline-none"
+						fieldClassName=""
+					/>
+					<ConfigTextField
+						id={`${configRow.id}-destination`}
+						label="Destination"
+						value={configRow.config.destination ?? ""}
+						onChange={(next) =>
+							updateRowRoot("destination", next, configRow.id)
+						}
+						placeholder="Where the row writes data to"
+						ariaLabel="Row destination"
+						labelClassName="evy-text-sm evy-font-medium evy-text-black"
+						inputClassName="evy-w-full evy-mt-1 evy-focus-visible:outline-none"
+						fieldClassName=""
+					/>
+				</div>,
+			];
 		},
-		[openChildConfiguration, updateRowContent],
+		[openChildConfiguration, updateRowContent, updateRowRoot],
 	);
 
 	const configurationElements = currentConfigRow
@@ -256,17 +340,15 @@ export function ConfigurationPanel() {
 						/>
 					</div>
 				)}
-				{showPageTitleInPanel &&
-					activePage &&
-					configurationElements.length > 0 && (
-						<div className="evy-border-b evy-border-gray" />
-					)}
-				{configurationElements.length > 0 ? (
+				{showPageTitleInPanel && activePage && currentConfigRow && (
+					<div className="evy-border-b evy-border-gray" />
+				)}
+				{currentConfigRow ? (
 					<>
 						{configurationElements}
 						<div className="evy-border-b evy-border-gray" />
 						<ActionEditor
-							actions={currentConfigRow?.config.actions ?? []}
+							actions={currentConfigRow.config.actions ?? []}
 							flows={flows}
 							onUpdate={updateRowActions}
 						/>

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -13,6 +13,7 @@ export function DraggableRowContainer({
 	showIndicators = false,
 	previousRowId,
 	nextRowId,
+	isDraggable = true,
 }: {
 	rowId: string;
 	children: React.ReactNode;
@@ -21,6 +22,7 @@ export function DraggableRowContainer({
 	showIndicators?: boolean;
 	previousRowId?: string;
 	nextRowId?: string;
+	isDraggable?: boolean;
 }) {
 	const { ref, state, indicators, dropzones } = useDraggable({
 		rowId,
@@ -28,6 +30,7 @@ export function DraggableRowContainer({
 		showIndicators,
 		previousRowId,
 		nextRowId,
+		isDraggable,
 	});
 
 	return (

--- a/web/app/components/PlaceholderDropIndicator.tsx
+++ b/web/app/components/PlaceholderDropIndicator.tsx
@@ -10,6 +10,7 @@ export function PlaceholderDropIndicator() {
 		<DraggableRowContainer
 			rowId={containerDropindicatorId}
 			orientation="horizontal"
+			isDraggable={false}
 		>
 			<div
 				className={`${verticalDropIndicator} ${dropIndicatorExpansionBefore}`}

--- a/web/app/hooks/useDraggable.ts
+++ b/web/app/hooks/useDraggable.ts
@@ -54,6 +54,7 @@ type UseDraggableOptions = {
 	showIndicators?: boolean;
 	previousRowId?: string;
 	nextRowId?: string;
+	isDraggable?: boolean;
 };
 
 type UseDraggableResult = {
@@ -69,6 +70,7 @@ export function useDraggable({
 	showIndicators = false,
 	previousRowId,
 	nextRowId,
+	isDraggable = true,
 }: UseDraggableOptions): UseDraggableResult {
 	const { dragging, dropIndicator, dispatchDropIndicator } = useDragContext();
 
@@ -160,30 +162,36 @@ export function useDraggable({
 		invariant(element, "useDraggable useEffect: ref.current is not defined");
 
 		return combine(
-			draggable({
-				element,
-				getInitialData: () => ({ rowId: rowId }),
-				onGenerateDragPreview: ({ location, source, nativeSetDragImage }) => {
-					const rect = source.element.getBoundingClientRect();
+			...(isDraggable
+				? [
+						draggable({
+							element,
+							getInitialData: () => ({ rowId: rowId }),
+							onGenerateDragPreview: ({
+								location,
+								source,
+								nativeSetDragImage,
+							}) => {
+								const rect = source.element.getBoundingClientRect();
 
-					if (nativeSetDragImage) {
-						setCustomNativeDragPreview({
-							nativeSetDragImage,
-							getOffset: preserveOffsetOnSource({
-								element,
-								input: location.current.input,
-							}),
-							render({ container }: { container: HTMLElement }) {
-								setState({ type: "preview", container, rect });
-								return () => setState(draggingState);
+								setCustomNativeDragPreview({
+									nativeSetDragImage,
+									getOffset: preserveOffsetOnSource({
+										element,
+										input: location.current.input,
+									}),
+									render({ container }: { container: HTMLElement }) {
+										setState({ type: "preview", container, rect });
+										return () => setState(draggingState);
+									},
+								});
 							},
-						});
-					}
-				},
 
-				onDragStart: () => setState(draggingState),
-				onDrop: () => setState(idleState),
-			}),
+							onDragStart: () => setState(draggingState),
+							onDrop: () => setState(idleState),
+						}),
+					]
+				: []),
 			dropTargetForExternal({
 				element,
 			}),
@@ -220,6 +228,7 @@ export function useDraggable({
 		currentRow?.config.view.content.children?.length,
 		dispatchDropIndicator,
 		dropIndicator,
+		isDraggable,
 		onDragEvent,
 		rowId,
 	]);

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -7,6 +7,7 @@ export const UnknownRow = defineRow("UnknownRow", {
 	config: {
 		type: "Text",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Unknown row",

--- a/web/app/rows/action/ButtonRow.tsx
+++ b/web/app/rows/action/ButtonRow.tsx
@@ -6,6 +6,7 @@ import { RowLayout } from "../design-system/RowLayout";
 export default defineRow("ButtonRow", {
 	config: {
 		type: "Button",
+		source: "",
 		view: {
 			content: {
 				title: "",

--- a/web/app/rows/action/TextActionRow.tsx
+++ b/web/app/rows/action/TextActionRow.tsx
@@ -7,6 +7,7 @@ export default defineRow("TextActionRow", {
 	config: {
 		type: "TextAction",
 		actions: [],
+		source: "{item}",
 		view: {
 			content: {
 				title: "Text action row title",

--- a/web/app/rows/container/ColumnContainerRow.tsx
+++ b/web/app/rows/container/ColumnContainerRow.tsx
@@ -9,6 +9,7 @@ export default defineRow(typeName, {
 	config: {
 		type: "ColumnContainer",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Column container row title",

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -9,6 +9,7 @@ export default defineRow(typeName, {
 	config: {
 		type: "ListContainer",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "List container row title",

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -29,6 +29,7 @@ export default defineRow(typeName, {
 	config: {
 		type: "SelectSegmentContainer",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Select segment container row title",

--- a/web/app/rows/container/SheetContainerRow.tsx
+++ b/web/app/rows/container/SheetContainerRow.tsx
@@ -9,6 +9,7 @@ export default defineRow(typeName, {
 	config: {
 		type: "SheetContainer",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Sheet container row title",

--- a/web/app/rows/edit/CalendarRow.tsx
+++ b/web/app/rows/edit/CalendarRow.tsx
@@ -6,6 +6,7 @@ export default defineRow("CalendarRow", {
 	config: {
 		type: "Calendar",
 		actions: [],
+		source: "{item}",
 		view: {
 			content: {
 				title: "Calendar row title",

--- a/web/app/rows/edit/DropdownRow.tsx
+++ b/web/app/rows/edit/DropdownRow.tsx
@@ -11,7 +11,7 @@ export default defineRow("DropdownRow", {
 			content: {
 				title: "Dropdown row title",
 				placeholder: "placeholder",
-				format: "{$0.value}",
+				format: "{datum.value}",
 			},
 			data: "",
 		},

--- a/web/app/rows/edit/DropdownRow.tsx
+++ b/web/app/rows/edit/DropdownRow.tsx
@@ -7,20 +7,20 @@ export default defineRow("DropdownRow", {
 	config: {
 		type: "Dropdown",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Dropdown row title",
 				placeholder: "placeholder",
 				format: "{datum.value}",
 			},
-			data: "",
 		},
 		destination: "{condition}",
 	} satisfies RowConfig,
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<Dropdown
-				value={row.config.view.data ?? ""}
+				value={row.config.source}
 				placeholder={row.config.view.content.placeholder ?? ""}
 			/>
 		</RowLayout>

--- a/web/app/rows/edit/InlinePickerRow.tsx
+++ b/web/app/rows/edit/InlinePickerRow.tsx
@@ -10,7 +10,7 @@ export default defineRow("InlinePickerRow", {
 		view: {
 			content: {
 				title: "Inline picker row title",
-				format: "{$0.value}",
+				format: "{datum.value}",
 			},
 			data: "",
 		},

--- a/web/app/rows/edit/InlinePickerRow.tsx
+++ b/web/app/rows/edit/InlinePickerRow.tsx
@@ -7,12 +7,12 @@ export default defineRow("InlinePickerRow", {
 	config: {
 		type: "InlinePicker",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Inline picker row title",
 				format: "{datum.value}",
 			},
-			data: "",
 		},
 		destination: "{distance}",
 	} satisfies RowConfig,

--- a/web/app/rows/edit/InputRow.tsx
+++ b/web/app/rows/edit/InputRow.tsx
@@ -7,6 +7,7 @@ export default defineRow("InputRow", {
 	config: {
 		type: "Input",
 		actions: [],
+		source: "{item}",
 		view: {
 			content: {
 				title: "Input row title",

--- a/web/app/rows/edit/SearchRow.tsx
+++ b/web/app/rows/edit/SearchRow.tsx
@@ -8,13 +8,13 @@ export default defineRow("SearchRow", {
 	config: {
 		type: "Search",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Search row title",
 				format: "{datum.value}",
 				placeholder: "placeholder",
 			},
-			data: "",
 		},
 		destination: "{address}",
 	} satisfies RowConfig,
@@ -23,7 +23,7 @@ export default defineRow("SearchRow", {
 			<div className="evy-relative">
 				<InlineIcon icon="::search::" alt="Search" />
 				<Input
-					value={row.config.view.data ?? ""}
+					value={row.config.source}
 					placeholder={row.config.view.content.placeholder ?? ""}
 				/>
 			</div>

--- a/web/app/rows/edit/SearchRow.tsx
+++ b/web/app/rows/edit/SearchRow.tsx
@@ -11,7 +11,7 @@ export default defineRow("SearchRow", {
 		view: {
 			content: {
 				title: "Search row title",
-				format: "{$0.value}",
+				format: "{datum.value}",
 				placeholder: "placeholder",
 			},
 			data: "",

--- a/web/app/rows/edit/SelectPhotoRow.tsx
+++ b/web/app/rows/edit/SelectPhotoRow.tsx
@@ -7,6 +7,7 @@ export default defineRow("SelectPhotoRow", {
 	config: {
 		type: "SelectPhoto",
 		actions: [],
+		source: "{item}",
 		view: {
 			content: {
 				title: "Select photo row title",

--- a/web/app/rows/edit/TextAreaRow.tsx
+++ b/web/app/rows/edit/TextAreaRow.tsx
@@ -7,6 +7,7 @@ export default defineRow("TextAreaRow", {
 	config: {
 		type: "TextArea",
 		actions: [],
+		source: "{item}",
 		view: {
 			content: {
 				title: "Text area row title",

--- a/web/app/rows/edit/TextSelectRow.tsx
+++ b/web/app/rows/edit/TextSelectRow.tsx
@@ -8,6 +8,7 @@ export default defineRow("TextSelectRow", {
 	config: {
 		type: "TextSelect",
 		actions: [],
+		source: "{item}",
 		view: {
 			content: {
 				title: "Text select row title",

--- a/web/app/rows/view/InfoRow.tsx
+++ b/web/app/rows/view/InfoRow.tsx
@@ -7,6 +7,7 @@ export default defineRow("InfoRow", {
 	config: {
 		type: "Info",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Info row title",

--- a/web/app/rows/view/InputListRow.tsx
+++ b/web/app/rows/view/InputListRow.tsx
@@ -7,19 +7,19 @@ export default defineRow("InputListRow", {
 	config: {
 		type: "InputList",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Input list row title",
 				placeholder: "Search for tags",
 				format: "{datum.value}",
 			},
-			data: "",
 		},
 	} satisfies RowConfig,
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<Input
-				value={row.config.view.data ?? ""}
+				value={row.config.source}
 				placeholder={row.config.view.content.placeholder ?? ""}
 			/>
 		</RowLayout>

--- a/web/app/rows/view/InputListRow.tsx
+++ b/web/app/rows/view/InputListRow.tsx
@@ -11,7 +11,7 @@ export default defineRow("InputListRow", {
 			content: {
 				title: "Input list row title",
 				placeholder: "Search for tags",
-				format: "{$0.value}",
+				format: "{datum.value}",
 			},
 			data: "",
 		},

--- a/web/app/rows/view/TextRow.tsx
+++ b/web/app/rows/view/TextRow.tsx
@@ -7,6 +7,7 @@ export default defineRow("TextRow", {
 	config: {
 		type: "Text",
 		actions: [],
+		source: "",
 		view: {
 			content: {
 				title: "Text row title",

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 
 import type { AppState } from "../../types/actions";
-import type { Row } from "../../types/row";
+import type { Row, RowConfig } from "../../types/row";
 
 function MockTextBase() {
 	return null;
@@ -12,6 +12,7 @@ const mockTextWithConfig = MockTextBase as typeof MockTextBase & {
 };
 mockTextWithConfig.config = {
 	type: "Text",
+	source: "",
 	actions: [],
 	view: {
 		content: { title: "", text: "" },
@@ -31,6 +32,7 @@ function textRow(id: string, text = "hello"): Row {
 		row: null,
 		config: {
 			type: "Text",
+			source: "",
 			actions: [],
 			view: {
 				content: { title: "T", text },
@@ -46,6 +48,7 @@ function sheetRow(id: string, child: Row, children: Row[] = []): Row {
 		row: null,
 		config: {
 			type: "SheetContainer",
+			source: "",
 			actions: [],
 			view: {
 				content: {
@@ -156,6 +159,54 @@ describe("pageReducer", () => {
 		});
 		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
 		expect(row?.config.view.content.text).toEqual(["a", "b"]);
+	});
+
+	it("UPDATE_ROW_ROOT sets source without changing view.content", () => {
+		const state = initialState();
+		const before = state.flows[0].pages[0].rows.find((r) => r.id === "row-1");
+		const next = pageReducer(state, {
+			type: "UPDATE_ROW_ROOT",
+			rowId: "row-1",
+			field: "source",
+			value: "{items}",
+		});
+		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
+		expect(row?.config.source).toBe("{items}");
+		expect(row?.config.view.content).toEqual(before?.config.view.content);
+	});
+
+	it("UPDATE_ROW_ROOT clears destination when value is empty string", () => {
+		const base = textRow("row-1");
+		const rowWithDestination: Row = {
+			...base,
+			config: {
+				...base.config,
+				destination: "{title}",
+			} satisfies RowConfig,
+		};
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [rowWithDestination],
+						},
+					],
+				},
+			],
+		});
+		const next = pageReducer(state, {
+			type: "UPDATE_ROW_ROOT",
+			rowId: "row-1",
+			field: "destination",
+			value: "",
+		});
+		const row = next.flows[0].pages[0].rows[0];
+		expect(row.config.destination).toBeUndefined();
 	});
 
 	it("SET_ACTIVE_ROW updates selection", () => {

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -18,6 +18,18 @@ import {
 } from "../../utils/flowFactory";
 import { findFlowById } from "../../utils/flowHelpers";
 
+function mapRowAcrossPages(
+	pages: UI_Page[],
+	rowId: string,
+	updater: (row: Row) => Row,
+): UI_Page[] {
+	return pages.map((page) => ({
+		...page,
+		rows: updateRowInTree(page.rows, rowId, updater),
+		footer: page.footer?.id === rowId ? updater(page.footer) : page.footer,
+	}));
+}
+
 export const pageReducer = (state: AppState, action: RowAction): AppState => {
 	if (action.type === "SET_ACTIVE_FLOW") {
 		return {
@@ -244,17 +256,26 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				},
 			});
 
-			const newPages = flow.pages.map((page) => {
-				const updatedFooter =
-					page.footer?.id === action.rowId ? updater(page.footer) : page.footer;
-				return {
-					...page,
-					rows: updateRowInTree(page.rows, action.rowId, updater),
-					footer: updatedFooter,
-				};
+			return updateState({
+				updatedPages: mapRowAcrossPages(flow.pages, action.rowId, updater),
+			});
+		}
+		case "UPDATE_ROW_ROOT": {
+			const updater = (row: Row): Row => ({
+				...row,
+				config: {
+					...row.config,
+					...(action.field === "source"
+						? { source: action.value }
+						: {
+								destination: action.value === "" ? undefined : action.value,
+							}),
+				},
 			});
 
-			return updateState({ updatedPages: newPages });
+			return updateState({
+				updatedPages: mapRowAcrossPages(flow.pages, action.rowId, updater),
+			});
 		}
 		case "UPDATE_ROW_ACTIONS": {
 			const updater = (row: Row): Row => ({
@@ -265,17 +286,9 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				},
 			});
 
-			const newPages = flow.pages.map((page) => {
-				const updatedFooter =
-					page.footer?.id === action.rowId ? updater(page.footer) : page.footer;
-				return {
-					...page,
-					rows: updateRowInTree(page.rows, action.rowId, updater),
-					footer: updatedFooter,
-				};
+			return updateState({
+				updatedPages: mapRowAcrossPages(flow.pages, action.rowId, updater),
 			});
-
-			return updateState({ updatedPages: newPages });
 		}
 		case "SET_ACTIVE_ROW": {
 			const page = flow.pages.find(

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -32,6 +32,12 @@ export type RowAction =
 			configValue: string;
 	  }
 	| {
+			type: "UPDATE_ROW_ROOT";
+			rowId: string;
+			field: "source" | "destination";
+			value: string;
+	  }
+	| {
 			type: "UPDATE_ROW_ACTIONS";
 			rowId: string;
 			actions: UI_RowAction[];

--- a/web/app/utils/decodeFlow.ts
+++ b/web/app/utils/decodeFlow.ts
@@ -12,7 +12,8 @@ import { baseRows } from "../rows/baseRows";
 import { UnknownRow } from "../rows/EVYRow";
 
 function encodeRow(row: Row): ServerRow {
-	const content = row.config.view.content;
+	const { view, ...rowRoot } = row.config;
+	const content = view.content;
 
 	// Build the encoded content, converting Row children/child to ServerRow
 	const encodedContent: ServerRowContent = { title: content.title };
@@ -46,13 +47,11 @@ function encodeRow(row: Row): ServerRow {
 
 	return {
 		id: row.id,
-		type: row.config.type,
+		...rowRoot,
 		view: {
-			...row.config.view,
+			...view,
 			content: encodedContent,
 		},
-		destination: row.config.destination,
-		actions: row.config.actions,
 	};
 }
 

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -107,6 +107,41 @@ test.describe("Row configuration", () => {
 		await expect(textInput).toHaveValue("Updated info text");
 	});
 
+	test("should display and edit Source binding in configuration panel", async ({
+		page,
+	}) => {
+		await openAppWithTestFlows(page, [
+			{
+				id: "step_1",
+				title: "Test Page",
+				rows: [
+					{
+						type: "Info",
+						source: "{initial}",
+						view: {
+							content: {
+								title: "Binding row",
+								text: "Body",
+							},
+						},
+						actions: [],
+					},
+				],
+			},
+		]);
+		await page.getByText("Binding row", { exact: true }).first().click();
+
+		const configPanel = getConfigPanel(page);
+		const sourceInput = configPanel.getByLabel("Row data source");
+		await expect(sourceInput).toBeVisible();
+		await expect(sourceInput).toHaveValue("{initial}");
+
+		await sourceInput.clear();
+		await sourceInput.fill("{items}");
+
+		await expect(sourceInput).toHaveValue("{items}");
+	});
+
 	test("should display and edit action items via popup", async ({ page }) => {
 		await openAppWithTestFlows(page, [
 			{

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -203,6 +203,35 @@ test.describe("Drag & Drop UX", () => {
 		expect(newRowCount).toBe(initialRowCount - 1);
 	});
 
+	test("should remove an empty column container by dragging it to the left sidebar", async ({
+		page,
+	}) => {
+		await setupTwoEmptyTestPages(page);
+
+		const rowsPanel = await getRowsPanel(page);
+		const firstPage = getFirstPage(page);
+		const pageContent = getPageContent(page);
+
+		const columnSidebarRow = await getSidebarRow(
+			page,
+			"Column container row title",
+		);
+		await columnSidebarRow.dragTo(pageContent);
+
+		await expect(
+			firstPage.getByText("Column container row title", { exact: true }),
+		).toBeVisible();
+
+		const emptyColumnRow = pageContent
+			.locator(SELECTORS.draggableRow)
+			.filter({ hasText: "Column container row title" });
+		await emptyColumnRow.dragTo(rowsPanel);
+
+		await expect(
+			firstPage.getByText("Column container row title", { exact: true }),
+		).not.toBeVisible();
+	});
+
 	test("should drag a row from position 1 to 2 on a page", async ({ page }) => {
 		await setupTwoEmptyTestPages(page);
 

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -22,9 +22,9 @@ interface ServerRowInputContent {
 interface ServerRowInput {
 	id?: string;
 	type: ServerRow["type"];
+	source?: string;
 	view: {
 		content: ServerRowInputContent;
-		data?: string;
 		max_lines?: string;
 	};
 	destination?: string;
@@ -169,9 +169,9 @@ function ensureRowId(row: ServerRowInput): ServerRow {
 		type: row.type,
 		view: {
 			content,
-			data: row.view.data,
 			max_lines: row.view.max_lines,
 		},
+		source: row.source ?? "",
 		destination: row.destination,
 		actions: row.actions,
 	};


### PR DESCRIPTION
## Summary

This branch aligns SDUI content with a `source` attribute (replacing prior `data` usage where applicable), extends web configuration and page editing behavior, improves drag-and-drop (including empty containers), and updates docs, seeds, generated Swift, and tests across API, web, and iOS.

## Changes

- **Schema & docs**: Update EVY SDUI JSON schema and service examples; refresh `evy_sdui.json`, `service_sdui.json`, and SDUI readme. Tighten row-content spec.
- **Codegen**: Adjust `generate-swift-sdui.ts` and Swift row/page types so iOS matches the new shape (dropdown, search, inline picker, input list, etc.).
- **Web**: `ConfigurationPanel` and `pageReducer` changes for editing flows; `decodeFlow` updates; row components pass through updated props; new/extended Playwright coverage for configuration and drag-and-drop.
- **Dragging**: `useDraggable`, `DraggableRowContainer`, and placeholder indicator tweaks so dragging empty containers behaves correctly.
- **Seeds & API test**: `scripts/seed.ts` and `api/src/tests/data.test.ts` adjusted for the new SDUI shape.

## JIRA

(JIRA ticket URL to be added)

## Figma

(To be filled if applicable)

## Stream / Loom

(To be filled if applicable)


Made with [Cursor](https://cursor.com)