### PR TITLE
[FEAT] Search rows, preview, and info row across web and iOS

### DIFF
--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -15,7 +15,7 @@ jobs:
             run:
                 working-directory: web
 
-        timeout-minutes: 2
+        timeout-minutes: 3
         runs-on: ubuntu-latest
         container: ghcr.io/evy-platform/evy-ci:playwright-1.59.1
         steps:

--- a/docs/evy/evy_sdui.json
+++ b/docs/evy/evy_sdui.json
@@ -11,6 +11,8 @@
 						"id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
 						"type": "ColumnContainer",
 						"source": "",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
@@ -19,42 +21,43 @@
 										"id": "441c1433-446b-4682-854d-5d795ef52709",
 										"type": "Button",
 										"source": "",
-										"view": {
-											"content": {
-												"title": "",
-												"label": "View"
-											}
-										},
+										"destination": "",
 										"actions": [
 											{
 												"condition": "",
 												"false": "",
 												"true": "navigate:74a49d4b-2176-4925-857a-e29e2991f1bd:82cae120-c7b1-4c29-bd42-e1521320b109"
 											}
-										]
+										],
+										"view": {
+											"content": {
+												"title": "",
+												"label": "View"
+											}
+										}
 									},
 									{
 										"id": "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
 										"type": "Button",
 										"source": "",
-										"view": {
-											"content": {
-												"title": "",
-												"label": "Create"
-											}
-										},
+										"destination": "",
 										"actions": [
 											{
 												"condition": "",
 												"false": "",
 												"true": "navigate:ca47e6c5-da19-4491-8422-adb40d9e8a27:306ed62c-c2af-4652-a873-26c7a388972d"
 											}
-										]
+										],
+										"view": {
+											"content": {
+												"title": "",
+												"label": "Create"
+											}
+										}
 									}
 								]
 							}
-						},
-						"actions": []
+						}
 					}
 				]
 			}

--- a/docs/evy/sdui/readme.md
+++ b/docs/evy/sdui/readme.md
@@ -188,6 +188,8 @@ Row types are defined in the schema (`types/schema/sdui/evy.schema.json`) and th
 | Action     | Button, TextAction |
 | Container  | ColumnContainer, ListContainer, SheetContainer, SelectSegmentContainer |
 
-Each row type’s `view.content` may include type-specific keys (e.g. `label`, `value`, `placeholder`, `format`). See `row-content.spec.json` for the exact keys per type.
+Each row type’s `view.content` may include type-specific keys (e.g. `label`, `value`, `placeholder`, `format`, `child`, `children`). See `row-content.spec.json` for the exact keys per type.
 
-For list-backed rows (Dropdown, InlinePicker, Search, InputList, etc.), `format` is evaluated per item from the list resolved via `source`. Use `datum` as the placeholder for the current item in expressions, e.g. `{datum.value}` or `{datum.unit} {datum.street}, {datum.city}`.
+For list-backed rows (Dropdown, InlinePicker, InputList, etc.), `format` is evaluated per item from the list resolved via `source`. Use `datum` as the placeholder for the current item in expressions, e.g. `{datum.value}` or `{datum.unit} {datum.street}, {datum.city}`.
+
+For **Search** rows, iOS renders each hit using `view.content.child` (typically an `Info` row template) instead of `format`; string fields in that child row are evaluated with `datum` the same way. The web builder’s Search row stub does not render live results.

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -10,26 +10,23 @@
 					{
 						"id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
 						"type": "Text",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "My item is called",
 								"text": "{item.title}"
 							},
 							"max_lines": ""
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					}
 				],
 				"footer": {
 					"id": "4c953f9b-597b-4e0c-82f0-2fe25efefba0",
 					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Go home"
-						}
-					},
+					"source": "{item}",
+					"destination": "",
 					"actions": [
 						{
 							"condition": "",
@@ -37,7 +34,12 @@
 							"true": "close"
 						}
 					],
-					"source": "{item}"
+					"view": {
+						"content": {
+							"title": "",
+							"label": "Go home"
+						}
+					}
 				}
 			}
 		]
@@ -52,78 +54,81 @@
 					{
 						"id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
 						"type": "SelectPhoto",
+						"source": "{item}",
+						"destination": "{photo_ids}",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
+								"subtitle": "Photos: {count(photo_ids)}/10 - Chose your listing's main photo first.",
 								"icon": "::image-plus::",
-								"photos": "{photo_ids}",
 								"content": "Add photos",
-								"subtitle": "Photos: {count(photo_ids)}/10 - Chose your listing's main photo first."
+								"photos": "{photo_ids}"
 							}
-						},
-						"destination": "{photo_ids}",
-						"actions": [],
-						"source": "{item}"
+						}
 					},
 					{
 						"id": "c3d4e5f6-a7b8-4c9d-8e1f-2a3b4c5d6e7f",
 						"type": "Input",
+						"source": "{item}",
+						"destination": "{title}",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "A row title ::star::",
-								"value": "{title}",
-								"placeholder": "My iPhone ::star:: 20"
+								"placeholder": "My iPhone ::star:: 20",
+								"value": "{title}"
 							}
-						},
-						"destination": "{title}",
-						"actions": [],
-						"source": "{item}"
+						}
 					},
 					{
 						"id": "d4e5f6a7-b8c9-4d0e-8f2a-3b4c5d6e7f8a",
 						"type": "Input",
+						"source": "{item}",
+						"destination": "{buildCurrency(price)}",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "Price",
-								"value": "{formatCurrency(price)}",
-								"placeholder": "{formatCurrency(price)}"
+								"placeholder": "{formatCurrency(price)}",
+								"value": "{formatCurrency(price)}"
 							}
-						},
-						"destination": "{buildCurrency(price)}",
-						"actions": [],
-						"source": "{item}"
+						}
 					},
 					{
 						"id": "e5f6a7b8-c9d0-4e1f-8a3b-4c5d6e7f8a9b",
 						"type": "Dropdown",
+						"source": "{conditions}",
+						"destination": "{condition}",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "Condition",
-								"format": "{datum.value}",
-								"placeholder": "Choose one"
+								"placeholder": "Choose one",
+								"format": "{datum.value}"
 							}
-						},
-						"destination": "{condition}",
-						"actions": [],
-						"source": "{conditions}"
+						}
 					},
 					{
 						"id": "f6a7b8c9-d0e1-4f2a-8b4c-5d6e7f8a9b0c",
 						"type": "Dropdown",
+						"source": "{selling_reasons}",
+						"destination": "{selling_reason}",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "Selling Reason",
-								"format": "{datum.value}",
-								"placeholder": "Choose one"
+								"placeholder": "Choose one",
+								"format": "{datum.value}"
 							}
-						},
-						"destination": "{selling_reason}",
-						"actions": [],
-						"source": "{selling_reasons}"
+						}
 					},
 					{
 						"id": "a7b8c9d0-e1f2-4a3b-8c5d-6e7f8a9b0c1d",
 						"type": "ColumnContainer",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "Dimensions (width x height x depth)",
@@ -131,102 +136,111 @@
 									{
 										"id": "b66e136d-828d-4ed0-ae27-cdc48f7cbffd",
 										"type": "Input",
+										"source": "{item}",
+										"destination": "{width}",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
-												"value": "{formatDimension(width)}",
-												"placeholder": "Width"
+												"placeholder": "Width",
+												"value": "{formatDimension(width)}"
 											}
-										},
-										"destination": "{width}",
-										"actions": [],
-										"source": "{item}"
+										}
 									},
 									{
 										"id": "09a9f654-1c2c-42f8-9a6a-4608fc248478",
 										"type": "Input",
+										"source": "{item}",
+										"destination": "{height}",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
-												"value": "{formatDimension(height)}",
-												"placeholder": "Height"
+												"placeholder": "Height",
+												"value": "{formatDimension(height)}"
 											}
-										},
-										"destination": "{height}",
-										"actions": [],
-										"source": "{item}"
+										}
 									},
 									{
 										"id": "7484ce1a-0771-45d2-a1cf-8b1336cfd018",
 										"type": "Input",
+										"source": "{item}",
+										"destination": "{length}",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
-												"value": "{formatDimension(length)}",
-												"placeholder": "Length"
+												"placeholder": "Length",
+												"value": "{formatDimension(length)}"
 											}
-										},
-										"destination": "{length}",
-										"actions": [],
-										"source": "{item}"
+										}
 									}
 								]
 							}
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					},
 					{
 						"id": "6c48841c-079f-4c58-bab6-af96a87d7399",
 						"type": "SheetContainer",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
 								"child": {
 									"id": "2422c9ec-df63-4fde-9632-0fe159c0b40e",
 									"type": "InputList",
+									"source": "{tags}",
+									"destination": "",
+									"actions": [],
 									"view": {
 										"content": {
 											"title": "Tags",
-											"format": "{datum.value}",
-											"placeholder": "Search for tags"
+											"placeholder": "Search for tags",
+											"format": "{datum.value}"
 										}
-									},
-									"actions": [],
-									"source": "{tags}"
+									}
 								},
 								"children": [
 									{
 										"id": "8f8c442e-ee2d-4974-9ef1-29005f3311e6",
 										"type": "Search",
+										"source": "{api:tags}",
+										"destination": "{tags}",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
-												"format": "{datum.value}",
-												"placeholder": "Search for tags"
+												"placeholder": "Search for tags",
+												"child": {
+													"id": "a1b2c3d4-e5f6-4789-a012-3456789abcde",
+													"type": "Info",
+													"source": "",
+													"destination": "",
+													"actions": [],
+													"view": {
+														"content": {
+															"title": "{datum.value}",
+															"subtitle": "",
+															"icon": ""
+														}
+													}
+												}
 											}
-										},
-										"destination": "{tags}",
-										"actions": [],
-										"source": "{api:tags}"
+										}
 									}
 								]
 							}
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					}
 				],
 				"title": "Create listing",
 				"footer": {
 					"id": "acabbedc-0a5a-4f10-8e0c-3d6cf76d86e8",
 					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"source": "{item}",
+					"destination": "",
 					"actions": [
 						{
 							"condition": "{length(title) > 0}",
@@ -269,7 +283,12 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,06b21b52-0845-468a-ace1-170a3b05f3a2)}"
 						}
 					],
-					"source": "{item}"
+					"view": {
+						"content": {
+							"title": "",
+							"label": "Next"
+						}
+					}
 				}
 			},
 			{
@@ -278,28 +297,24 @@
 					{
 						"id": "c9d0e1f2-a3b4-4c5d-8e7f-8a9b0c1d2e3f",
 						"type": "TextArea",
+						"source": "{item}",
+						"destination": "{description}",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
 								"value": "",
 								"placeholder": "Write a short description of your product"
 							}
-						},
-						"destination": "{description}",
-						"actions": [],
-						"source": "{item}"
+						}
 					}
 				],
 				"title": "Describe item",
 				"footer": {
 					"id": "cc86c53a-170d-4800-8897-8f99f3697055",
 					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"source": "{item}",
+					"destination": "",
 					"actions": [
 						{
 							"condition": "{length(description) > 0}",
@@ -307,7 +322,12 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,26dae81a-4122-4b5c-8396-a72a319ccd8b)}"
 						}
 					],
-					"source": "{item}"
+					"view": {
+						"content": {
+							"title": "",
+							"label": "Next"
+						}
+					}
 				}
 			},
 			{
@@ -316,13 +336,24 @@
 					{
 						"id": "d0e1f2a3-b4c5-4d6e-8f8a-9b0c1d2e3f4a",
 						"type": "SelectSegmentContainer",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
+								"segments": [
+									"Pickup",
+									"Delivery",
+									"Shipping"
+								],
 								"children": [
 									{
 										"id": "22222222-2222-4222-8222-222222222201",
 										"type": "ListContainer",
+										"source": "{item}",
+										"destination": "",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
@@ -330,106 +361,125 @@
 													{
 														"id": "22222222-2222-4222-8222-222222222202",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
-																"text": "Allow buyers to pick up the item"
+																"subtitle": "Allow buyers to pick up the item",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222203",
 														"type": "SheetContainer",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
 																"child": {
 																	"id": "22222222-2222-4222-8222-222222222204",
 																	"type": "TextAction",
+																	"source": "{item}",
+																	"destination": "{pickup_address}",
+																	"actions": [],
 																	"view": {
 																		"content": {
 																			"title": "Where",
 																			"text": "{formatAddress(pickup_address)}",
-																			"action": "Change",
-																			"placeholder": "Enter pick up address"
+																			"placeholder": "Enter pick up address",
+																			"action": "Change"
 																		}
-																	},
-																	"destination": "{pickup_address}",
-																	"actions": [],
-																	"source": "{item}"
+																	}
 																},
 																"children": [
 																	{
 																		"id": "22222222-2222-4222-8222-222222222205",
 																		"type": "Search",
+																		"source": "local:address",
+																		"destination": "{address}",
+																		"actions": [],
 																		"view": {
 																			"content": {
 																				"title": "",
-																				"format": "{datum.unit} {datum.street}, {datum.city} {datum.state} {datum.postcode}",
-																				"placeholder": "Search address"
+																				"placeholder": "Search address",
+																				"child": {
+																					"id": "33333333-3333-4333-8333-333333333305",
+																					"type": "Info",
+																					"source": "",
+																					"destination": "",
+																					"actions": [],
+																					"view": {
+																						"content": {
+																							"title": "{datum.unit} {datum.street}, {datum.city} {datum.state} {datum.postcode}",
+																							"subtitle": "",
+																							"icon": ""
+																						}
+																					}
+																				}
 																			}
-																		},
-																		"destination": "{address}",
-																		"actions": [],
-																		"source": "local:address"
+																		}
 																	}
 																]
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222206",
 														"type": "Input",
+														"source": "{item}",
+														"destination": "{address_instructions}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
-																"value": "{address_instructions}",
-																"placeholder": "Additional information"
+																"placeholder": "Additional information",
+																"value": "{address_instructions}"
 															}
-														},
-														"destination": "{address_instructions}",
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222207",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "When",
-																"text": "When are you available for buyers to inspect or pick up this item"
+																"subtitle": "When are you available for buyers to inspect or pick up this item",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222208",
 														"type": "Calendar",
+														"source": "{item}",
+														"destination": "{pickup_timeslots}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
 																"primary": "{pickup_timeslots}",
 																"secondary": "{delivery_timeslots}"
 															}
-														},
-														"destination": "{pickup_timeslots}",
-														"actions": [],
-														"source": "{item}"
+														}
 													}
 												]
 											}
-										},
-										"actions": [],
-										"source": "{item}"
+										}
 									},
 									{
 										"id": "22222222-2222-4222-8222-222222222209",
 										"type": "ListContainer",
+										"source": "{item}",
+										"destination": "",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
@@ -437,89 +487,96 @@
 													{
 														"id": "22222222-2222-4222-8222-222222222210",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
-																"text": "Deliver directly to the buyer"
+																"subtitle": "Deliver directly to the buyer",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222211",
 														"type": "Input",
+														"source": "{item}",
+														"destination": "{delivery_fee}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "Surcharge",
-																"value": "{formatCurrency(delivery_fee)}",
-																"placeholder": "Do you want to charge for delivery?"
+																"placeholder": "Do you want to charge for delivery?",
+																"value": "{formatCurrency(delivery_fee)}"
 															}
-														},
-														"destination": "{delivery_fee}",
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222212",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "How far",
-																"text": "How long can you travel to deliver this item"
+																"subtitle": "How long can you travel to deliver this item",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222213",
 														"type": "InlinePicker",
+														"source": "{durations}",
+														"destination": "{distance}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
 																"format": "{datum.value}"
 															}
-														},
-														"destination": "{distance}",
-														"actions": [],
-														"source": "{durations}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222214",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "When",
-																"text": "When are you available to deliver this item"
+																"subtitle": "When are you available to deliver this item",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222215",
 														"type": "Calendar",
+														"source": "{item}",
+														"destination": "{delivery_timeslots}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
 																"primary": "{delivery_timeslots}",
 																"secondary": "{pickup_timeslots}"
 															}
-														},
-														"destination": "{delivery_timeslots}",
-														"actions": [],
-														"source": "{item}"
+														}
 													}
 												]
 											}
