### PR TITLE
[FEAT] Smooth canvas cursor easing and dot-field morph tuning

### DIFF
--- a/web/app/components/CanvasViewport.tsx
+++ b/web/app/components/CanvasViewport.tsx
@@ -15,6 +15,9 @@ import { useFocusPanOnEnter } from "../hooks/useFocusPanOnEnter";
 import { useViewportGestures } from "../hooks/useViewportGestures";
 import { CameraContext } from "../state/contexts/CameraContext";
 
+/** Time constant for display cursor to ease toward the pointer (~95% in this many ms). */
+const CURSOR_EASE_MS = 200;
+
 const worldStyle: CSSProperties = {
 	transformOrigin: "0 0",
 	willChange: "transform",
@@ -55,7 +58,9 @@ export function CanvasViewport({
 
 	const contentMeasureRef = useRef<HTMLDivElement | null>(null);
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
-	const cursorRef = useRef<CursorPosition>(null);
+	const targetCursorRef = useRef<CursorPosition>(null);
+	const displayCursorRef = useRef<CursorPosition>(null);
+	const lastCursorEaseTsRef = useRef<number | null>(null);
 	const camRef = useRef(getCamera());
 	const disableMorphRef = useRef(false);
 	const requestRepaintRef = useRef<() => void>(() => {});
@@ -84,6 +89,7 @@ export function CanvasViewport({
 		}
 
 		let rafId: number | null = null;
+		const easeTauMs = CURSOR_EASE_MS / 3;
 
 		const paintDotField = () => {
 			const cssWidth = canvas.clientWidth;
@@ -115,7 +121,7 @@ export function CanvasViewport({
 				scale: currentCam.scale,
 				offsetX: currentCam.offsetX,
 				offsetY: currentCam.offsetY,
-				cursor: cursorRef.current,
+				cursor: displayCursorRef.current,
 				backgroundColor: style.getPropertyValue("--color-evy-light").trim(),
 				colorMedium: style.getPropertyValue("--color-evy-gray-medium").trim(),
 				colorDark: style.getPropertyValue("--color-evy-gray-dark").trim(),
@@ -123,14 +129,50 @@ export function CanvasViewport({
 			});
 		};
 
+		const tick = (timeStamp: number) => {
+			rafId = null;
+
+			const target = targetCursorRef.current;
+			const display = displayCursorRef.current;
+
+			let stillAnimating = false;
+
+			if (target === null) {
+				displayCursorRef.current = null;
+				lastCursorEaseTsRef.current = null;
+			} else if (display === null) {
+				displayCursorRef.current = { x: target.x, y: target.y };
+				lastCursorEaseTsRef.current = timeStamp;
+			} else {
+				const lastTs = lastCursorEaseTsRef.current;
+				const dt = lastTs !== null ? Math.max(0.0001, timeStamp - lastTs) : 16;
+				lastCursorEaseTsRef.current = timeStamp;
+
+				const alpha = 1 - Math.exp(-dt / easeTauMs);
+				const nx = display.x + (target.x - display.x) * alpha;
+				const ny = display.y + (target.y - display.y) * alpha;
+				if (Math.hypot(target.x - nx, target.y - ny) < 0.1) {
+					displayCursorRef.current = { x: target.x, y: target.y };
+				} else {
+					displayCursorRef.current = { x: nx, y: ny };
+					stillAnimating = true;
+				}
+			}
+
+			paintDotField();
+
+			if (stillAnimating) {
+				rafId = requestAnimationFrame(tick);
+			} else {
+				lastCursorEaseTsRef.current = null;
+			}
+		};
+
 		const schedulePaint = () => {
 			if (rafId != null) {
 				return;
 			}
-			rafId = requestAnimationFrame(() => {
-				rafId = null;
-				paintDotField();
-			});
+			rafId = requestAnimationFrame(tick);
 		};
 
 		requestRepaintRef.current = schedulePaint;
@@ -142,7 +184,7 @@ export function CanvasViewport({
 
 		const onMove = (event: MouseEvent) => {
 			const rect = canvas.getBoundingClientRect();
-			cursorRef.current = {
+			targetCursorRef.current = {
 				x: event.clientX - rect.left,
 				y: event.clientY - rect.top,
 			};
@@ -150,7 +192,9 @@ export function CanvasViewport({
 		};
 
 		const onLeave = () => {
-			cursorRef.current = null;
+			targetCursorRef.current = null;
+			displayCursorRef.current = null;
+			lastCursorEaseTsRef.current = null;
 			schedulePaint();
 		};
 

--- a/web/app/components/canvasDotField.ts
+++ b/web/app/components/canvasDotField.ts
@@ -65,7 +65,8 @@ export function drawDotField(params: DrawDotFieldParams): void {
 
 	const dotBaseRadius = DOT_BASE_RADIUS * scale;
 	const dotHoverRadius = DOT_HOVER_RADIUS * scale;
-	const morphRadius = MORPH_RADIUS_PX * scale;
+	/** Fixed in CSS px so zoom changes how many grid cells fall inside the radius. */
+	const morphRadius = MORPH_RADIUS_PX;
 
 	const half = gridSize / 2;
 	const iStart = Math.ceil((0 - offsetX - half) / gridSize);
@@ -84,7 +85,8 @@ export function drawDotField(params: DrawDotFieldParams): void {
 			const baseX = offsetX + i * gridSize + half;
 			const baseY = offsetY + j * gridSize + half;
 
-			let influence = 0;
+			let colorInfluence = 0;
+			let pullInfluence = 0;
 			let dx = 0;
 			let dy = 0;
 			let d = 0;
@@ -92,27 +94,27 @@ export function drawDotField(params: DrawDotFieldParams): void {
 				dx = cursorX - baseX;
 				dy = cursorY - baseY;
 				d = Math.hypot(dx, dy);
-				if (d < R && d > 1e-6) {
-					const t = 1 - d / R;
-					influence = t * t;
-				} else if (d <= 1e-6) {
-					influence = 1;
+				if (d < R) {
+					const t = d / R;
+					const oneMinusT = 1 - t;
+					colorInfluence = oneMinusT * oneMinusT;
+					pullInfluence = Math.sin(Math.PI * t);
 				}
 			}
 
 			let drawX = baseX;
 			let drawY = baseY;
-			if (!disableMorph && hasCursor && influence > 0 && d > 1e-6) {
-				const pull = influence * MORPH_STRENGTH * gridSize;
+			if (!disableMorph && hasCursor && pullInfluence > 0 && d > 1e-6) {
+				const pull = pullInfluence * MORPH_STRENGTH * gridSize;
 				drawX += (dx / d) * pull;
 				drawY += (dy / d) * pull;
 			}
 
-			const colorT = Math.sqrt(influence);
+			const colorT = Math.sqrt(colorInfluence);
 			ctx.fillStyle = mixDotColor(colorMedium, colorDark, colorT);
 
 			const radius =
-				dotBaseRadius + (dotHoverRadius - dotBaseRadius) * influence;
+				dotBaseRadius + (dotHoverRadius - dotBaseRadius) * colorInfluence;
 			ctx.beginPath();
 			ctx.arc(drawX, drawY, radius, 0, Math.PI * 2);
 			ctx.fill();


### PR DESCRIPTION
## Summary

- **Canvas viewport:** Split the cursor into a target (pointer) position and a display position. The display position eases toward the target with an exponential decay (~`CURSOR_EASE_MS` / 3 time constant per step) so the dot field reacts smoothly instead of snapping every frame. Paint runs on a `requestAnimationFrame` loop while easing is active.
- **Dot field:** Keep the morph influence radius in **CSS pixels** (not scaled by zoom) so zoom changes how many grid cells fall inside the effect. Separate **color/size** influence (quadratic falloff) from **pull** influence (sine-based) so dots can move with a different curve than their highlight.

## JIRA

## Testing

- [ ] Manual check in web builder canvas (cursor move / leave; zoom levels)

Made with [Cursor](https://cursor.com)