-										},
-										"actions": [],
-										"source": "{item}"
+										}
 									},
 									{
 										"id": "22222222-2222-4222-8222-222222222216",
 										"type": "ListContainer",
+										"source": "{item}",
+										"destination": "",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "",
@@ -527,96 +584,87 @@
 													{
 														"id": "22222222-2222-4222-8222-222222222217",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
-																"text": "Postal shipping at the buyer's expense"
+																"subtitle": "Postal shipping at the buyer's expense",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222218",
 														"type": "Input",
+														"source": "{item}",
+														"destination": "{shipping_source_postal_code}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "Where from",
-																"value": "{shipping_source_postal_code}",
-																"placeholder": "Postal code you will be shipping from"
+																"placeholder": "Postal code you will be shipping from",
+																"value": "{shipping_source_postal_code}"
 															}
-														},
-														"destination": "{shipping_source_postal_code}",
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222219",
 														"type": "Info",
+														"source": "{item}",
+														"destination": "",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "Where to",
-																"text": "Select how far you are willing to ship"
+																"subtitle": "Select how far you are willing to ship",
+																"icon": ""
 															}
-														},
-														"actions": [],
-														"source": "{item}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222220",
 														"type": "InlinePicker",
+														"source": "{areas}",
+														"destination": "{shipping_destination_areas}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "",
 																"format": "{datum.value}"
 															}
-														},
-														"destination": "{shipping_destination_areas}",
-														"actions": [],
-														"source": "{areas}"
+														}
 													},
 													{
 														"id": "22222222-2222-4222-8222-222222222221",
 														"type": "Input",
+														"source": "{item}",
+														"destination": "{weight}",
+														"actions": [],
 														"view": {
 															"content": {
 																"title": "Weight (kg)",
-																"value": "{formatWeight(weight)}",
-																"placeholder": "Weight"
+																"placeholder": "Weight",
+																"value": "{formatWeight(weight)}"
 															}
-														},
-														"destination": "{weight}",
-														"actions": [],
-														"source": "{item}"
+														}
 													}
 												]
 											}
-										},
-										"actions": [],
-										"source": "{item}"
+										}
 									}
-								],
-								"segments": [
-									"Pickup",
-									"Delivery",
-									"Shipping"
 								]
 							}
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					}
 				],
 				"title": "Pickup & delivery",
 				"footer": {
 					"id": "b1600fd2-aac2-4399-8a94-72baca75b9ba",
 					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"source": "{item}",
+					"destination": "",
 					"actions": [
 						{
 							"condition": "{count(pickup_timeslots) > 0 || count(delivery_timeslots) > 0 || count(shipping_destination_areas) > 0}",
@@ -624,7 +672,12 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,25a3269b-344c-477d-89c8-b2f5426a5d91)}"
 						}
 					],
-					"source": "{item}"
+					"view": {
+						"content": {
+							"title": "",
+							"label": "Next"
+						}
+					}
 				}
 			},
 			{
@@ -633,18 +686,23 @@
 					{
 						"id": "e1f2a3b4-c5d6-4e7f-8a9b-0c1d2e3f4a5b",
 						"type": "Info",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
-								"text": "Payment will be made by the buyers on pickup"
+								"subtitle": "Payment will be made by the buyers on pickup",
+								"icon": ""
 							}
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					},
 					{
 						"id": "f2a3b4c5-d6e7-4f8a-9b0c-1d2e3f4a5b6c",
 						"type": "ListContainer",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
@@ -652,46 +710,40 @@
 									{
 										"id": "33333333-3333-4333-8333-333333333301",
 										"type": "TextSelect",
+										"source": "{item}",
+										"destination": "{payment_cash}",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "Accept cash",
 												"text": "Let buyers know you will accept cash on pickup"
 											}
-										},
-										"destination": "{payment_cash}",
-										"actions": [],
-										"source": "{item}"
+										}
 									},
 									{
 										"id": "33333333-3333-4333-8333-333333333302",
 										"type": "TextSelect",
+										"source": "{item}",
+										"destination": "{payment_app}",
+										"actions": [],
 										"view": {
 											"content": {
 												"title": "Accept app payments",
 												"text": "Benefit from EVY seller protection when accepting payments through the app on pickup\\n- Cards are verified before the purchase\\n- Payment is transferred immediately when both buyer and seller confirm using a temporary code"
 											}
-										},
-										"destination": "{payment_app}",
-										"actions": [],
-										"source": "{item}"
+										}
 									}
 								]
 							}
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					}
 				],
 				"title": "Payment options",
 				"footer": {
 					"id": "db46724f-c8f0-43cb-b888-6a23e4ca76cb",
 					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"source": "{item}",
+					"destination": "",
 					"actions": [
 						{
 							"condition": "{payment_cash == true || payment_app == true}",
@@ -699,7 +751,12 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,857362ad-856f-465b-85a3-94bc8bb686cd)}"
 						}
 					],
-					"source": "{item}"
+					"view": {
+						"content": {
+							"title": "",
+							"label": "Next"
+						}
+					}
 				}
 			},
 			{
@@ -708,26 +765,24 @@
 					{
 						"id": "a3b4c5d6-e7f8-4a9b-8c1d-2e3f4a5b6c7d",
 						"type": "Info",
+						"source": "{item}",
+						"destination": "",
+						"actions": [],
 						"view": {
 							"content": {
 								"title": "",
-								"text": "EVY is all about Data privacy. Your identity and profile information remains encrypted on your phone and inaccessible to anyone but you. However, the following information about your listing will be public:\n\n* Title & description\n* Photos\n* Condition & selling reason\n* Price\n* Dimension\n* Pickup address & schedule\n* Delivery schedule"
+								"subtitle": "EVY is all about Data privacy. Your identity and profile information remains encrypted on your phone and inaccessible to anyone but you. However, the following information about your listing will be public:\n\n* Title & description\n* Photos\n* Condition & selling reason\n* Price\n* Dimension\n* Pickup address & schedule\n* Delivery schedule",
+								"icon": ""
 							}
-						},
-						"actions": [],
-						"source": "{item}"
+						}
 					}
 				],
 				"title": "Sharing data publicly",
 				"footer": {
 					"id": "20e9a035-8a42-4282-8725-49b620866c70",
 					"type": "Button",
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Submit"
-						}
-					},
+					"source": "{item}",
+					"destination": "",
 					"actions": [
 						{
 							"condition": "",
@@ -735,7 +790,12 @@
 							"true": "{create(item)}"
 						}
 					],
-					"source": "{item}"
+					"view": {
+						"content": {
+							"title": "",
+							"label": "Submit"
+						}
+					}
 				}
 			}
 		]

--- a/ios/evy/Data/EVYSearchController.swift
+++ b/ios/evy/Data/EVYSearchController.swift
@@ -5,6 +5,7 @@
 //  Created by Geoffroy Lesage on 22/8/2024.
 //
 
+import Foundation
 import SwiftUI
 
 private enum EVYSearchSourceType {
@@ -180,3 +181,39 @@ class EVYSearchController: ObservableObject {
     }
 }
 
+#Preview {
+    AsyncPreview { (asyncView: EVYSearch) in
+        asyncView
+    } view: {
+        // Local-only: no EVY.getRow / EVYAPIManager (avoids API_HOST fatalError in Xcode canvas).
+        if !EVY.data.exists(key: "tags") {
+            try EVY.data.create(key: "tags", data: Data("[]".utf8))
+        }
+        let templateJson = """
+        {
+            "id": "preview-search-row",
+            "type": "Info",
+            "source": "",
+            "destination": "",
+            "actions": [],
+            "view": {
+                "content": {
+                    "title": "{datum.unit} {datum.street}",
+                    "subtitle": "{datum.city} {datum.state} {datum.postcode}",
+                    "icon": ""
+                }
+            }
+        }
+        """
+        let template = try JSONDecoder().decode(
+            UI_Row.self,
+            from: Data(templateJson.utf8),
+        )
+        return EVYSearch(
+            source: "local:address",
+            destination: "{tags}",
+            placeholder: "Search",
+            resultTemplate: template
+        )
+    }
+}

--- a/ios/evy/Data/EVYSearchController.swift
+++ b/ios/evy/Data/EVYSearchController.swift
@@ -15,19 +15,92 @@ private enum EVYSearchSourceType {
 public struct EVYSearchResult: Equatable {
     let data: EVYJson
     let value: String
+    let displayRow: UI_Row
+
+    public static func == (lhs: EVYSearchResult, rhs: EVYSearchResult) -> Bool {
+        lhs.value == rhs.value && lhs.data == rhs.data
+    }
+}
+
+// MARK: - Search Result Template
+private func deepCopyJSONValue(_ value: Any) -> Any {
+    switch value {
+    case let d as [String: Any]:
+        var out: [String: Any] = [:]
+        out.reserveCapacity(d.count)
+        for (k, v) in d {
+            out[k] = deepCopyJSONValue(v)
+        }
+        return out
+    case let d as NSDictionary:
+        var out: [String: Any] = [:]
+        for case let (k as String, v) in d {
+            out[k] = deepCopyJSONValue(v)
+        }
+        return out
+    case let a as [Any]:
+        return a.map { deepCopyJSONValue($0) }
+    case let a as NSArray:
+        return a.map { deepCopyJSONValue($0) }
+    default:
+        return value
+    }
+}
+
+@MainActor
+private final class SearchTemplateFormatPrep {
+    private let rootPrototype: [String: Any]
+    private static let displayKeys = [
+        "title", "subtitle", "text", "label", "placeholder", "value",
+    ]
+
+    init(template: UI_Row) throws {
+        let data = try JSONEncoder().encode(template)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw EVYSearchFormattingError.invalidTemplate
+        }
+        rootPrototype = root
+    }
+
+    func formattedResult(datum: EVYJson) throws -> (row: UI_Row, value: String) {
+        guard var root = deepCopyJSONValue(rootPrototype) as? [String: Any],
+              var view = root["view"] as? [String: Any],
+              var content = view["content"] as? [String: Any] else {
+            throw EVYSearchFormattingError.invalidTemplate
+        }
+        for key in Array(content.keys) {
+            if let raw = content[key] as? String {
+                content[key] = try EVY.formatData(json: datum, format: raw)
+            }
+        }
+        let value = Self.displayKeys
+            .compactMap { content[$0] as? String }
+            .first(where: { !$0.isEmpty }) ?? ""
+        view["content"] = content
+        root["view"] = view
+        root["id"] = UUID().uuidString
+        let out = try JSONSerialization.data(withJSONObject: root)
+        return (try JSONDecoder().decode(UI_Row.self, from: out), value)
+    }
+}
+
+enum EVYSearchFormattingError: Error {
+    case invalidTemplate
 }
 
 @MainActor
 class EVYSearchController: ObservableObject {
     private let sourceType: EVYSearchSourceType
     private let source: String
-    private let format: String
-    
+    private let resultTemplate: UI_Row?
+
+    private var cachedFormatPrep: SearchTemplateFormatPrep?
+
     @Published var results: [EVYSearchResult] = []
-    
-    init (source: String, format: String) {
-        self.format = format
-        
+
+    init(source: String, resultTemplate: UI_Row?) {
+        self.resultTemplate = resultTemplate
+
         let sourceProps = EVY.parsePropsFromText(source)
         if sourceProps.hasPrefix("api:") {
             sourceType = .api
@@ -40,31 +113,52 @@ class EVYSearchController: ObservableObject {
             self.source = source
         }
     }
-    
+
+    private func loadFormatPrep() throws -> SearchTemplateFormatPrep {
+        if let prep = cachedFormatPrep {
+            return prep
+        }
+        guard let resultTemplate else {
+            throw EVYSearchFormattingError.invalidTemplate
+        }
+        let prep = try SearchTemplateFormatPrep(template: resultTemplate)
+        cachedFormatPrep = prep
+        return prep
+    }
+
+    func makeSearchResult(datum: EVYJson) throws -> EVYSearchResult {
+        let (row, value) = try loadFormatPrep().formattedResult(datum: datum)
+        return EVYSearchResult(data: datum, value: value, displayRow: row)
+    }
+
     func search(name: String) async {
+        guard resultTemplate != nil else {
+            results = []
+            return
+        }
+
         switch sourceType {
         case .local:
-			let address = """
-				{
-					"unit": "100",
-					"street": "Main Street",
-					"city": "Rosebery",
-					"postcode": "2018",
-					"state": "NSW",
-					"country": "Australia",
-					"location": {
-						"latitude": "45.323124",
-						"longitude": "-3.424233"
-					},
-					"instructions": ""
-				}
-			""".data(using: .utf8)!
+            let address = """
+                {
+                    "unit": "100",
+                    "street": "Main Street",
+                    "city": "Rosebery",
+                    "postcode": "2018",
+                    "state": "NSW",
+                    "country": "Australia",
+                    "location": {
+                        "latitude": "45.323124",
+                        "longitude": "-3.424233"
+                    },
+                    "instructions": ""
+                }
+            """.data(using: .utf8)!
             let id = UUID()
             do {
                 try EVY.data.create(key: id.uuidString, data: address)
                 let json = try EVY.getDataFromProps(id.uuidString)
-                let jsonFormatted = try EVY.formatData(json: json, format: format)
-                results = [EVYSearchResult(data: json, value: jsonFormatted)]
+                results = [try makeSearchResult(datum: json)]
             } catch {
                 #if DEBUG
                 print("[EVYSearchController] Error in local search: \(error)")
@@ -75,10 +169,7 @@ class EVYSearchController: ObservableObject {
             do {
                 let data = try await EVYMovieAPI().search(term: name)
                 let response = try JSONDecoder().decode([EVYJson].self, from: data)
-                for res in response {
-                    let resFormatted = try EVY.formatData(json: res, format: format)
-                    results.append(EVYSearchResult(data: res, value: resFormatted))
-                }
+                results = try response.map { try makeSearchResult(datum: $0) }
             } catch {
                 #if DEBUG
                 print("[EVYSearchController] Error in API search: \(error)")
@@ -89,15 +180,3 @@ class EVYSearchController: ObservableObject {
     }
 }
 
-#Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
-		
-		return EVYSearch(source: "{api:movies}",
-						 destination: "{tags}",
-						 placeholder: "Search",
-						 format: "{$0.value}")
-	}
-}

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -114,6 +114,13 @@ struct EVY {
     static func formatData(json: EVYJson, format: String) throws -> String {
         try _formatData(json: json, format: format)
     }
+
+    static func formatDataOrToString(json: EVYJson, format: String) throws -> String {
+        if format.isEmpty {
+            return json.toString()
+        }
+        return try formatData(json: json, format: format)
+    }
     
     static func ensureDraftExists(
         variableName: String,

--- a/ios/evy/UI/Atoms/EVYRowTitle.swift
+++ b/ios/evy/UI/Atoms/EVYRowTitle.swift
@@ -9,11 +9,9 @@ struct EVYRowTitle: View {
 	let title: String
 
 	var body: some View {
-		Group {
-			if !title.isEmpty {
-				EVYTextView(title)
-					.padding(.vertical, Constants.padding)
-			}
+		if !title.isEmpty {
+			EVYTextView(title)
+				.padding(.vertical, Constants.padding)
 		}
 	}
 }

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -71,8 +71,8 @@ private struct EVYPageBody: View {
     @MainActor
     private func bootstrapDrafts(in page: UI_Page, scopeId: String?) {
         forEachRow(in: page) { row in
-            guard let destination = row.destination, !destination.isEmpty else { return }
-            let variableName = parsePropsFromText(destination)
+            guard !row.destination.isEmpty else { return }
+            let variableName = parsePropsFromText(row.destination)
             guard !variableName.isEmpty else { return }
             let initialData: Data?
             if row.type == .inlinePicker {
@@ -90,3 +90,4 @@ private struct EVYPageBody: View {
         }
     }
 }
+

--- a/ios/evy/UI/EVYRow.swift
+++ b/ios/evy/UI/EVYRow.swift
@@ -27,10 +27,8 @@ struct EVYRow: View, Identifiable {
 	var id: String { row.id }
 
 	var body: some View {
-		Group {
-			if let payload = try? UI_RowPayload.from(row: row) {
-				rowView(for: payload)
-			}
+		if let payload = try? UI_RowPayload.from(row: row) {
+			rowView(for: payload)
 		}
 	}
 

--- a/ios/evy/UI/Rows/Container/EVYSheetContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYSheetContainerRow.swift
@@ -32,10 +32,12 @@ struct EVYSheetContainerRow: View, EVYRowProtocol {
 								EVYRow(row: row)
 							}
 						}
-						.frame(maxHeight: .infinity, alignment: .top)
+						.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+						.background(Color.white.ignoresSafeArea())
 						.padding(.top, Constants.majorPadding)
 						.presentationDetents([.medium, .large])
 						.presentationDragIndicator(.visible)
+						.presentationBackground(.white)
 					}
 			}
 		}

--- a/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
@@ -12,9 +12,9 @@ struct EVYDropdownRow: View, EVYRowProtocol {
 
 	private let view: DropdownRowViewData
 	private let source: String
-	private let destination: String?
+	private let destination: String
 
-	init(view: DropdownRowViewData, source: String, destination: String?) {
+	init(view: DropdownRowViewData, source: String, destination: String) {
 		self.view = view
 		self.source = source
 		self.destination = destination
@@ -26,7 +26,7 @@ struct EVYDropdownRow: View, EVYRowProtocol {
 				EVYTextView(view.content.title)
 					.padding(.vertical, Constants.padding)
 			}
-			if let destination {
+			if !destination.isEmpty {
 				EVYDropdown(
 					title: view.content.title,
 					placeholder: view.content.placeholder,

--- a/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
@@ -12,9 +12,9 @@ struct EVYInlinePickerRow: View, EVYRowProtocol {
 
 	private let view: InlinePickerRowViewData
 	private let source: String
-	private let destination: String?
+	private let destination: String
 
-	init(view: InlinePickerRowViewData, source: String, destination: String?) {
+	init(view: InlinePickerRowViewData, source: String, destination: String) {
 		self.view = view
 		self.source = source
 		self.destination = destination
@@ -26,7 +26,7 @@ struct EVYInlinePickerRow: View, EVYRowProtocol {
 				EVYTextView(view.content.title)
 					.padding(.vertical, Constants.padding)
 			}
-			if let destination {
+			if !destination.isEmpty {
 				EVYInlinePicker(
 					title: view.content.title,
 					data: source,

--- a/ios/evy/UI/Rows/Edit/EVYInputRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInputRow.swift
@@ -11,9 +11,9 @@ struct EVYInputRow: View, EVYRowProtocol {
 	public static let JSONType = "Input"
 
 	private let view: InputRowViewData
-	private let destination: String?
+	private let destination: String
 
-	init(view: InputRowViewData, destination: String?) {
+	init(view: InputRowViewData, destination: String) {
 		self.view = view
 		self.destination = destination
 	}
@@ -21,7 +21,7 @@ struct EVYInputRow: View, EVYRowProtocol {
 	var body: some View {
 		VStack(alignment: .leading) {
 			EVYRowTitle(title: view.content.title)
-			if let destination {
+			if !destination.isEmpty {
 				EVYTextField(
 					input: view.content.value,
 					destination: destination,

--- a/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
@@ -12,10 +12,10 @@ struct EVYSearchRow: View, EVYRowProtocol {
 
 	private let view: SearchRowViewData
 	private let source: String
-	private let destination: String?
+	private let destination: String
 	@State private var showSheet = false
 
-	init(view: SearchRowViewData, source: String, destination: String?) {
+	init(view: SearchRowViewData, source: String, destination: String) {
 		self.view = view
 		self.source = source
 		self.destination = destination
@@ -27,12 +27,12 @@ struct EVYSearchRow: View, EVYRowProtocol {
 				EVYTextView(view.content.title)
 					.padding(.vertical, Constants.padding)
 			}
-			if let destination {
+			if !destination.isEmpty {
 				EVYSearch(
 					source: source,
 					destination: destination,
 					placeholder: view.content.placeholder,
-					format: view.content.format
+					resultTemplate: view.content.child
 				)
 			}
 		}

--- a/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
@@ -12,15 +12,15 @@ struct EVYSelectPhotoRow: View, EVYRowProtocol {
 	public static let JSONType = "SelectPhoto"
 
 	private let view: SelectPhotoRowViewData
-	private let destination: String?
+	private let destination: String
 
-	init(view: SelectPhotoRowViewData, destination: String?) {
+	init(view: SelectPhotoRowViewData, destination: String) {
 		self.view = view
 		self.destination = destination
 	}
 
 	var body: some View {
-		if let destination {
+		if !destination.isEmpty {
 			EVYSelectPhoto(
 				title: view.content.title,
 				subtitle: view.content.subtitle,

--- a/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
@@ -11,9 +11,9 @@ struct EVYTextAreaRow: View, EVYRowProtocol {
 	public static let JSONType = "TextArea"
 
 	private let view: TextAreaRowViewData
-	private let destination: String?
+	private let destination: String
 
-	init(view: TextAreaRowViewData, destination: String?) {
+	init(view: TextAreaRowViewData, destination: String) {
 		self.view = view
 		self.destination = destination
 	}
@@ -24,7 +24,7 @@ struct EVYTextAreaRow: View, EVYRowProtocol {
 				EVYTextView(view.content.title)
 					.padding(.vertical, Constants.padding)
 			}
-			if let destination {
+			if !destination.isEmpty {
 				EVYTextField(
 					input: view.content.value,
 					destination: destination,

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -16,8 +16,8 @@ struct EVYTextSelectRow: View, EVYRowProtocol {
 	private let value: EVYJson
 	private let selected: EVYState<Bool>
 
-	init?(view: TextSelectRowViewData, destination: String?, actions: [UI_RowAction]) {
-		guard let destination else { return nil }
+	init?(view: TextSelectRowViewData, destination: String, actions: [UI_RowAction]) {
+		guard !destination.isEmpty else { return nil }
 		self.view = view
 		self.destination = destination
 		self.actions = actions

--- a/ios/evy/UI/Rows/View/EVYInfoRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInfoRow.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct EVYInfoRow: View, EVYRowProtocol {
 	public static let JSONType = "Info"
 
+	private static let leadingIconMinWidth: CGFloat = 32
+
 	private let view: InfoRowViewData
 
 	init(view: InfoRowViewData) {
@@ -17,16 +19,52 @@ struct EVYInfoRow: View, EVYRowProtocol {
 	}
 
 	var body: some View {
-		if view.content.title.count > 0 {
-			VStack(alignment: .leading) {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-				EVYTextView(view.content.text, style: .info)
-					.frame(maxWidth: .infinity, alignment: .leading)
+		let content = view.content
+		let hasTitle = !content.title.isEmpty
+		let hasSubtitle = !content.subtitle.isEmpty
+		let icon = content.icon.trimmingCharacters(in: .whitespacesAndNewlines)
+		let showIcon = !icon.isEmpty
+
+		HStack(alignment: .top, spacing: Constants.minorPadding) {
+			if showIcon {
+				EVYTextView(icon, style: .body)
+					.frame(minWidth: Self.leadingIconMinWidth, alignment: .center)
 			}
+			infoTextColumn(content: content, hasTitle: hasTitle, hasSubtitle: hasSubtitle)
+		}
+		.infoRowOuterWidth(expands: !hasTitle)
+		.padding(Constants.minorPadding)
+	}
+
+	@ViewBuilder
+	private func infoTextColumn(content: InfoRowContent, hasTitle: Bool, hasSubtitle: Bool) -> some View {
+		VStack(alignment: hasTitle && hasSubtitle ? .leading : .center, spacing: 0) {
+			if hasTitle {
+				EVYTextView(content.title)
+					.frame(maxWidth: .infinity, alignment: .leading)
+					.lineLimit(1)
+					.truncationMode(.tail)
+			}
+			if hasSubtitle {
+				EVYTextView(content.subtitle, style: .info)
+					.frame(maxWidth: .infinity,
+						   alignment: hasTitle && hasSubtitle ? .leading : .center)
+					.lineLimit(3)
+					.truncationMode(.tail)
+			}
+		}
+		.frame(maxWidth: .infinity,
+			   alignment: hasTitle && hasSubtitle ? .leading : .center)
+	}
+}
+
+private extension View {
+	@ViewBuilder
+	func infoRowOuterWidth(expands: Bool) -> some View {
+		if expands {
+			frame(maxWidth: .infinity)
 		} else {
-			EVYTextView(view.content.text, style: .info)
-				.frame(maxWidth: .infinity, alignment: .center)
+			self
 		}
 	}
 }

--- a/ios/evy/UI/Rows/View/EVYTextRow.swift
+++ b/ios/evy/UI/Rows/View/EVYTextRow.swift
@@ -26,7 +26,7 @@ struct EVYTextRow: View, EVYRowProtocol {
 			}
 			EVYTextView(view.content.text)
 				.frame(maxWidth: .infinity, alignment: .leading)
-				.lineLimit(Int(view.max_lines ?? "1") ?? 1)
+				.lineLimit(Int(view.max_lines.isEmpty ? "1" : view.max_lines) ?? 1)
 				.background {
 					ViewThatFits(in: .vertical) {
 						EVYTextView(view.content.text).hidden()

--- a/ios/evy/UI/Views/EVYDropdown.swift
+++ b/ios/evy/UI/Views/EVYDropdown.swift
@@ -8,17 +8,17 @@
 import SwiftUI
     
 struct EVYDropdown: View {
-    let title: String?
+    let title: String
     let destination: String
     let format: String
-    let placeholder: String?
+    let placeholder: String
     
     private var options: [EVYJson] = []
     private var selection: EVYState<String>
     @State private var showSheet = false
     
-    init(title: String?,
-         placeholder: String?,
+    init(title: String = "",
+         placeholder: String = "",
          data: String,
          format: String,
          destination: String)
@@ -48,10 +48,10 @@ struct EVYDropdown: View {
                 if case let .string(identifier) = value {
                     if identifier.isEmpty { return "" }
                     if let matchingOption = loadedOptions.first(where: { $0.identifierValue() == identifier }) {
-                        return try EVY.formatData(json: matchingOption, format: format)
+                        return try EVY.formatDataOrToString(json: matchingOption, format: format)
                     }
                 }
-                return try EVY.formatData(json: value, format: format)
+                return try EVY.formatDataOrToString(json: value, format: format)
             } catch {
                 #if DEBUG
                 print("[EVYDropdown] Error formatting selection: \(error) for input \($0)")
@@ -67,7 +67,7 @@ struct EVYDropdown: View {
                 if selection.value.count > 0 {
                     EVYTextView(selection.value)
                 } else {
-					EVYTextView(placeholder ?? "", style: .info)
+					EVYTextView(placeholder, style: .info)
                 }
             }
             Spacer()
@@ -87,15 +87,18 @@ struct EVYDropdown: View {
         .onTapGesture { showSheet.toggle() }
         .sheet(isPresented: $showSheet, content: {
             VStack {
-                if title?.count ?? 0 > 0 {
-                    EVYTextView(title!).padding(.top, Constants.majorPadding)
+                if title.count > 0 {
+                    EVYTextView(title).padding(.top, Constants.majorPadding)
                 }
                 EVYSelectList(options: options,
                               format: format,
                               destination: destination)
-                    .presentationDetents([.medium, .large])
-                    .presentationDragIndicator(.visible)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .background(Color.white.ignoresSafeArea())
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+            .presentationBackground(.white)
         })
     }
 }
@@ -107,13 +110,11 @@ struct EVYDropdown: View {
 		try! EVY.getUserData()
 		try! await EVY.createItem()
 		
-		return Group {
-			EVYDropdown(title: "Dropdown",
-						placeholder: "A placeholder",
-						data: "{conditions}",
-						format: "{$0.value}",
-						destination: "{condition}")
-		}
+		return EVYDropdown(title: "Dropdown",
+						   placeholder: "A placeholder",
+						   data: "{conditions}",
+						   format: "{$0.value}",
+						   destination: "{condition}")
 	}
 }
 

--- a/ios/evy/UI/Views/EVYInlinePicker.swift
+++ b/ios/evy/UI/Views/EVYInlinePicker.swift
@@ -79,7 +79,8 @@ struct EVYInlinePicker: View {
                 Button(action: {
                     performAction(option: option)
                 }) {
-                    let formatted = (try? EVY.formatData(json: option, format: format)) ?? option.toString()
+                    let formatted = (try? EVY.formatDataOrToString(json: option, format: format))
+                        ?? option.toString()
                     let textView = EVYTextView(formatted)
                     EVYRectangle.fitWidth(content: textView,
                                             style: isSelected ? .primary : .secondary)
@@ -96,11 +97,9 @@ struct EVYInlinePicker: View {
 		try! EVY.getUserData()
 		try! await EVY.createItem()
 		
-		return Group {
-			EVYInlinePicker(title: "Dropdown",
-							data: "{durations}",
-							format: "{$0.value}",
-							destination: "{duration}")
-		}
+		return EVYInlinePicker(title: "Dropdown",
+							   data: "{durations}",
+							   format: "{$0.value}",
+							   destination: "{duration}")
 	}
 }

--- a/ios/evy/UI/Views/EVYInputList.swift
+++ b/ios/evy/UI/Views/EVYInputList.swift
@@ -22,9 +22,13 @@ struct EVYInputList: View {
             do {
                 let data = try EVY.getDataFromText($0)
                 if case let .array(arrayValue) = data {
-                    return try arrayValue.map { try EVY.formatData(json: $0, format: format) }
+                    return try arrayValue.map { json in
+                        try EVY.formatDataOrToString(json: json, format: format)
+                    }
                 } else {
-                    return [try EVY.formatData(json: data, format: format)]
+                    return [
+                        try EVY.formatDataOrToString(json: data, format: format),
+                    ]
                 }
             } catch {
                 #if DEBUG
@@ -62,10 +66,8 @@ struct EVYInputList: View {
 	} view: {
 		try! await EVY.createItem()
 		
-		return Group {
-			EVYInputList(data: "{tags}",
-						 format: "{$0.value}",
-						 placeholder: "Add tags to improve search")
-		}
+		return EVYInputList(data: "{tags}",
+							format: "{$0.value}",
+							placeholder: "Add tags to improve search")
 	}
 }

--- a/ios/evy/UI/Views/EVYSearch.swift
+++ b/ios/evy/UI/Views/EVYSearch.swift
@@ -9,25 +9,26 @@ import SwiftUI
 
 struct EVYSearch: View {
     private let canSelectMultiple: Bool
-    
+
     let source: String
     let destination: String
     let placeholder: String
-    let format: String
-    
-    init(source: String,
-         destination: String,
-         placeholder: String,
-         format: String)
-    {
+    let resultTemplate: UI_Row?
+
+    init(
+        source: String,
+        destination: String,
+        placeholder: String,
+        resultTemplate: UI_Row?,
+    ) {
         self.source = source
         self.destination = destination
         self.placeholder = placeholder
-        self.format = format
-        
+        self.resultTemplate = resultTemplate
+
         do {
             let data = try EVY.getDataFromText(destination)
-            if case .array(_) = data {
+            if case .array = data {
                 canSelectMultiple = true
             } else {
                 canSelectMultiple = false
@@ -36,18 +37,22 @@ struct EVYSearch: View {
             canSelectMultiple = false
         }
     }
-    
+
     var body: some View {
         if canSelectMultiple {
-            EVYSearchMultiple(source: source,
-                              format: format,
-                              destination: destination,
-                              placeholder: placeholder)
+            EVYSearchMultiple(
+                source: source,
+                resultTemplate: resultTemplate,
+                destination: destination,
+                placeholder: placeholder,
+            )
         } else {
-            EVYSearchSingle(source: source,
-                            format: format,
-                            destination: destination,
-                            placeholder: placeholder)
+            EVYSearchSingle(
+                source: source,
+                resultTemplate: resultTemplate,
+                destination: destination,
+                placeholder: placeholder,
+            )
         }
     }
 }

--- a/ios/evy/UI/Views/EVYSearchMultiple.swift
+++ b/ios/evy/UI/Views/EVYSearchMultiple.swift
@@ -12,50 +12,57 @@ struct EVYSearchMultiple: View {
     @State private var selected: [EVYSearchResult] = []
     @State private var searchFieldValue = ""
     @ObservedObject private var searchController: EVYSearchController
-    
+
     let source: String
     let destination: String
     let placeholder: String
-    let format: String
-    
-    init(source: String,
-         format: String,
-         destination: String,
-         placeholder: String)
-    {
+    let resultTemplate: UI_Row?
+
+    init(
+        source: String,
+        resultTemplate: UI_Row?,
+        destination: String,
+        placeholder: String,
+    ) {
         self.source = source
-        self.format = format
+        self.resultTemplate = resultTemplate
         self.destination = destination
         self.placeholder = placeholder
-        
-        searchController = EVYSearchController(source: source, format: format)
+
+        searchController = EVYSearchController(source: source, resultTemplate: resultTemplate)
     }
-    
+
     func refresh() {
+        guard resultTemplate != nil else {
+            return
+        }
         do {
             let existingData = try EVY.getDataFromText(destination)
             guard case let .array(arrayValue) = existingData else {
                 return
             }
-            
+
+            var seenValues = Set(selected.map(\.value))
+            var next = selected
+            next.reserveCapacity(selected.count + arrayValue.count)
             for value in arrayValue {
-                let formattedValue = try EVY.formatData(json: value, format: format)
-                let alreadySelected = selected.contains { $0.value == formattedValue }
-                if !alreadySelected {
-                    selected.append(EVYSearchResult(data: value, value: formattedValue))
+                let result = try searchController.makeSearchResult(datum: value)
+                if seenValues.insert(result.value).inserted {
+                    next.append(result)
                 }
             }
+            selected = next
         } catch {
             #if DEBUG
             print("[EVYSearchMultiple] Error refreshing data: \(error)")
             #endif
         }
     }
-    
+
     func select(_ element: EVYSearchResult) {
         do {
             selected.append(element)
-            
+
             let encoded = try JSONEncoder().encode(selected.map { $0.data })
             try EVY.updateData(encoded, at: destination)
             searchController.results.removeAll { $0.value == element.value }
@@ -63,7 +70,7 @@ struct EVYSearchMultiple: View {
             selected.removeAll { $0.value == element.value }
         }
     }
-    
+
     func unselect(_ element: EVYSearchResult) {
         do {
             selected.removeAll { $0.value == element.value }
@@ -73,19 +80,20 @@ struct EVYSearchMultiple: View {
             searchController.results.removeAll { $0.value == element.value }
         }
     }
-    
+
     var body: some View {
         VStack {
-            // Search bar
             HStack {
                 Image(uiImage: Lucide.search)
                     .padding(.leading, Constants.minorPadding)
                 TextField(placeholder, text: $searchFieldValue).font(.evy)
             }
-            .padding(EdgeInsets(top: Constants.fieldPadding,
-                                leading: Constants.minorPadding,
-                                bottom: Constants.fieldPadding,
-                                trailing: Constants.minorPadding))
+            .padding(EdgeInsets(
+                top: Constants.fieldPadding,
+                leading: Constants.minorPadding,
+                bottom: Constants.fieldPadding,
+                trailing: Constants.minorPadding,
+            ))
             .background(
                 RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
                     .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
@@ -95,15 +103,14 @@ struct EVYSearchMultiple: View {
             .padding(.horizontal, Constants.majorPadding)
             .onChange(of: searchFieldValue) { _, newValue in
                 Task(operation: {
-                    if !newValue.isEmpty &&  newValue.count > 3 {
+                    if !newValue.isEmpty && newValue.count > 3 {
                         await searchController.search(name: newValue)
                     } else {
                         searchController.results.removeAll()
                     }
                 })
             }
-            
-            // Search selection
+
             if selected.count > 0 {
                 ScrollView(.horizontal, content: {
                     HStack {
@@ -117,35 +124,38 @@ struct EVYSearchMultiple: View {
                 })
                 .scrollIndicators(.hidden)
             }
-            
-            // Search results
+
             List {
                 ForEach(searchController.results, id: \.value) { result in
-                    EVYTextView(result.value)
+                    EVYRow(row: result.displayRow)
                         .onTapGesture { select(result) }
                 }
                 .onChange(of: searchController.results) { _, _ in
                     searchController.results.removeAll { r in
-                        return selected.contains { $0.value == r.value }
+                        selected.contains { $0.value == r.value }
                     }
                 }
             }
             .listStyle(.plain)
             .listRowSpacing(20)
+            .scrollContentBackground(.hidden)
+            .background(Color.white)
         }
         .onAppear { refresh() }
     }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
-		
-		return EVYSearch(source: "{api:tags}",
-						 destination: "{tags}",
-						 placeholder: "Search",
-						 format: "{$0.value}")
-	}
+    AsyncPreview { asyncView in
+        asyncView
+    } view: {
+        try! await EVY.createItem()
+
+        return EVYSearch(
+            source: "{api:tags}",
+            destination: "{tags}",
+            placeholder: "Search",
+            resultTemplate: nil,
+        )
+    }
 }

--- a/ios/evy/UI/Views/EVYSearchSingle.swift
+++ b/ios/evy/UI/Views/EVYSearchSingle.swift
@@ -12,21 +12,22 @@ struct EVYSearchSingle: View {
     @State private var selected: String = ""
     @State private var value: String = ""
     @ObservedObject private var searchController: EVYSearchController
-    
+
     let destination: String
     let placeholder: String
-    
-    init(source: String,
-         format: String,
-         destination: String,
-         placeholder: String)
-    {
+
+    init(
+        source: String,
+        resultTemplate: UI_Row?,
+        destination: String,
+        placeholder: String,
+    ) {
         self.destination = destination
         self.placeholder = placeholder
-        
-        searchController = EVYSearchController(source: source, format: format)
+
+        searchController = EVYSearchController(source: source, resultTemplate: resultTemplate)
     }
-    
+
     func select(_ element: EVYSearchResult) {
         do {
             value = element.value
@@ -39,7 +40,7 @@ struct EVYSearchSingle: View {
             #endif
         }
     }
-    
+
     func unselect() {
         do {
             value = ""
@@ -51,7 +52,7 @@ struct EVYSearchSingle: View {
             #endif
         }
     }
-    
+
     var body: some View {
         VStack {
             // Search bar
@@ -60,20 +61,22 @@ struct EVYSearchSingle: View {
                     Image(uiImage: Lucide.search)
                         .padding(.leading, Constants.minorPadding)
                 }
-                
+
                 TextField(placeholder, text: $value)
                     .font(.evy)
-            
+
                 if !value.isEmpty {
                     Image(uiImage: Lucide.x)
                         .padding(.trailing, Constants.minorPadding)
                         .onTapGesture { unselect() }
                 }
             }
-            .padding(EdgeInsets(top: Constants.fieldPadding,
-                                leading: Constants.minorPadding,
-                                bottom: Constants.fieldPadding,
-                                trailing: Constants.minorPadding))
+            .padding(EdgeInsets(
+                top: Constants.fieldPadding,
+                leading: Constants.minorPadding,
+                bottom: Constants.fieldPadding,
+                trailing: Constants.minorPadding,
+            ))
             .background(
                 RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
                     .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
@@ -92,33 +95,35 @@ struct EVYSearchSingle: View {
                     if newValue == selected {
                         return
                     }
-                    
+
                     await searchController.search(name: newValue)
                 })
             }
-            
+
             // Search results
             List {
                 ForEach(searchController.results, id: \.value) { result in
-                    EVYTextView(result.value).onTapGesture { select(result) }
+                    EVYRow(row: result.displayRow)
+						.onTapGesture { select(result) }
                 }
             }
             .listStyle(.plain)
             .listRowSpacing(20)
+            .scrollContentBackground(.hidden)
+            .background(Color.white)
         }
     }
 }
+
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
-		
-		return Group {
-		EVYSearch(source: "{local:address}",
-				  destination: "{address}",
-					  placeholder: "Search",
-					  format: "{$0.unit} {$0.street}, {$0.city} {$0.state} {$0.postcode}")
-		}
-	}
+    AsyncPreview { asyncView in
+        asyncView
+    } view: {
+        try! await EVY.createItem()
+
+        return EVYSearch(source: "{local:address}",
+						 destination: "{address}",
+						 placeholder: "Search",
+						 resultTemplate: nil)
+    }
 }

--- a/ios/evy/UI/Views/EVYSelectItem.swift
+++ b/ios/evy/UI/Views/EVYSelectItem.swift
@@ -93,7 +93,8 @@ struct EVYSelectItem: View {
     
     var body: some View {
         HStack {
-            let text = (try? EVY.formatData(json: value, format: format)) ?? value.toString()
+            let text = (try? EVY.formatDataOrToString(json: value, format: format))
+                ?? value.toString()
             EVYTextView(text, style: textStyle)
                 .frame(maxWidth: .infinity, alignment: .leading)
             EVYRadioButton(isSelected: selected.value, style: selectionStyle)

--- a/ios/evy/UI/Views/EVYSelectList.swift
+++ b/ios/evy/UI/Views/EVYSelectList.swift
@@ -28,6 +28,7 @@ struct EVYSelectList: View {
             .listRowBackground(Color.clear)
         }
         .listStyle(.inset)
+        .scrollContentBackground(.hidden)
     }
 }
 

--- a/ios/evy/Utils/forEachRow.swift
+++ b/ios/evy/Utils/forEachRow.swift
@@ -16,10 +16,8 @@ func forEachRow(in page: UI_Page, visitor: (UI_Row) -> Void) {
 
 private func visit(_ row: UI_Row, visitor: (UI_Row) -> Void) {
     visitor(row)
-    if let children = row.view.content.children {
-        for child in children {
-            visit(child, visitor: visitor)
-        }
+    for child in row.view.content.children {
+        visit(child, visitor: visitor)
     }
     if let child = row.view.content.child {
         visit(child, visitor: visitor)

--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -217,9 +217,7 @@ func _evaluateFromText(_ input: String) throws -> Bool {
 
 @MainActor
 func _formatData(json: EVYJson, format: String) throws -> String {
-    if format.count < 1 {
-        return json.toString()
-    }
+	if format.count < 1 { return "" }
 
     let temporaryId = UUID().uuidString
     let formatWithNewData = format
@@ -227,9 +225,7 @@ func _formatData(json: EVYJson, format: String) throws -> String {
         .replacingOccurrences(of: ".datum", with: ".\(temporaryId)")
         .replacingOccurrences(of: "(datum)", with: "(\(temporaryId))")
 
-    if formatWithNewData.isEmpty {
-        return json.toString()
-    }
+    if formatWithNewData.isEmpty { return "" }
 
     let encodedData = try JSONEncoder().encode(json)
     try EVY.data.create(key: temporaryId, data: encodedData)

--- a/scripts/generate-swift-sdui.ts
+++ b/scripts/generate-swift-sdui.ts
@@ -172,10 +172,10 @@ public final class UI_Row: Codable {
     public let type: EVYRowType
     public let view: UI_RowView
     public let source: String
-    public let destination: String?
+    public let destination: String
     public let actions: [UI_RowAction]
 
-    public init(id: String, type: EVYRowType, view: UI_RowView, source: String, destination: String?, actions: [UI_RowAction]) {
+    public init(id: String, type: EVYRowType, view: UI_RowView, source: String, destination: String, actions: [UI_RowAction]) {
         self.id = id
         self.type = type
         self.view = view
@@ -199,7 +199,7 @@ public final class UI_Row: Codable {
         type = try container.decode(EVYRowType.self, forKey: .type)
         view = try container.decode(UI_RowView.self, forKey: .view)
         source = try container.decode(String.self, forKey: .source)
-        destination = try container.decodeIfPresent(String.self, forKey: .destination)
+        destination = try container.decodeIfPresent(String.self, forKey: .destination) ?? ""
         actions = try container.decodeIfPresent([UI_RowAction].self, forKey: .actions) ?? []
     }
 
@@ -209,7 +209,7 @@ public final class UI_Row: Codable {
         try container.encode(type, forKey: .type)
         try container.encode(view, forKey: .view)
         try container.encode(source, forKey: .source)
-        try container.encodeIfPresent(destination, forKey: .destination)
+        try container.encode(destination, forKey: .destination)
         try container.encode(actions, forKey: .actions)
     }
 }
@@ -292,13 +292,13 @@ function emitRowContentWithPassthrough(): string {
 	return `// MARK: - UI_RowContent (preserves additional string keys so payload decode gets full content)
 public class UI_RowContent: Codable {
     public let title: String
-    public let children: [UI_Row]?
+    public let children: [UI_Row]
     public let child: UI_Row?
-    public let segments: [String]?
+    public let segments: [String]
     /// Additional content keys (e.g. label, value, placeholder) preserved for payload decoding.
     private let additional: [String: String]
 
-    public init(title: String, children: [UI_Row]?, child: UI_Row?, segments: [String]?, additional: [String: String] = [:]) {
+    public init(title: String, children: [UI_Row] = [], child: UI_Row? = nil, segments: [String] = [], additional: [String: String] = [:]) {
         self.title = title
         self.children = children
         self.child = child
@@ -309,9 +309,9 @@ public class UI_RowContent: Codable {
     public required init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: UI_RowContentCodingKeys.self)
         title = try c.decode(String.self, forKey: .title)
-        children = try c.decodeIfPresent([UI_Row].self, forKey: .children)
+        children = try c.decodeIfPresent([UI_Row].self, forKey: .children) ?? []
         child = try c.decodeIfPresent(UI_Row.self, forKey: .child)
-        segments = try c.decodeIfPresent([String].self, forKey: .segments)
+        segments = try c.decodeIfPresent([String].self, forKey: .segments) ?? []
         let known = Set(["title", "children", "child", "segments"])
         var extra: [String: String] = [:]
         for key in c.allKeys {
@@ -326,9 +326,9 @@ public class UI_RowContent: Codable {
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: UI_RowContentCodingKeys.self)
         try c.encode(title, forKey: .title)
-        try c.encodeIfPresent(children, forKey: .children)
+        try c.encode(children, forKey: .children)
         try c.encodeIfPresent(child, forKey: .child)
-        try c.encodeIfPresent(segments, forKey: .segments)
+        try c.encode(segments, forKey: .segments)
         for (k, v) in additional {
             try c.encode(v, forKey: UI_RowContentCodingKeys(stringValue: k, intValue: nil)!)
         }
@@ -411,17 +411,66 @@ ${defBlocks.join("\n\n")}
 `;
 }
 
+/** Decode line for one row-content spec field (non-optional Swift types; missing keys use defaults). */
+function emitRowContentDecodeLine(key: string, specType: string): string {
+	const k = swiftIdentifier(key);
+	switch (specType) {
+		case "string":
+			return `        ${k} = try c.decodeIfPresent(String.self, forKey: .${k}) ?? ""`;
+		case "[UI_Row]":
+			return `        ${k} = try c.decodeIfPresent([UI_Row].self, forKey: .${k}) ?? []`;
+		case "[String]":
+			return `        ${k} = try c.decodeIfPresent([String].self, forKey: .${k}) ?? []`;
+		case "UI_Row":
+			return `        ${k} = try c.decodeIfPresent(UI_Row.self, forKey: .${k})`;
+		default:
+			return `        ${k} = try c.decodeIfPresent(String.self, forKey: .${k}) ?? ""`;
+	}
+}
+
+function emitRowContentEncodeLine(key: string, specType: string): string {
+	const k = swiftIdentifier(key);
+	switch (specType) {
+		case "UI_Row":
+			return `        try c.encodeIfPresent(${k}, forKey: .${k})`;
+		default:
+			return `        try c.encode(${k}, forKey: .${k})`;
+	}
+}
+
 function emitRowContentStruct(
 	rowType: string,
 	content: Record<string, string>,
 ): string {
 	const contentName = `${rowType}RowContent`;
-	const fields = Object.entries(content).map(
-		([k, v]) => `    public let ${k}: ${swiftTypeForSpecType(v)}`,
+	const entries = Object.entries(content);
+	const fieldLines = entries.map(
+		([k, v]) =>
+			`    public let ${swiftIdentifier(k)}: ${swiftTypeForSpecType(v)}`,
 	);
+	const codingKeyCases = entries.map(
+		([k]) => `        case ${swiftIdentifier(k)}`,
+	);
+	const decodeLines = entries.map(([k, v]) => emitRowContentDecodeLine(k, v));
+	const encodeLines = entries.map(([k, v]) => emitRowContentEncodeLine(k, v));
+
 	return `// MARK: - ${contentName}
 public struct ${contentName}: Codable {
-${fields.join("\n")}
+${fieldLines.join("\n")}
+
+    private enum CodingKeys: String, CodingKey {
+${codingKeyCases.join("\n")}
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+${decodeLines.join("\n")}
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+${encodeLines.join("\n")}
+    }
 }`;
 }
 
@@ -432,16 +481,50 @@ function emitRowViewDataStruct(
 	const viewDataName = `${rowType}RowViewData`;
 	const contentName = `${rowType}RowContent`;
 
-	const viewFields: string[] = ["    public let content: " + contentName];
-	if (spec.view) {
-		for (const [k] of Object.entries(spec.view)) {
-			viewFields.push(`    public let ${k}: String?`);
-		}
+	if (!spec.view || Object.keys(spec.view).length === 0) {
+		return `// MARK: - ${viewDataName}
+public struct ${viewDataName}: Codable {
+    public let content: ${contentName}
+}`;
 	}
+
+	const viewEntries = Object.entries(spec.view);
+	const viewFieldLines = viewEntries.map(
+		([k]) => `    public let ${swiftIdentifier(k)}: String`,
+	);
+	const codingKeyCases = [
+		"        case content",
+		...viewEntries.map(([k]) => `        case ${swiftIdentifier(k)}`),
+	];
+	const decodeViewLines = viewEntries.map(
+		([k]) =>
+			`        ${swiftIdentifier(k)} = try c.decodeIfPresent(String.self, forKey: .${swiftIdentifier(k)}) ?? ""`,
+	);
+	const encodeViewLines = viewEntries.map(
+		([k]) =>
+			`        try c.encode(${swiftIdentifier(k)}, forKey: .${swiftIdentifier(k)})`,
+	);
 
 	return `// MARK: - ${viewDataName}
 public struct ${viewDataName}: Codable {
-${viewFields.join("\n")}
+    public let content: ${contentName}
+${viewFieldLines.join("\n")}
+
+    private enum CodingKeys: String, CodingKey {
+${codingKeyCases.join("\n")}
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        content = try c.decode(${contentName}.self, forKey: .content)
+${decodeViewLines.join("\n")}
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(content, forKey: .content)
+${encodeViewLines.join("\n")}
+    }
 }`;
 }
 
@@ -463,7 +546,7 @@ function emitUIRowPayloads(rowSpec: RowSpec): string {
 		if (!spec) continue;
 		const viewDataName = `${rowType}RowViewData`;
 		payloadCases.push(
-			`    case ${rowTypeToEnumCase(rowType)}(${viewDataName}, String, String?, [UI_RowAction])`,
+			`    case ${rowTypeToEnumCase(rowType)}(${viewDataName}, String, String, [UI_RowAction])`,
 		);
 	}
 

--- a/scripts/normalize-sdui-docs.ts
+++ b/scripts/normalize-sdui-docs.ts
@@ -1,0 +1,33 @@
+/**
+ * One-off / maintenance: normalize seeded SDUI JSON under docs/ to the canonical
+ * row shape (defaults merged). Run from repo root: bun scripts/normalize-sdui-docs.ts
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { normalizeServerFlow } from "../web/app/utils/decodeFlow";
+import { validateUiFlow } from "../types/validators";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+const FILES = [
+	join(SCRIPT_DIR, "..", "docs", "evy", "evy_sdui.json"),
+	join(SCRIPT_DIR, "..", "docs", "services", "service_sdui.json"),
+] as const;
+
+async function main(): Promise<void> {
+	for (const filePath of FILES) {
+		const raw = await readFile(filePath, "utf-8");
+		const parsed: unknown = JSON.parse(raw);
+		const flows = Array.isArray(parsed) ? parsed : [parsed];
+		const normalized = flows.map((f) =>
+			validateUiFlow(normalizeServerFlow(validateUiFlow(f))),
+		);
+		const out = Array.isArray(parsed) ? normalized : normalized[0];
+		await writeFile(filePath, `${JSON.stringify(out, null, "\t")}\n`, "utf-8");
+		console.log(`Wrote ${filePath}`);
+	}
+}
+
+await main();

--- a/types/schema/sdui/evy.schema.json
+++ b/types/schema/sdui/evy.schema.json
@@ -85,6 +85,7 @@
 				"value": { "type": "string" },
 				"placeholder": { "type": "string" },
 				"format": { "type": "string" },
+				"child": { "$ref": "#/$defs/UI_Row" },
 				"action": { "type": "string" },
 				"primary": { "type": "string" },
 				"secondary": { "type": "string" },
@@ -96,7 +97,6 @@
 					"type": "array",
 					"items": { "$ref": "#/$defs/UI_Row" }
 				},
-				"child": { "$ref": "#/$defs/UI_Row" },
 				"segments": {
 					"type": "array",
 					"items": { "type": "string" }

--- a/types/schema/sdui/row-content.spec.json
+++ b/types/schema/sdui/row-content.spec.json
@@ -15,7 +15,8 @@
 	"Info": {
 		"content": {
 			"title": "string",
-			"text": "string"
+			"subtitle": "string",
+			"icon": "string"
 		}
 	},
 	"Text": {
@@ -64,8 +65,8 @@
 	"Search": {
 		"content": {
 			"title": "string",
-			"format": "string",
-			"placeholder": "string"
+			"placeholder": "string",
+			"child": "UI_Row"
 		}
 	},
 	"SelectPhoto": {

--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -12,6 +12,56 @@ import {
 } from "../utils/actionHelpers";
 import { ActionEditor } from "./ActionEditor";
 import { PageInUseDialog } from "./PageInUseDialog";
+import { mergeRowContentWithPaletteDefaults } from "../utils/decodeFlow";
+
+const INFO_PANEL_FIELD_ORDER = ["icon", "title", "subtitle"] as const;
+const INPUT_LIST_PANEL_FIELD_ORDER = [
+	"title",
+	"placeholder",
+	"format",
+] as const;
+
+function isContainerKey(k: string): boolean {
+	return k === "child" || k === "children";
+}
+
+function sortContentEntriesForPanel(
+	rowType: string,
+	entries: [string, unknown][],
+): [string, unknown][] {
+	const containers = entries.filter(([k]) => isContainerKey(k));
+	const rest = entries.filter(([k]) => !isContainerKey(k));
+
+	const byKey = new Map(rest);
+	const fieldOrder =
+		rowType === "Info"
+			? INFO_PANEL_FIELD_ORDER
+			: rowType === "InputList"
+				? INPUT_LIST_PANEL_FIELD_ORDER
+				: undefined;
+
+	if (!fieldOrder) {
+		return [...rest, ...containers];
+	}
+
+	const fixed = new Set<string>(fieldOrder);
+	const ordered: [string, unknown][] = [];
+
+	for (const k of fieldOrder) {
+		if (byKey.has(k)) {
+			const v = byKey.get(k);
+			if (v !== undefined) {
+				ordered.push([k, v]);
+			}
+		}
+	}
+	for (const [k, v] of rest) {
+		if (!fixed.has(k)) {
+			ordered.push([k, v]);
+		}
+	}
+	return [...ordered, ...containers];
+}
 
 function isRow(value: unknown): value is Row {
 	return value !== null && typeof value === "object" && "config" in value;
@@ -186,13 +236,11 @@ export function ConfigurationPanel() {
 
 	const renderConfiguration = useCallback(
 		(configRow: Row): React.ReactNode[] => {
-			const content = configRow.config.view.content;
-			const entries = Object.entries(content).sort(([a], [b]) => {
-				const isContainerKey = (k: string) => k === "child" || k === "children";
-				if (isContainerKey(a) && !isContainerKey(b)) return 1;
-				if (!isContainerKey(a) && isContainerKey(b)) return -1;
-				return 0;
-			});
+			const merged = mergeRowContentWithPaletteDefaults(configRow);
+			const entries = sortContentEntriesForPanel(
+				configRow.config.type,
+				Object.entries(merged),
+			);
 
 			const contentElements = entries.map(([key, value]) => {
 				const uniqueId = `${configRow.id}-${key}`;
@@ -345,10 +393,13 @@ export function ConfigurationPanel() {
 				)}
 				{currentConfigRow ? (
 					<>
+						<p className="evy-text-lg evy-font-semibold">
+							{currentConfigRow.config.type} Row
+						</p>
 						{configurationElements}
 						<div className="evy-border-b evy-border-gray" />
 						<ActionEditor
-							actions={currentConfigRow.config.actions ?? []}
+							actions={currentConfigRow.config.actions}
 							flows={flows}
 							onUpdate={updateRowActions}
 						/>

--- a/web/app/hooks/useDraggable.ts
+++ b/web/app/hooks/useDraggable.ts
@@ -16,7 +16,7 @@ import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/externa
 
 import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 
-import { useDragContext } from "../state";
+import { useDragContext } from "../state/contexts/DragContext";
 import { useRowById } from "./useRowById";
 
 const rowEdges: Edge[] = ["top", "bottom"];

--- a/web/app/hooks/useRowById.ts
+++ b/web/app/hooks/useRowById.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { useFlowsContext } from "../state";
+import { useFlowsContext } from "../state/contexts/FlowsContext";
 import type { Row } from "../types/row";
 import { findFlowById } from "../utils/flowHelpers";
 import { getRowsRecursive } from "../utils/rowTree";

--- a/web/app/rows/action/ButtonRow.tsx
+++ b/web/app/rows/action/ButtonRow.tsx
@@ -18,13 +18,7 @@ export default defineRow("ButtonRow", {
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<div className="evy-p-2 evy-flex evy-justify-center">
-				<Button
-					label={
-						typeof row.config.view.content.label === "string"
-							? row.config.view.content.label
-							: ""
-					}
-				/>
+				<Button label={row.config.view.content.label} />
 			</div>
 		</RowLayout>
 	),

--- a/web/app/rows/action/TextActionRow.tsx
+++ b/web/app/rows/action/TextActionRow.tsx
@@ -22,13 +22,13 @@ export default defineRow("TextActionRow", {
 		<RowLayout title={row.config.view.content.title}>
 			<div className="evy-flex evy-justify-between">
 				<p className="evy-text-md">
-					<EVYText text={row.config.view.content.text ?? ""} />
+					<EVYText text={row.config.view.content.text} />
 				</p>
 				<button
 					type="button"
 					className="evy-text-blue evy-text-sm evy-hover:text-black evy-bg-transparent evy-border-none"
 				>
-					<EVYText text={row.config.view.content.action ?? ""} />
+					<EVYText text={row.config.view.content.action} />
 				</button>
 			</div>
 		</RowLayout>

--- a/web/app/rows/edit/DropdownRow.tsx
+++ b/web/app/rows/edit/DropdownRow.tsx
@@ -21,7 +21,7 @@ export default defineRow("DropdownRow", {
 		<RowLayout title={row.config.view.content.title}>
 			<Dropdown
 				value={row.config.source}
-				placeholder={row.config.view.content.placeholder ?? ""}
+				placeholder={row.config.view.content.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/InputRow.tsx
+++ b/web/app/rows/edit/InputRow.tsx
@@ -20,8 +20,8 @@ export default defineRow("InputRow", {
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<Input
-				value={row.config.view.content.value?.toString() ?? ""}
-				placeholder={row.config.view.content.placeholder?.toString() ?? ""}
+				value={row.config.view.content.value}
+				placeholder={row.config.view.content.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/SearchRow.tsx
+++ b/web/app/rows/edit/SearchRow.tsx
@@ -1,8 +1,35 @@
-import type { RowConfig } from "../../types/row";
+import { createElement } from "react";
+
+import type { Row, RowConfig } from "../../types/row";
+import { SEARCH_DEFAULT_RESULT_CONTENT } from "../../utils/searchRowDefaults";
 import { defineRow } from "../defineRow";
 import InlineIcon from "../design-system/InlineIcon";
 import Input from "../design-system/Input";
 import { RowLayout } from "../design-system/RowLayout";
+import InfoRow from "../view/InfoRow";
+import { SearchPreviewResults } from "./searchPreview";
+
+const SEARCH_RESULT_TEMPLATE_ROW_ID =
+	"00000000-0000-4000-8000-000000000001";
+
+const defaultSearchResultTemplateRow: Row = {
+	id: SEARCH_RESULT_TEMPLATE_ROW_ID,
+	row: createElement(InfoRow, {
+		key: SEARCH_RESULT_TEMPLATE_ROW_ID,
+		rowId: SEARCH_RESULT_TEMPLATE_ROW_ID,
+	}),
+	config: {
+		type: "Info",
+		source: "",
+		destination: "",
+		actions: [],
+		view: {
+			content: {
+				...SEARCH_DEFAULT_RESULT_CONTENT,
+			},
+		},
+	},
+};
 
 export default defineRow("SearchRow", {
 	config: {
@@ -12,8 +39,8 @@ export default defineRow("SearchRow", {
 		view: {
 			content: {
 				title: "Search row title",
-				format: "{datum.value}",
 				placeholder: "placeholder",
+				child: defaultSearchResultTemplateRow,
 			},
 		},
 		destination: "{address}",
@@ -27,6 +54,10 @@ export default defineRow("SearchRow", {
 					placeholder={row.config.view.content.placeholder ?? ""}
 				/>
 			</div>
+			<SearchPreviewResults
+				templateRow={row.config.view.content.child}
+				parentRowId={row.id}
+			/>
 		</RowLayout>
 	),
 });

--- a/web/app/rows/edit/SearchRow.tsx
+++ b/web/app/rows/edit/SearchRow.tsx
@@ -9,8 +9,7 @@ import { RowLayout } from "../design-system/RowLayout";
 import InfoRow from "../view/InfoRow";
 import { SearchPreviewResults } from "./searchPreview";
 
-const SEARCH_RESULT_TEMPLATE_ROW_ID =
-	"00000000-0000-4000-8000-000000000001";
+const SEARCH_RESULT_TEMPLATE_ROW_ID = "00000000-0000-4000-8000-000000000001";
 
 const defaultSearchResultTemplateRow: Row = {
 	id: SEARCH_RESULT_TEMPLATE_ROW_ID,

--- a/web/app/rows/edit/SelectPhotoRow.tsx
+++ b/web/app/rows/edit/SelectPhotoRow.tsx
@@ -26,32 +26,14 @@ export default defineRow("SelectPhotoRow", {
 				style={{ padding: "var(--size-8)" }}
 			>
 				<div className="evy-flex evy-justify-center evy-text-center evy-flex-col">
-					<EVYText
-						text={
-							typeof row.config.view.content.icon === "string"
-								? row.config.view.content.icon
-								: ""
-						}
-					/>
+					<EVYText text={row.config.view.content.icon} />
 					<p className="evy-text-sm">
-						<EVYText
-							text={
-								typeof row.config.view.content.content === "string"
-									? row.config.view.content.content
-									: ""
-							}
-						/>
+						<EVYText text={row.config.view.content.content} />
 					</p>
 				</div>
 			</div>
 			<p className="evy-text-sm">
-				<EVYText
-					text={
-						typeof row.config.view.content.subtitle === "string"
-							? row.config.view.content.subtitle
-							: ""
-					}
-				/>
+				<EVYText text={row.config.view.content.subtitle} />
 			</p>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/TextAreaRow.tsx
+++ b/web/app/rows/edit/TextAreaRow.tsx
@@ -20,8 +20,8 @@ export default defineRow("TextAreaRow", {
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<TextArea
-				value={row.config.view.content.value ?? ""}
-				placeholder={row.config.view.content.placeholder ?? ""}
+				value={row.config.view.content.value}
+				placeholder={row.config.view.content.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/TextSelectRow.tsx
+++ b/web/app/rows/edit/TextSelectRow.tsx
@@ -21,7 +21,7 @@ export default defineRow("TextSelectRow", {
 		<RowLayout title={row.config.view.content.title}>
 			<div className="evy-flex evy-justify-between evy-gap-2">
 				<p className="evy-text-sm">
-					<EVYText text={row.config.view.content.text ?? ""} />
+					<EVYText text={row.config.view.content.text} />
 				</p>
 				<Checkbox checked={false} />
 			</div>

--- a/web/app/rows/edit/searchPreview.test.ts
+++ b/web/app/rows/edit/searchPreview.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { createElement } from "react";
+
+import type { Row } from "../../types/row";
+import InfoRow from "../view/InfoRow";
+import {
+	buildSearchPreviewRows,
+	formatSearchPreviewString,
+} from "./searchPreview";
+
+function buildInfoTemplateRow(): Row {
+	return {
+		id: "info-template",
+		row: createElement(InfoRow, {
+			key: "info-template",
+			rowId: "info-template",
+		}),
+		config: {
+			type: "Info",
+			source: "",
+			destination: "",
+			actions: [],
+			view: {
+				content: {
+					title: "{datum.value}",
+					subtitle: "{datum.city}",
+					icon: "",
+				},
+			},
+		},
+	};
+}
+
+describe("formatSearchPreviewString", () => {
+	it("replaces datum bindings with dummy preview values", () => {
+		expect(formatSearchPreviewString("{datum.value}")).toBe("Example tag");
+		expect(formatSearchPreviewString("{datum.city}, {datum.postcode}")).toBe(
+			"Sydney, 2000",
+		);
+	});
+});
+
+describe("buildSearchPreviewRows", () => {
+	it("creates three formatted preview rows from the child template", () => {
+		const previewRows = buildSearchPreviewRows(
+			buildInfoTemplateRow(),
+			"search-row",
+		);
+
+		expect(previewRows).toHaveLength(3);
+		expect(previewRows.map((row) => row.id)).toEqual([
+			"search-row:search-preview:0",
+			"search-row:search-preview:1",
+			"search-row:search-preview:2",
+		]);
+		expect(previewRows.map((row) => row.config.view.content.title)).toEqual([
+			"Example tag",
+			"Example tag",
+			"Example tag",
+		]);
+		expect(previewRows[0]?.config.view.content.subtitle).toBe("Sydney");
+	});
+
+	it("falls back to the default info template when child is omitted", () => {
+		const previewRows = buildSearchPreviewRows(undefined, "search-row");
+
+		expect(previewRows).toHaveLength(3);
+		expect(previewRows[0]?.config.type).toBe("Info");
+		expect(previewRows[0]?.config.view.content.title).toBe("Example tag");
+	});
+});

--- a/web/app/rows/edit/searchPreview.tsx
+++ b/web/app/rows/edit/searchPreview.tsx
@@ -1,0 +1,242 @@
+import { createElement, useMemo, type ReactNode } from "react";
+
+import type { FlowsContextValue } from "../../state/contexts/FlowsContext";
+import { FlowsContext } from "../../state/contexts/FlowsContext";
+import type { Row } from "../../types/row";
+import {
+	SEARCH_DEFAULT_RESULT_CONTENT,
+	SEARCH_PREVIEW_DATUM,
+	SEARCH_PREVIEW_RESULT_COUNT,
+} from "../../utils/searchRowDefaults";
+import type { RowComponent } from "../defineRow";
+import ButtonRow from "../action/ButtonRow";
+import TextActionRow from "../action/TextActionRow";
+import CalendarRow from "./CalendarRow";
+import DropdownRow from "./DropdownRow";
+import InlinePickerRow from "./InlinePickerRow";
+import InputRow from "./InputRow";
+import SelectPhotoRow from "./SelectPhotoRow";
+import TextAreaRow from "./TextAreaRow";
+import TextSelectRow from "./TextSelectRow";
+import { RowLayout } from "../design-system/RowLayout";
+import InfoRow from "../view/InfoRow";
+import InputListRow from "../view/InputListRow";
+import TextRow from "../view/TextRow";
+
+const previewRowComponents: Record<string, RowComponent> = {
+	Button: ButtonRow,
+	Calendar: CalendarRow,
+	Dropdown: DropdownRow,
+	Info: InfoRow,
+	InlinePicker: InlinePickerRow,
+	Input: InputRow,
+	InputList: InputListRow,
+	SelectPhoto: SelectPhotoRow,
+	Text: TextRow,
+	TextAction: TextActionRow,
+	TextArea: TextAreaRow,
+	TextSelect: TextSelectRow,
+};
+
+type SearchPreviewDatum = Record<string, string>;
+
+function SearchPreviewFallback({ rowType }: { rowType: string }) {
+	return (
+		<RowLayout title="">
+			<p className="evy-p-2 evy-text-sm evy-text-gray">
+				Preview unavailable for `{rowType}` result rows
+			</p>
+		</RowLayout>
+	);
+}
+
+function resolveDatumValue(path: string, datum: SearchPreviewDatum): string {
+	const normalizedPath = path.trim();
+	if (!normalizedPath) {
+		return datum.value ?? "";
+	}
+
+	return datum[normalizedPath] ?? "";
+}
+
+export function formatSearchPreviewString(
+	template: string,
+	datum: SearchPreviewDatum = SEARCH_PREVIEW_DATUM,
+): string {
+	return template.replace(/\{datum(?:\.([^}]+))?\}/g, (_match, path?: string) =>
+		resolveDatumValue(path ?? "", datum),
+	);
+}
+
+function formatSearchPreviewContentStrings(
+	value: unknown,
+	datum: SearchPreviewDatum,
+): unknown {
+	if (typeof value === "string") {
+		return formatSearchPreviewString(value, datum);
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((entry) =>
+			formatSearchPreviewContentStrings(entry, datum),
+		);
+	}
+
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value).map(([key, nestedValue]) => [
+				key,
+				formatSearchPreviewContentStrings(nestedValue, datum),
+			]),
+		);
+	}
+
+	return value;
+}
+
+function flattenPreviewRows(row: Row): Row[] {
+	const child = row.config.view.content.child;
+	const children = row.config.view.content.children ?? [];
+
+	return [
+		row,
+		...(child ? flattenPreviewRows(child) : []),
+		...children.flatMap(flattenPreviewRows),
+	];
+}
+
+function buildPreviewRowElement(rowType: string, rowId: string): ReactNode {
+	const RowComponent = previewRowComponents[rowType];
+	if (!RowComponent) {
+		return <SearchPreviewFallback rowType={rowType} />;
+	}
+
+	return createElement(RowComponent, { key: rowId, rowId });
+}
+
+function buildDefaultSearchPreviewChild(parentRowId: string): Row {
+	const id = `${parentRowId}:search-preview-default`;
+
+	return {
+		id,
+		row: createElement(InfoRow, { key: id, rowId: id }),
+		config: {
+			type: "Info",
+			source: "",
+			destination: "",
+			actions: [],
+			view: {
+				content: {
+					...SEARCH_DEFAULT_RESULT_CONTENT,
+				},
+			},
+		},
+	};
+}
+
+function cloneSearchPreviewRow(
+	row: Row,
+	datum: SearchPreviewDatum,
+	previewId: string,
+): Row {
+	const child = row.config.view.content.child;
+	const children = row.config.view.content.children;
+	const {
+		child: _ignoredChild,
+		children: _ignoredChildren,
+		...contentWithoutRows
+	} = row.config.view.content;
+
+	const formattedChild = child
+		? cloneSearchPreviewRow(child, datum, `${previewId}:child`)
+		: undefined;
+	const formattedChildren = children?.map((nestedChild, index) =>
+		cloneSearchPreviewRow(
+			nestedChild,
+			datum,
+			`${previewId}:children:${index.toString()}`,
+		),
+	);
+
+	return {
+		id: previewId,
+		row: buildPreviewRowElement(row.config.type, previewId),
+		config: {
+			...row.config,
+			view: {
+				...row.config.view,
+				content: {
+					...(formatSearchPreviewContentStrings(
+						contentWithoutRows,
+						datum,
+					) as typeof contentWithoutRows),
+					...(formattedChild ? { child: formattedChild } : {}),
+					...(formattedChildren ? { children: formattedChildren } : {}),
+				},
+			},
+		},
+	};
+}
+
+export function buildSearchPreviewRows(
+	templateRow: Row | undefined,
+	parentRowId: string,
+	datum: SearchPreviewDatum = SEARCH_PREVIEW_DATUM,
+): Row[] {
+	const previewTemplate =
+		templateRow ?? buildDefaultSearchPreviewChild(parentRowId);
+
+	return Array.from({ length: SEARCH_PREVIEW_RESULT_COUNT }, (_unused, index) =>
+		cloneSearchPreviewRow(
+			previewTemplate,
+			datum,
+			`${parentRowId}:search-preview:${index.toString()}`,
+		),
+	);
+}
+
+export function SearchPreviewResults({
+	templateRow,
+	parentRowId,
+}: {
+	templateRow: Row | undefined;
+	parentRowId: string;
+}) {
+	const previewRows = useMemo(
+		() => buildSearchPreviewRows(templateRow, parentRowId),
+		[templateRow, parentRowId],
+	);
+	const flattenedRows = useMemo(
+		() => previewRows.flatMap(flattenPreviewRows),
+		[previewRows],
+	);
+	const previewContextValue = useMemo<FlowsContextValue>(
+		() => ({
+			rows: flattenedRows,
+			flows: [],
+			focusMode: false,
+			configStack: [],
+			dispatchRow: () => {},
+		}),
+		[flattenedRows],
+	);
+
+	if (previewRows.length === 0) {
+		return null;
+	}
+
+	return (
+		<FlowsContext.Provider value={previewContextValue}>
+			<div className="evy-mt-2 evy-flex evy-flex-col">
+				{previewRows.map((previewRow) => (
+					<div
+						key={previewRow.id}
+						className="evy-border-0 evy-border-t evy-border-solid evy-border-gray-light"
+					>
+						{previewRow.row}
+					</div>
+				))}
+			</div>
+		</FlowsContext.Provider>
+	);
+}

--- a/web/app/rows/view/InfoRow.tsx
+++ b/web/app/rows/view/InfoRow.tsx
@@ -1,7 +1,19 @@
+import type { CSSProperties } from "react";
+
 import type { RowConfig } from "../../types/row";
-import { defineRow } from "../defineRow";
 import EVYText from "../design-system/EVYText";
-import { RowLayout } from "../design-system/RowLayout";
+import { defineRow } from "../defineRow";
+
+function lineClampStyle(lines: number): CSSProperties {
+	return {
+		display: "-webkit-box",
+		WebkitLineClamp: lines,
+		WebkitBoxOrient: "vertical",
+		overflow: "hidden",
+		overflowWrap: "anywhere",
+		wordBreak: "break-word",
+	};
+}
 
 export default defineRow("InfoRow", {
 	config: {
@@ -11,15 +23,58 @@ export default defineRow("InfoRow", {
 		view: {
 			content: {
 				title: "Info row title",
-				text: "Info row info",
+				subtitle: "",
+				icon: "",
 			},
 		},
 	} satisfies RowConfig,
-	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
-			<p className="evy-text-sm">
-				<EVYText text={row.config.view.content.text ?? ""} />
-			</p>
-		</RowLayout>
-	),
+	render: (row) => {
+		const { title, subtitle, icon } = row.config.view.content;
+		const titleStr = title ?? "";
+		const subtitleStr = subtitle ?? "";
+		const iconStr = (icon ?? "").trim();
+
+		const hasTitle = titleStr.length > 0;
+		const body = (
+			<div
+				className={
+					hasTitle ? "evy-min-w-0 evy-flex-1" : "evy-flex-1 evy-text-center"
+				}
+			>
+				{hasTitle ? (
+					<p className="evy-text-md" style={lineClampStyle(1)}>
+						<EVYText text={titleStr} />
+					</p>
+				) : null}
+				{subtitleStr.length > 0 ? (
+					<p className="evy-text-sm evy-text-gray" style={lineClampStyle(3)}>
+						<EVYText text={subtitleStr} />
+					</p>
+				) : null}
+			</div>
+		);
+
+		return (
+			<div className="evy-p-2">
+				{iconStr.length > 0 ? (
+					<div className="evy-flex evy-items-start evy-gap-2">
+						<div className="evy-shrink-0 evy-flex evy-items-center evy-justify-center evy-min-w-[2rem] evy-text-md">
+							<EVYText text={iconStr} />
+						</div>
+						{body}
+					</div>
+				) : (
+					<div
+						className={
+							hasTitle
+								? "evy-flex evy-items-start"
+								: "evy-flex evy-justify-center"
+						}
+					>
+						{body}
+					</div>
+				)}
+			</div>
+		);
+	},
 });

--- a/web/app/rows/view/InputListRow.tsx
+++ b/web/app/rows/view/InputListRow.tsx
@@ -20,7 +20,7 @@ export default defineRow("InputListRow", {
 		<RowLayout title={row.config.view.content.title}>
 			<Input
 				value={row.config.source}
-				placeholder={row.config.view.content.placeholder ?? ""}
+				placeholder={row.config.view.content.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/view/TextRow.tsx
+++ b/web/app/rows/view/TextRow.tsx
@@ -19,7 +19,7 @@ export default defineRow("TextRow", {
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<p className="evy-text-sm">
-				<EVYText text={row.config.view.content.text ?? ""} />
+				<EVYText text={row.config.view.content.text} />
 			</p>
 		</RowLayout>
 	),

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -175,7 +175,7 @@ describe("pageReducer", () => {
 		expect(row?.config.view.content).toEqual(before?.config.view.content);
 	});
 
-	it("UPDATE_ROW_ROOT clears destination when value is empty string", () => {
+	it("UPDATE_ROW_ROOT sets destination to empty string when value is empty string", () => {
 		const base = textRow("row-1");
 		const rowWithDestination: Row = {
 			...base,
@@ -206,7 +206,7 @@ describe("pageReducer", () => {
 			value: "",
 		});
 		const row = next.flows[0].pages[0].rows[0];
-		expect(row.config.destination).toBeUndefined();
+		expect(row.config.destination).toBe("");
 	});
 
 	it("SET_ACTIVE_ROW updates selection", () => {

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -1,10 +1,10 @@
-import { createElement } from "react";
 import invariant from "tiny-invariant";
 
 import type { AppState, RowAction } from "../../types/actions";
 import type { UI_Page } from "../../types/flow";
 import type { Row } from "../../types/row";
 import { baseRows } from "../../rows/baseRows";
+import { buildRowForNewPageFromBase } from "../../utils/decodeFlow";
 import {
 	removeRowFromTree,
 	updateRowInTree,
@@ -123,18 +123,14 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			});
 			if (!baseRow) return state;
 
-			const rowDataAdd: Row = {
-				...baseRow,
-				id: action.newRowId,
-				config: structuredClone(baseRow.config),
-				row: createElement(baseRow, { rowId: action.newRowId }),
-			};
+			const rowDataAdd: Row = buildRowForNewPageFromBase(
+				baseRow,
+				action.newRowId,
+			);
 
 			const page = flow.pages.find((p) => p.id === action.destinationPageId);
 			if (!page) return state;
 
-			// Reuse the same tree insertion logic as MOVE_ROW so dragging a brand-new
-			// row from the sidebar and moving an existing nested row behave the same.
 			const insertionResult = insertRowIntoTree(
 				page.rows,
 				rowDataAdd,

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -267,9 +267,7 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 					...row.config,
 					...(action.field === "source"
 						? { source: action.value }
-						: {
-								destination: action.value === "" ? undefined : action.value,
-							}),
+						: { destination: action.value }),
 				},
 			});
 

--- a/web/app/utils/conditionExpression.ts
+++ b/web/app/utils/conditionExpression.ts
@@ -268,7 +268,7 @@ function serializeExpressionInner(expr: ConditionExpression): string {
 	return parts.join(sep);
 }
 
-/** Convert an expression tree to a flat list (backwards-compatible helper). */
+/** Convert an expression tree to a flat list of leaf conditions. */
 export function expressionToFlatParts(
 	expr: ConditionExpression | null,
 ): ConditionPart[] {

--- a/web/app/utils/decodeFlow.test.ts
+++ b/web/app/utils/decodeFlow.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "bun:test";
+import type { UI_Flow as ServerFlow, UI_Row as ServerRow } from "evy-types";
+
+import { validateUiFlow } from "../../../types/validators";
+import {
+	decodeFlows,
+	encodeFlow,
+	normalizeServerFlow,
+	normalizeServerRow,
+} from "./decodeFlow";
+
+const FLOW_ID = "f267c629-2594-4770-8cec-d5324ebb4058";
+const PAGE_ID = "55e427ac-263c-441f-9673-f60627b1baea";
+const ROW_A = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const ROW_B = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+
+describe("normalizeServerRow", () => {
+	it("fills root string defaults and empty destination when omitted", () => {
+		const partial = {
+			id: ROW_A,
+			type: "Button",
+			view: {
+				content: {
+					label: "OK",
+				},
+			},
+			actions: [{ condition: "", false: "", true: "close" }],
+		} as unknown as ServerRow;
+
+		const n = normalizeServerRow(partial);
+		expect(n.source).toBe("");
+		expect(n.destination).toBe("");
+		expect(n.view.content).toMatchObject({
+			title: "",
+			label: "OK",
+		});
+	});
+
+	it("merges Info content string fields from defaults when missing", () => {
+		const n = normalizeServerRow({
+			id: ROW_A,
+			type: "Info",
+			source: "{item}",
+			actions: [],
+			view: {
+				content: {
+					title: "T",
+					subtitle: "Sub",
+				},
+			},
+		} as ServerRow);
+
+		expect(n.view.content).toMatchObject({
+			title: "T",
+			subtitle: "Sub",
+			icon: "",
+		});
+	});
+
+	it("preserves Info content keys as sent by the server", () => {
+		const n = normalizeServerRow({
+			id: ROW_A,
+			type: "Info",
+			source: "",
+			actions: [],
+			view: {
+				content: {
+					title: "T",
+					text: "extra",
+					subtitle: "",
+					icon: "",
+				},
+			},
+		} as ServerRow);
+
+		expect((n.view.content as { text?: string }).text).toBe("extra");
+	});
+
+	it("normalizes nested rows in children", () => {
+		const n = normalizeServerRow({
+			id: ROW_A,
+			type: "ListContainer",
+			source: "",
+			actions: [],
+			view: {
+				content: {
+					title: "List",
+					children: [
+						{
+							id: ROW_B,
+							type: "Button",
+							source: "",
+							actions: [],
+							view: {
+								content: {
+									label: "Go",
+								},
+							},
+						} as unknown as ServerRow,
+					],
+				},
+			},
+		} as ServerRow);
+
+		const first = n.view.content.children?.[0];
+		expect(first?.type).toBe("Button");
+		expect(first?.destination).toBe("");
+		expect(first?.view.content).toMatchObject({
+			title: "",
+			label: "Go",
+		});
+	});
+
+	it("uses default segments when segments key is omitted", () => {
+		const n = normalizeServerRow({
+			id: ROW_A,
+			type: "SelectSegmentContainer",
+			source: "",
+			actions: [],
+			view: {
+				content: {
+					title: "Tabs",
+					children: [],
+				},
+			},
+		} as ServerRow);
+
+		expect(n.view.content.segments).toEqual(["X", "Y", "Z"]);
+	});
+
+	it("merges Search child from palette when server omits child", () => {
+		const n = normalizeServerRow({
+			id: ROW_A,
+			type: "Search",
+			source: "{api:tags}",
+			destination: "{tags}",
+			actions: [],
+			view: {
+				content: {
+					title: "Find",
+					placeholder: "Search",
+				},
+			},
+		} as ServerRow);
+
+		expect(n.view.content.child?.type).toBe("Info");
+		expect(n.view.content.child?.view.content).toMatchObject({
+			title: "{datum.value}",
+			subtitle: "",
+			icon: "",
+		});
+	});
+});
+
+describe("decodeFlows / encodeFlow", () => {
+	it("round-trips to the same normalized server shape as normalizeServerFlow", () => {
+		const raw: ServerFlow = {
+			id: FLOW_ID,
+			name: "F",
+			pages: [
+				{
+					id: PAGE_ID,
+					title: "P",
+					rows: [
+						{
+							id: ROW_A,
+							type: "Text",
+							source: "{item}",
+							actions: [],
+							view: {
+								content: {
+									title: "Hello",
+									text: "{x}",
+								},
+								max_lines: "",
+							},
+						},
+					],
+				},
+			],
+		};
+
+		const validated = validateUiFlow(raw);
+		const canonical = normalizeServerFlow(validated);
+		const decoded = decodeFlows([validated])[0];
+		const encoded = encodeFlow(decoded);
+		expect(encoded).toEqual(canonical);
+	});
+});

--- a/web/app/utils/decodeFlow.test.ts
+++ b/web/app/utils/decodeFlow.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import type { UI_Flow as ServerFlow, UI_Row as ServerRow } from "evy-types";
+import invariant from "tiny-invariant";
 
 import { validateUiFlow } from "../../../types/validators";
+import SearchRow from "../rows/edit/SearchRow";
 import {
+	buildRowForNewPageFromBase,
 	decodeFlows,
 	encodeFlow,
 	normalizeServerFlow,
@@ -185,5 +188,21 @@ describe("decodeFlows / encodeFlow", () => {
 		const decoded = decodeFlows([validated])[0];
 		const encoded = encodeFlow(decoded);
 		expect(encoded).toEqual(canonical);
+	});
+});
+
+describe("buildRowForNewPageFromBase", () => {
+	it("produces a Search row with a non-palette id for the nested template child", () => {
+		const newId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+		const row = buildRowForNewPageFromBase(SearchRow, newId);
+		expect(row.id).toBe(newId);
+		expect(row.config.type).toBe("Search");
+		expect(row.config.view.content.title).toBe("Search row title");
+		const child = row.config.view.content.child;
+		expect(child).toBeDefined();
+		invariant(child, "search row template child");
+		const childId = child.id;
+		expect(childId).toBeDefined();
+		expect(childId).not.toBe("00000000-0000-4000-8000-000000000001");
 	});
 });

--- a/web/app/utils/decodeFlow.ts
+++ b/web/app/utils/decodeFlow.ts
@@ -331,3 +331,32 @@ export const decodeFlows = (flows: ServerFlow[]): UI_Flow[] => {
 		})),
 	}));
 };
+
+function assignFreshIdsInPlace(row: ServerRow, rootId: string): void {
+	row.id = rootId;
+	const { child, children } = row.view.content;
+	if (child) {
+		assignFreshIdsInPlace(child, crypto.randomUUID());
+	}
+	if (children) {
+		for (const c of children) {
+			assignFreshIdsInPlace(c, crypto.randomUUID());
+		}
+	}
+}
+
+/** Clone a palette base row for `ADD_ROW`: encode to ServerRow, deep-clone, assign fresh ids, decode. */
+export function buildRowForNewPageFromBase(
+	baseRow: RowComponent,
+	newRowId: string,
+): Row {
+	const tempId = "row-build-temp";
+	const seed: Row = {
+		id: tempId,
+		row: createElement(baseRow, { key: tempId, rowId: tempId }),
+		config: baseRow.config,
+	};
+	const cloned = structuredClone(encodeRowToServerRow(seed));
+	assignFreshIdsInPlace(cloned, newRowId);
+	return decodeRow(cloned);
+}

--- a/web/app/utils/decodeFlow.ts
+++ b/web/app/utils/decodeFlow.ts
@@ -21,7 +21,9 @@ function getBaseRowForType(type: string): RowComponent | undefined {
 	return BASE_ROW_BY_TYPE.get(type);
 }
 
-export function mergeRowContentWithPaletteDefaults(row: Row): Record<string, unknown> {
+export function mergeRowContentWithPaletteDefaults(
+	row: Row,
+): Record<string, unknown> {
 	const baseRow = getBaseRowForType(row.config.type);
 	const content = {
 		...(row.config.view.content as Record<string, unknown>),
@@ -251,8 +253,12 @@ function encodeRowToServerRow(row: Row): ServerRow {
 	const mergedView: ServerRow["view"] = {
 		content: mergedContent,
 	};
-	if (row.config.view.max_lines !== undefined || def.view.max_lines !== undefined) {
-		mergedView.max_lines = row.config.view.max_lines ?? def.view.max_lines ?? "";
+	if (
+		row.config.view.max_lines !== undefined ||
+		def.view.max_lines !== undefined
+	) {
+		mergedView.max_lines =
+			row.config.view.max_lines ?? def.view.max_lines ?? "";
 	}
 	return {
 		id: row.id,

--- a/web/app/utils/decodeFlow.ts
+++ b/web/app/utils/decodeFlow.ts
@@ -6,52 +6,261 @@ import type {
 	UI_RowContent as ServerRowContent,
 } from "evy-types";
 
-import type { Row } from "../types/row";
+import type { Row, RowConfig } from "../types/row";
 import type { UI_Flow, UI_Page } from "../types/flow";
 import { baseRows } from "../rows/baseRows";
 import { UnknownRow } from "../rows/EVYRow";
 
-function encodeRow(row: Row): ServerRow {
-	const { view, ...rowRoot } = row.config;
-	const content = view.content;
+type RowComponent = (typeof baseRows)[number];
 
-	// Build the encoded content, converting Row children/child to ServerRow
-	const encodedContent: ServerRowContent = { title: content.title };
+const BASE_ROW_BY_TYPE = new Map<string, RowComponent>(
+	baseRows.map((r) => [r.config.type, r]),
+);
 
-	// Copy over all string/string[] properties
-	const contentRecord = content as unknown as Record<string, unknown>;
-	const encodedRecord = encodedContent as unknown as Record<string, unknown>;
-	for (const key of Object.keys(contentRecord)) {
+function getBaseRowForType(type: string): RowComponent | undefined {
+	return BASE_ROW_BY_TYPE.get(type);
+}
+
+export function mergeRowContentWithPaletteDefaults(row: Row): Record<string, unknown> {
+	const baseRow = getBaseRowForType(row.config.type);
+	const content = {
+		...(row.config.view.content as Record<string, unknown>),
+	};
+	if (!baseRow) {
+		return content;
+	}
+	return {
+		...(baseRow.config.view.content as Record<string, unknown>),
+		...content,
+	};
+}
+
+export function normalizeServerRow(row: ServerRow): ServerRow {
+	const baseRow = getBaseRowForType(row.type);
+	if (!baseRow) {
+		return normalizeUnknownServerRow(row);
+	}
+	const def = baseRow.config;
+	const mergedContent = normalizeRowContentAgainstDefaults(
+		row.view.content,
+		def.view.content,
+	);
+	const mergedView: ServerRow["view"] = {
+		content: mergedContent,
+	};
+	if (row.view.max_lines !== undefined || def.view.max_lines !== undefined) {
+		mergedView.max_lines = row.view.max_lines ?? def.view.max_lines ?? "";
+	}
+	return {
+		id: row.id,
+		type: row.type,
+		source: row.source ?? def.source ?? "",
+		destination: row.destination ?? def.destination ?? "",
+		actions: row.actions ?? def.actions ?? [],
+		view: mergedView,
+	};
+}
+
+export function normalizeServerFlow(flow: ServerFlow): ServerFlow {
+	return {
+		...flow,
+		pages: flow.pages.map((page) => ({
+			...page,
+			rows: page.rows.map(normalizeServerRow),
+			footer: page.footer ? normalizeServerRow(page.footer) : undefined,
+		})),
+	};
+}
+
+function normalizeUnknownServerRow(row: ServerRow): ServerRow {
+	const title =
+		typeof row.view.content.title === "string"
+			? row.view.content.title
+			: "Unknown row";
+	return {
+		id: row.id,
+		type: row.type,
+		source: row.source ?? "",
+		destination: row.destination ?? "",
+		actions: row.actions ?? [],
+		view: {
+			...(row.view.max_lines !== undefined
+				? { max_lines: row.view.max_lines }
+				: {}),
+			content: {
+				...row.view.content,
+				title,
+			} as ServerRowContent,
+		},
+	};
+}
+
+function normalizeRowContentAgainstDefaults(
+	incoming: ServerRowContent,
+	defaults: RowConfig["view"]["content"],
+): ServerRowContent {
+	const def = defaults as unknown as Record<string, unknown>;
+	const inc = incoming as unknown as Record<string, unknown>;
+	const allKeys = new Set([...Object.keys(def), ...Object.keys(inc)]);
+	const out: Record<string, unknown> = {};
+
+	for (const key of allKeys) {
 		if (key === "children") {
-			if (content.children) {
-				encodedContent.children = content.children.map((child: Row) =>
-					encodeRow(child),
-				);
+			const defaultChildren = Array.isArray(def.children) ? def.children : [];
+			const rawChildren: unknown =
+				"children" in inc
+					? Array.isArray(inc.children)
+						? inc.children
+						: []
+					: defaultChildren;
+			out.children = (rawChildren as ServerRow[]).map((child) =>
+				normalizeServerRow(child),
+			);
+			continue;
+		}
+		if (key === "child") {
+			if ("child" in inc && inc.child !== undefined && inc.child !== null) {
+				out.child = normalizeServerRow(inc.child as ServerRow);
+			} else if (def.child !== undefined && def.child !== null) {
+				out.child = normalizeServerRow(rowToServerRow(def.child as Row));
 			}
-		} else if (key === "child") {
-			if (content.child) {
-				encodedContent.child = encodeRow(content.child);
-			}
-		} else {
-			const value = contentRecord[key];
-			if (typeof value === "string") {
-				encodedRecord[key] = value;
-			} else if (
-				Array.isArray(value) &&
-				value.every((x): x is string => typeof x === "string")
-			) {
-				encodedRecord[key] = value;
-			}
+			continue;
+		}
+		if (key === "segments") {
+			const defaultSegments = Array.isArray(def.segments) ? def.segments : [];
+			const rawSegments: unknown =
+				"segments" in inc
+					? Array.isArray(inc.segments) &&
+						inc.segments.every((x): x is string => typeof x === "string")
+						? inc.segments
+						: []
+					: defaultSegments;
+			out.segments = rawSegments;
+			continue;
+		}
+
+		const dv = def[key];
+		const iv = inc[key];
+		if (typeof dv === "string" || typeof iv === "string") {
+			out[key] = typeof iv === "string" ? iv : typeof dv === "string" ? dv : "";
+		} else if (iv !== undefined) {
+			out[key] = iv;
+		} else if (dv !== undefined) {
+			out[key] = dv;
 		}
 	}
 
+	return out as unknown as ServerRowContent;
+}
+
+/** Map builder Row → wire ServerRow shape (recursive child/children); does not run `normalizeServerRow`. */
+function rowToServerRow(row: Row): ServerRow {
+	const { view, ...rowRoot } = row.config;
+	const content = view.content as unknown as Record<string, unknown>;
+	const serverContent: Record<string, unknown> = {};
+	for (const key of Object.keys(content)) {
+		if (key === "children") {
+			const ch = content.children;
+			serverContent.children = Array.isArray(ch)
+				? (ch as Row[]).map(rowToServerRow)
+				: [];
+		} else if (key === "child") {
+			if (content.child) {
+				serverContent.child = rowToServerRow(content.child as Row);
+			}
+		} else {
+			serverContent[key] = content[key];
+		}
+	}
 	return {
 		id: row.id,
 		...rowRoot,
 		view: {
 			...view,
-			content: encodedContent,
+			content: serverContent as unknown as ServerRowContent,
 		},
+	} as ServerRow;
+}
+
+function encodeMergeRowContent(
+	incomingRowContent: Record<string, unknown>,
+	defaults: RowConfig["view"]["content"],
+): ServerRowContent {
+	const def = defaults as unknown as Record<string, unknown>;
+	const inc = incomingRowContent;
+	const allKeys = new Set([...Object.keys(def), ...Object.keys(inc)]);
+	const out: Record<string, unknown> = {};
+
+	for (const key of allKeys) {
+		if (key === "children") {
+			const defaultChildren = Array.isArray(def.children) ? def.children : [];
+			const rawChildren: Row[] =
+				"children" in inc
+					? Array.isArray(inc.children)
+						? (inc.children as Row[])
+						: []
+					: (defaultChildren as Row[]);
+			out.children = rawChildren.map(encodeRowToServerRow);
+			continue;
+		}
+		if (key === "child") {
+			if ("child" in inc && inc.child !== undefined && inc.child !== null) {
+				out.child = encodeRowToServerRow(inc.child as Row);
+			} else if (def.child !== undefined && def.child !== null) {
+				out.child = encodeRowToServerRow(def.child as Row);
+			}
+			continue;
+		}
+		if (key === "segments") {
+			const defaultSegments = Array.isArray(def.segments) ? def.segments : [];
+			const rawSegments: unknown =
+				"segments" in inc
+					? Array.isArray(inc.segments) &&
+						inc.segments.every((x): x is string => typeof x === "string")
+						? inc.segments
+						: []
+					: defaultSegments;
+			out.segments = rawSegments;
+			continue;
+		}
+
+		const dv = def[key];
+		const iv = inc[key];
+		if (typeof dv === "string" || typeof iv === "string") {
+			out[key] = typeof iv === "string" ? iv : typeof dv === "string" ? dv : "";
+		} else if (iv !== undefined) {
+			out[key] = iv;
+		} else if (dv !== undefined) {
+			out[key] = dv;
+		}
+	}
+
+	return out as unknown as ServerRowContent;
+}
+
+function encodeRowToServerRow(row: Row): ServerRow {
+	const baseRow = getBaseRowForType(row.config.type);
+	if (!baseRow) {
+		return normalizeUnknownServerRow(rowToServerRow(row));
+	}
+	const def = baseRow.config;
+	const mergedContent = encodeMergeRowContent(
+		row.config.view.content as unknown as Record<string, unknown>,
+		def.view.content,
+	);
+	const mergedView: ServerRow["view"] = {
+		content: mergedContent,
+	};
+	if (row.config.view.max_lines !== undefined || def.view.max_lines !== undefined) {
+		mergedView.max_lines = row.config.view.max_lines ?? def.view.max_lines ?? "";
+	}
+	return {
+		id: row.id,
+		type: row.config.type,
+		source: row.config.source ?? def.source ?? "",
+		destination: row.config.destination ?? def.destination ?? "",
+		actions: row.config.actions ?? def.actions ?? [],
+		view: mergedView,
 	};
 }
 
@@ -60,42 +269,47 @@ export function encodeFlow(flow: UI_Flow): ServerFlow {
 		...flow,
 		pages: flow.pages.map((page: UI_Page) => ({
 			...page,
-			rows: page.rows.map(encodeRow),
-			footer: page.footer ? encodeRow(page.footer) : undefined,
+			rows: page.rows.map(encodeRowToServerRow),
+			footer: page.footer ? encodeRowToServerRow(page.footer) : undefined,
 		})),
 	};
 }
 
 function decodeRow(row: ServerRow): Row {
-	const baseRow = baseRows.find((baseRow) => row.type === baseRow.config.type);
+	const normalized = normalizeServerRow(row);
+	const baseRow = getBaseRowForType(normalized.type);
 	if (!baseRow) {
 		return {
-			id: row.id,
-			row: createElement(UnknownRow, { key: row.id, rowId: row.id }),
+			id: normalized.id,
+			row: createElement(UnknownRow, {
+				key: normalized.id,
+				rowId: normalized.id,
+			}),
 			config: UnknownRow.config,
 		};
 	}
+	const vc = normalized.view.content;
+	const decodedContent = {
+		...vc,
+		...(Array.isArray(vc.children)
+			? {
+					children: vc.children.map((child: ServerRow) => decodeRow(child)),
+				}
+			: {}),
+		...(vc.child ? { child: decodeRow(vc.child) } : {}),
+	} as unknown as Row["config"]["view"]["content"];
+
 	return {
-		id: row.id,
-		row: createElement(baseRow, { key: row.id, rowId: row.id }),
+		id: normalized.id,
+		row: createElement(baseRow, { key: normalized.id, rowId: normalized.id }),
 		config: {
-			...row,
-			actions: row.actions ?? [],
+			type: normalized.type,
+			source: normalized.source,
+			destination: normalized.destination,
+			actions: normalized.actions,
 			view: {
-				...row.view,
-				content: {
-					...row.view.content,
-					title:
-						typeof row.view.content.title === "string"
-							? row.view.content.title
-							: "Invalid title",
-					children: row.view.content.children?.map((child: ServerRow) =>
-						decodeRow(child),
-					),
-					child: row.view.content.child
-						? decodeRow(row.view.content.child)
-						: undefined,
-				},
+				max_lines: normalized.view.max_lines,
+				content: decodedContent,
 			},
 		},
 	};

--- a/web/app/utils/searchRowDefaults.ts
+++ b/web/app/utils/searchRowDefaults.ts
@@ -1,0 +1,22 @@
+export const SEARCH_DEFAULT_RESULT_CONTENT = {
+	title: "{datum.value}",
+	subtitle: "",
+	icon: "",
+} as const;
+
+export const SEARCH_PREVIEW_RESULT_COUNT = 3;
+
+export const SEARCH_PREVIEW_DATUM = {
+	value: "Example tag",
+	label: "Example tag",
+	name: "Example tag",
+	title: "Example tag",
+	text: "Example tag",
+	subtitle: "Preview subtitle",
+	unit: "12A",
+	street: "Example Street",
+	city: "Sydney",
+	state: "NSW",
+	postcode: "2000",
+	country: "Australia",
+} as const;

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -81,7 +81,7 @@ test.describe("Row configuration", () => {
 						view: {
 							content: {
 								title: "Test Info Row",
-								text: "Initial text content",
+								subtitle: "Initial subtitle content",
 							},
 						},
 						actions: [],
@@ -98,13 +98,13 @@ test.describe("Row configuration", () => {
 		await expect(
 			configPanel.getByLabel("title", { exact: true }),
 		).toBeVisible();
-		await expect(configPanel.getByLabel("text")).toBeVisible();
+		await expect(configPanel.getByLabel("subtitle")).toBeVisible();
 
-		const textInput = configPanel.getByLabel("text");
-		await textInput.clear();
-		await textInput.fill("Updated info text");
+		const subtitleInput = configPanel.getByLabel("subtitle");
+		await subtitleInput.clear();
+		await subtitleInput.fill("Updated subtitle text");
 
-		await expect(textInput).toHaveValue("Updated info text");
+		await expect(subtitleInput).toHaveValue("Updated subtitle text");
 	});
 
 	test("should display and edit Source binding in configuration panel", async ({
@@ -121,7 +121,7 @@ test.describe("Row configuration", () => {
 						view: {
 							content: {
 								title: "Binding row",
-								text: "Body",
+								subtitle: "Body",
 							},
 						},
 						actions: [],
@@ -140,6 +140,41 @@ test.describe("Row configuration", () => {
 		await sourceInput.fill("{items}");
 
 		await expect(sourceInput).toHaveValue("{items}");
+	});
+
+	test("should display InputList format in configuration panel", async ({
+		page,
+	}) => {
+		await openAppWithTestFlows(page, [
+			{
+				id: "step_1",
+				title: "Test Page",
+				rows: [
+					{
+						type: "InputList",
+						view: {
+							content: {
+								title: "Tags",
+								placeholder: "Search for tags",
+								format: "{datum.value}",
+							},
+						},
+						actions: [],
+					},
+				],
+			},
+		]);
+		await page.getByText("Tags", { exact: true }).first().click();
+
+		const configPanel = getConfigPanel(page);
+		const formatInput = configPanel.getByLabel("format");
+		await expect(formatInput).toBeVisible();
+		await expect(formatInput).toHaveValue("{datum.value}");
+
+		await formatInput.clear();
+		await formatInput.fill("{datum.label}");
+
+		await expect(formatInput).toHaveValue("{datum.label}");
 	});
 
 	test("should display and edit action items via popup", async ({ page }) => {
@@ -328,7 +363,7 @@ test.describe("Row configuration", () => {
 						view: {
 							content: {
 								title: "No Action Row",
-								text: "Some text",
+								subtitle: "Some subtitle",
 							},
 						},
 						actions: [],

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -453,8 +453,6 @@ test.describe("Drag & Drop UX", () => {
 	}) => {
 		await setupTwoEmptyTestPages(page);
 
-		const rowsPanel = await getRowsPanel(page);
-		const firstPage = getFirstPage(page);
 		const pageContent = getPageContent(page);
 
 		const allRowTypes = [
@@ -482,14 +480,12 @@ test.describe("Drag & Drop UX", () => {
 			.count();
 
 		for (const rowText of allRowTypes) {
-			const sidebarRow = rowsPanel
-				.getByText(rowText, { exact: true })
-				.locator("..");
-			await expect(
-				sidebarRow.getByText(rowText, { exact: true }),
-			).toBeVisible();
+			const sidebarRow = await getSidebarRow(page, rowText);
+			await expect(sidebarRow).toBeVisible();
 			await sidebarRow.dragTo(pageContent);
-			await expect(firstPage.getByText(rowText, { exact: true })).toBeVisible();
+			const pageRow = getPageRow(page, rowText);
+			await pageRow.scrollIntoViewIfNeeded();
+			await expect(pageRow.getByText(rowText, { exact: true })).toBeVisible();
 		}
 
 		const finalRowCount = await pageContent
@@ -498,7 +494,9 @@ test.describe("Drag & Drop UX", () => {
 		expect(finalRowCount).toBe(initialRowCount + allRowTypes.length);
 
 		for (const rowText of allRowTypes) {
-			await expect(firstPage.getByText(rowText, { exact: true })).toBeVisible();
+			const pageRow = getPageRow(page, rowText);
+			await pageRow.scrollIntoViewIfNeeded();
+			await expect(pageRow.getByText(rowText, { exact: true })).toBeVisible();
 		}
 	});
 });

--- a/web/tests/dragAndDrop.spec.ts
+++ b/web/tests/dragAndDrop.spec.ts
@@ -92,7 +92,7 @@ test.describe("Drag & Drop UX", () => {
 									view: {
 										content: {
 											title: "Child Info",
-											text: "Child text",
+											subtitle: "Child subtitle",
 										},
 									},
 									actions: [],
@@ -142,7 +142,7 @@ test.describe("Drag & Drop UX", () => {
 										view: {
 											content: {
 												title: "Nested Info",
-												text: "Nested text",
+												subtitle: "Nested subtitle",
 											},
 										},
 										actions: [],

--- a/web/tests/flowSelector.spec.ts
+++ b/web/tests/flowSelector.spec.ts
@@ -26,7 +26,7 @@ test.describe("Flow Selector", () => {
 							view: {
 								content: {
 									title: "Flow 1 Info",
-									text: "This is from Flow 1",
+									subtitle: "This is from Flow 1",
 								},
 							},
 							actions: [],
@@ -49,7 +49,7 @@ test.describe("Flow Selector", () => {
 							view: {
 								content: {
 									title: "Flow 2 Info",
-									text: "This is from Flow 2",
+									subtitle: "This is from Flow 2",
 								},
 							},
 							actions: [],

--- a/web/tests/rowSelection.spec.ts
+++ b/web/tests/rowSelection.spec.ts
@@ -19,7 +19,7 @@ test.describe("Row Selection", () => {
 						view: {
 							content: {
 								title: "First Info Row",
-								text: "First row text content",
+								subtitle: "First row subtitle content",
 							},
 						},
 						actions: [],
@@ -57,7 +57,7 @@ test.describe("Row Selection", () => {
 						view: {
 							content: {
 								title: "First Info Row",
-								text: "First row text content",
+								subtitle: "First row subtitle content",
 							},
 						},
 						actions: [],
@@ -67,7 +67,7 @@ test.describe("Row Selection", () => {
 						view: {
 							content: {
 								title: "Second Info Row",
-								text: "Second row text content",
+								subtitle: "Second row subtitle content",
 							},
 						},
 						actions: [],
@@ -111,7 +111,7 @@ test.describe("Row Selection", () => {
 						view: {
 							content: {
 								title: "First Info Row",
-								text: "First row text content",
+								subtitle: "First row subtitle content",
 							},
 						},
 						actions: [],
@@ -190,7 +190,7 @@ test.describe("Row Selection", () => {
 						view: {
 							content: {
 								title: "First Info Row",
-								text: "First row text content",
+								subtitle: "First row subtitle content",
 							},
 						},
 						actions: [],
@@ -232,7 +232,7 @@ test.describe("Row Selection", () => {
 						view: {
 							content: {
 								title: "First Info Row",
-								text: "First row text content",
+								subtitle: "First row subtitle content",
 							},
 						},
 						actions: [],
@@ -248,18 +248,18 @@ test.describe("Row Selection", () => {
 			.first();
 		await firstInfoRow.click();
 
-		// Edit the text field
-		const textInput = configPanel.getByLabel("text");
-		await textInput.clear();
-		await textInput.fill("New text content");
+		// Edit the subtitle field
+		const subtitleInput = configPanel.getByLabel("subtitle");
+		await subtitleInput.clear();
+		await subtitleInput.fill("New subtitle content");
 
 		// Title should still show the same row's title
 		await expect(configPanel.getByLabel("title", { exact: true })).toHaveValue(
 			"First Info Row",
 		);
 
-		// The updated text should be visible
-		await expect(textInput).toHaveValue("New text content");
+		// The updated subtitle should be visible
+		await expect(subtitleInput).toHaveValue("New subtitle content");
 	});
 });
 

--- a/web/tests/rows.spec.ts
+++ b/web/tests/rows.spec.ts
@@ -15,7 +15,7 @@ test.describe("EVY Rows", () => {
 						view: {
 							content: {
 								title: "Test Info",
-								text: "Test text",
+								subtitle: "Test subtitle",
 							},
 						},
 						actions: [],

--- a/web/tests/secondarySheet.spec.ts
+++ b/web/tests/secondarySheet.spec.ts
@@ -24,7 +24,7 @@ test.describe("Secondary Sheet Page", () => {
 								view: {
 									content: {
 										title: "Child Info",
-										text: "Child text",
+										subtitle: "Child subtitle",
 									},
 								},
 								actions: [],

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -74,7 +74,9 @@ export async function getSidebarRow(
 	text: string,
 ): Promise<Locator> {
 	const rowsPanel = await getRowsPanel(page);
-	return rowsPanel.getByText(text, { exact: true }).locator("..");
+	const row = rowsPanel.getByText(text, { exact: true }).locator("..");
+	await row.scrollIntoViewIfNeeded();
+	return row;
 }
 
 export function getFirstPage(page: Page): Locator {
@@ -88,6 +90,7 @@ export function getPageContent(page: Page, pageIndex = 0): Locator {
 		.locator(SELECTORS.pageContent);
 }
 
+/** Canvas row in the phone, from the row title (two parents up to the card). */
 export function getPageRow(page: Page, text: string, pageIndex = 0): Locator {
 	return page
 		.locator(SELECTORS.phoneContainer)


### PR DESCRIPTION
## Summary

This change adds and wires **search** behavior end-to-end in SDUI (schema, docs, web preview/editor, iOS runtime) and extends the **info** view row on both platforms.

### Web
- **decodeFlow**: Expanded flow decoding and selection logic with new tests (`decodeFlow.test.ts`).
- **Search preview**: New `searchPreview.tsx` and `searchPreview.test.ts` for search row editing/preview; updates to `SearchRow.tsx`, `searchRowDefaults.ts`, and related row components.
- **Info row**: `InfoRow.tsx` updates for richer display; `TextRow` and related view rows adjusted as needed.
- **Configuration / state**: `ConfigurationPanel.tsx`, `pageReducer`, and test/spec updates (`configuration.spec.ts`, drag/row selection tests) to align with new behavior.

### iOS
- **Search**: `EVYSearchController.swift` and search UI (`EVYSearch*.swift`, `EVYDropdown`, inline picker/input list) updated for single/multi search and consistency with web semantics.
- **Rows**: Edit rows (search, dropdown, input, etc.) and **info** view row (`EVYInfoRow`) updated; sheet container and page/row plumbing (`EVYPage`, `EVYRow`, `forEachRow`, `interpreter`) adjusted.
- **App hook**: `EVY.swift` registration or wiring for new capabilities.

### Schema, codegen, and docs
- **JSON schema / SDUI docs**: `evy.schema.json`, `row-content.spec.json`, `docs/services/service_sdui.json`, `docs/evy/evy_sdui.json`, readme tweaks.
- **Scripts**: `generate-swift-sdui.ts` and `normalize-sdui-docs.ts` updates to keep generated Swift and docs in sync.

## JIRA

_(fill in if applicable)_

## Figma

_(fill in if applicable)_

## Stream / demo

_(fill in if applicable)_

Made with [Cursor](https://cursor.com)