### PR TITLE
[FEAT] nested row hierarchy in URL and monorepo updates

### DIFF
--- a/web/app/components/AppPage.tsx
+++ b/web/app/components/AppPage.tsx
@@ -27,8 +27,8 @@ export default function AppPage({ pageId }: { pageId: string }) {
 	const scrollableRef = useRef<HTMLDivElement | null>(null);
 
 	const selectRow = useCallback(
-		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", pageId, rowId }),
-		[pageId, dispatchRow],
+		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", rowId }),
+		[dispatchRow],
 	);
 
 	const selectPage = useCallback(

--- a/web/app/components/ContainerChildren.tsx
+++ b/web/app/components/ContainerChildren.tsx
@@ -1,4 +1,7 @@
+import { useCallback } from "react";
+
 import type { Row } from "../types/row";
+import { useFlowsContext } from "../state";
 import { DraggableRowContainer } from "./DraggableRowContainer";
 import { PlaceholderDropIndicator } from "./PlaceholderDropIndicator";
 
@@ -13,6 +16,15 @@ export function ContainerChildren({
 	showIndicators?: boolean;
 	showPlaceholder: boolean;
 }) {
+	const { dispatchRow } = useFlowsContext();
+
+	const selectNestedRow = useCallback(
+		(nestedRowId: string) => {
+			dispatchRow({ type: "SET_ACTIVE_ROW", rowId: nestedRowId });
+		},
+		[dispatchRow],
+	);
+
 	if (!rows?.length) {
 		return showPlaceholder ? (
 			<PlaceholderDropIndicator key="placeholder" />
@@ -27,6 +39,7 @@ export function ContainerChildren({
 				<DraggableRowContainer
 					key={child.id}
 					rowId={child.id}
+					selectRow={() => selectNestedRow(child.id)}
 					orientation={orientation}
 					showIndicators={showIndicators}
 					previousRowId={index > 0 ? rows[index - 1].id : undefined}

--- a/web/app/components/SecondarySheetPage.tsx
+++ b/web/app/components/SecondarySheetPage.tsx
@@ -27,8 +27,10 @@ export default function SecondarySheetPage({
 	const childRows = sheetRow?.config.view.content.children ?? [];
 
 	const selectRow = useCallback(
-		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", pageId, rowId }),
-		[pageId, dispatchRow],
+		(rowId: string) => {
+			dispatchRow({ type: "SET_ACTIVE_ROW", rowId });
+		},
+		[dispatchRow],
 	);
 
 	const extraData = useMemo(() => ({ sheetRowId }), [sheetRowId]);

--- a/web/app/hooks/useUrlSync.ts
+++ b/web/app/hooks/useUrlSync.ts
@@ -2,11 +2,20 @@ import { useEffect, useRef, type Dispatch } from "react";
 
 import type { RowAction } from "../types/actions";
 import type { UI_Flow } from "../types/flow";
-import { buildUrlPath, parseUrlPath, resolveUrlIds } from "../utils/urlUtils";
+import {
+	buildUrlPath,
+	parseUrlPath,
+	resolveCanonicalPageIdForUrl,
+	resolveUrlIds,
+	validateRowPathSegmentsForPage,
+} from "../utils/urlUtils";
+import { findFlowById } from "../utils/flowHelpers";
 
 export function useUrlSync(
 	activeFlowId: string | undefined,
 	activePageId: string | undefined,
+	activeRowId: string | undefined,
+	configStack: string[],
 	flows: UI_Flow[],
 	dispatchRow: Dispatch<RowAction>,
 ) {
@@ -14,9 +23,17 @@ export function useUrlSync(
 	const isPopStateNavigation = useRef(false);
 
 	useEffect(() => {
+		const canonicalPageId = resolveCanonicalPageIdForUrl(
+			flows,
+			activeFlowId,
+			activePageId,
+		);
+		const rowPathSegments =
+			activeRowId !== undefined ? [activeRowId, ...configStack] : [];
+
 		if (isInitialMount.current) {
 			isInitialMount.current = false;
-			const url = buildUrlPath(activeFlowId, activePageId);
+			const url = buildUrlPath(activeFlowId, canonicalPageId, rowPathSegments);
 			window.history.replaceState(null, "", url);
 			return;
 		}
@@ -26,21 +43,41 @@ export function useUrlSync(
 			return;
 		}
 
-		const url = buildUrlPath(activeFlowId, activePageId);
+		const url = buildUrlPath(activeFlowId, canonicalPageId, rowPathSegments);
 		if (window.location.pathname !== url) {
 			window.history.pushState(null, "", url);
 		}
-	}, [activeFlowId, activePageId]);
+	}, [activeFlowId, activePageId, activeRowId, configStack, flows]);
 
 	useEffect(() => {
 		const handlePopState = () => {
-			const { flowId: urlFlowId, pageId: urlPageId } = parseUrlPath();
+			const {
+				flowId: urlFlowId,
+				pageId: urlPageId,
+				rowPathSegments,
+			} = parseUrlPath();
 			const { flowId, pageId } = resolveUrlIds(urlFlowId, urlPageId, flows);
 			isPopStateNavigation.current = true;
 
 			if (flowId && flowId !== activeFlowId) {
 				dispatchRow({ type: "SET_ACTIVE_FLOW", flowId });
 			}
+
+			const targetFlow = findFlowById(flows, flowId ?? activeFlowId);
+			const page = targetFlow?.pages.find((p) => p.id === pageId);
+
+			if (page && rowPathSegments.length > 0) {
+				const validated = validateRowPathSegmentsForPage(page, rowPathSegments);
+				if (validated) {
+					dispatchRow({
+						type: "SET_ACTIVE_ROW",
+						rowId: validated.rootRowId,
+						configStack: validated.configStack,
+					});
+					return;
+				}
+			}
+
 			if (pageId) {
 				dispatchRow({ type: "SET_ACTIVE_PAGE", pageId });
 			}

--- a/web/app/state/AppProvider.tsx
+++ b/web/app/state/AppProvider.tsx
@@ -17,7 +17,12 @@ import { baseRows } from "../rows/baseRows";
 import { wsClient } from "../api/wsClient";
 import { useUrlSync } from "../hooks/useUrlSync";
 import { findFlowById } from "../utils/flowHelpers";
-import { parseUrlPath, resolveUrlIds } from "../utils/urlUtils";
+import {
+	deriveSheetAndFocusFromRowChain,
+	parseUrlPath,
+	resolveUrlIds,
+	validateRowPathSegmentsForPage,
+} from "../utils/urlUtils";
 
 export function AppProvider({
 	children,
@@ -35,19 +40,49 @@ export function AppProvider({
 	}));
 
 	const initialState = useMemo(() => {
-		const { flowId: urlFlowId, pageId: urlPageId } = parseUrlPath();
+		const {
+			flowId: urlFlowId,
+			pageId: urlPageId,
+			rowPathSegments,
+		} = parseUrlPath();
 		const { flowId: activeFlowId, pageId: activePageId } = resolveUrlIds(
 			urlFlowId,
 			urlPageId,
 			initialFlows,
 		);
 
+		const flows = decodeFlows(initialFlows);
+		const activeFlow = findFlowById(flows, activeFlowId);
+		const page = activeFlow?.pages.find((p) => p.id === activePageId);
+
+		let activeRowId: string | undefined;
+		let configStack: string[] = [];
+		let focusMode = false;
+		let secondarySheetRowId: string | undefined;
+
+		if (page && activeFlow && rowPathSegments.length > 0) {
+			const validated = validateRowPathSegmentsForPage(page, rowPathSegments);
+			if (validated) {
+				activeRowId = validated.rootRowId;
+				configStack = validated.configStack;
+				const sheet = deriveSheetAndFocusFromRowChain(
+					activeFlow.pages,
+					validated.rootRowId,
+					validated.configStack,
+				);
+				focusMode = sheet.focusMode;
+				secondarySheetRowId = sheet.secondarySheetRowId;
+			}
+		}
+
 		return {
-			flows: decodeFlows(initialFlows),
+			flows,
 			activeFlowId,
 			activePageId,
-			focusMode: false,
-			configStack: [],
+			activeRowId,
+			focusMode,
+			secondarySheetRowId,
+			configStack,
 		};
 	}, [initialFlows]);
 
@@ -83,6 +118,8 @@ export function AppProvider({
 	useUrlSync(
 		appState.activeFlowId,
 		appState.activePageId,
+		appState.activeRowId,
+		appState.configStack,
 		appState.flows,
 		dispatchRow,
 	);

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -213,11 +213,92 @@ describe("pageReducer", () => {
 		const state = initialState();
 		const next = pageReducer(state, {
 			type: "SET_ACTIVE_ROW",
-			pageId: "page-1",
 			rowId: "row-1",
 		});
 		expect(next.activeRowId).toBe("row-1");
 		expect(next.activePageId).toBe("page-1");
+	});
+
+	it("SET_ACTIVE_ROW derives root and config stack for nested row", () => {
+		const inner = textRow("inner");
+		const list: Row = {
+			id: "list-1",
+			row: null,
+			config: {
+				type: "ListContainer",
+				source: "",
+				actions: [],
+				view: {
+					content: {
+						title: "",
+						children: [inner],
+					},
+				},
+			} as Row["config"],
+		};
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [list],
+						},
+					],
+				},
+			],
+		});
+		const next = pageReducer(state, {
+			type: "SET_ACTIVE_ROW",
+			rowId: "inner",
+		});
+		expect(next.activeRowId).toBe("list-1");
+		expect(next.configStack).toEqual(["inner"]);
+		expect(next.activePageId).toBe("page-1");
+	});
+
+	it("SET_ACTIVE_ROW respects explicit configStack for URL restore", () => {
+		const inner = textRow("inner");
+		const list: Row = {
+			id: "list-1",
+			row: null,
+			config: {
+				type: "ListContainer",
+				source: "",
+				actions: [],
+				view: {
+					content: {
+						title: "",
+						children: [inner],
+					},
+				},
+			} as Row["config"],
+		};
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [list],
+						},
+					],
+				},
+			],
+		});
+		const next = pageReducer(state, {
+			type: "SET_ACTIVE_ROW",
+			rowId: "list-1",
+			configStack: ["inner"],
+		});
+		expect(next.activeRowId).toBe("list-1");
+		expect(next.configStack).toEqual(["inner"]);
 	});
 
 	it("SET_ACTIVE_PAGE clears row selection", () => {

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -8,10 +8,12 @@ import { buildRowForNewPageFromBase } from "../../utils/decodeFlow";
 import {
 	removeRowFromTree,
 	updateRowInTree,
-	getRowsRecursive,
 	findRowInPages,
+	findRowIdPathFromPageRoot,
+	findRowInSinglePage,
 	insertRowIntoTree,
 } from "../../utils/rowTree";
+import { deriveSheetAndFocusFromRowChain } from "../../utils/urlUtils";
 import {
 	buildNewClientFlow,
 	buildNewClientPage,
@@ -285,19 +287,35 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			});
 		}
 		case "SET_ACTIVE_ROW": {
-			const page = flow.pages.find(
-				(page) =>
-					page.rows.some((row) =>
-						getRowsRecursive(row).some((r) => r.id === action.rowId),
-					) || page.footer?.id === action.rowId,
-			);
+			const page = flow.pages.find((p) => findRowInSinglePage(p, action.rowId));
 			if (!page) return state;
 
-			return updateState({
-				activeRowId: action.rowId,
-				activePageId: action.pageId,
-				configStack: [],
-			});
+			let rootId: string;
+			let stack: string[];
+			if (action.configStack !== undefined) {
+				rootId = action.rowId;
+				stack = action.configStack;
+			} else {
+				const path = findRowIdPathFromPageRoot(page, action.rowId);
+				if (!path) return state;
+				rootId = path[0];
+				stack = path.slice(1);
+			}
+
+			const sheetState = deriveSheetAndFocusFromRowChain(
+				flow.pages,
+				rootId,
+				stack,
+			);
+
+			return {
+				...state,
+				activeRowId: rootId,
+				activePageId: page.id,
+				configStack: stack,
+				focusMode: sheetState.focusMode,
+				secondarySheetRowId: sheetState.secondarySheetRowId,
+			};
 		}
 		case "SET_ACTIVE_PAGE": {
 			const page = flow.pages.find((p) => p.id === action.pageId);
@@ -403,13 +421,20 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 		}
 		case "NAVIGATE_BREADCRUMB": {
 			const newStack = state.configStack.slice(0, action.configStackLength);
-			const truncated =
-				newStack.length < state.configStack.length && state.secondarySheetRowId;
+			const sheetState =
+				state.activeRowId !== undefined
+					? deriveSheetAndFocusFromRowChain(
+							flow.pages,
+							state.activeRowId,
+							newStack,
+						)
+					: { focusMode: false, secondarySheetRowId: undefined };
 
 			return {
 				...state,
 				configStack: newStack,
-				...(truncated ? { secondarySheetRowId: undefined } : {}),
+				focusMode: sheetState.focusMode,
+				secondarySheetRowId: sheetState.secondarySheetRowId,
 			};
 		}
 		default:

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -54,8 +54,9 @@ export type RowAction =
 	| { type: "REMOVE_PAGE"; pageId: string }
 	| {
 			type: "SET_ACTIVE_ROW";
-			pageId: string;
 			rowId: string;
+			/** When set (e.g. browser URL restore), uses this stack instead of deriving from the canvas path */
+			configStack?: string[];
 	  }
 	| {
 			type: "SET_ACTIVE_PAGE";

--- a/web/app/utils/rowTree.test.ts
+++ b/web/app/utils/rowTree.test.ts
@@ -5,6 +5,7 @@ import type { Row } from "../types/row";
 import {
 	findContainerById,
 	findContainerOfRow,
+	findRowIdPathFromPageRoot,
 	findRowInPages,
 	getRowsRecursive,
 	insertRowIntoTree,
@@ -100,6 +101,33 @@ describe("findRowInPages", () => {
 
 	it("returns undefined when missing", () => {
 		expect(findRowInPages("x", [page("p", [makeRow("a")])])).toBeUndefined();
+	});
+
+	it("finds row nested under footer", () => {
+		const inner = makeRow("foot-inner");
+		const foot = makeRow("foot", { child: inner });
+		const p: UI_Page = { id: "p", title: "T", rows: [], footer: foot };
+		expect(findRowInPages("foot-inner", [p])).toBe(inner);
+	});
+});
+
+describe("findRowIdPathFromPageRoot", () => {
+	it("returns path from top-level row to nested leaf", () => {
+		const leaf = makeRow("leaf");
+		const mid = makeRow("mid", { child: leaf });
+		const p = page("p1", [makeRow("root", { children: [mid] })]);
+		expect(findRowIdPathFromPageRoot(p, "leaf")).toEqual([
+			"root",
+			"mid",
+			"leaf",
+		]);
+	});
+
+	it("works when leaf is under footer", () => {
+		const inner = makeRow("f-in");
+		const foot = makeRow("foot", { child: inner });
+		const p: UI_Page = { id: "p", title: "T", rows: [], footer: foot };
+		expect(findRowIdPathFromPageRoot(p, "f-in")).toEqual(["foot", "f-in"]);
 	});
 });
 

--- a/web/app/utils/rowTree.ts
+++ b/web/app/utils/rowTree.ts
@@ -74,15 +74,66 @@ function findPageContainingRow(
 
 export function findRowInPages(
 	rowId: string,
-	pages: { rows: Row[] }[],
+	pages: { rows: Row[]; footer?: Row }[],
 ): Row | undefined {
 	for (const page of pages) {
-		for (const row of page.rows) {
-			const found = findRowInSubtree(row, rowId);
-			if (found) return found;
-		}
+		const found = findRowInSinglePage(page, rowId);
+		if (found) return found;
 	}
 	return undefined;
+}
+
+/** Resolves a row anywhere on a single page (main `rows` or `footer`). */
+export function findRowInSinglePage(
+	page: { rows: Row[]; footer?: Row },
+	rowId: string,
+): Row | undefined {
+	for (const row of page.rows) {
+		const found = findRowInSubtree(row, rowId);
+		if (found) return found;
+	}
+	if (page.footer) {
+		return findRowInSubtree(page.footer, rowId);
+	}
+	return undefined;
+}
+
+/**
+ * Path of row ids from a top-level page row (or footer root) down to `leafRowId`.
+ * Used to derive `activeRowId` + `configStack` when selecting a nested row on the canvas.
+ */
+export function findRowIdPathFromPageRoot(
+	page: UI_Page,
+	leafRowId: string,
+): string[] | null {
+	for (const top of page.rows) {
+		const path = findRowIdPathFromAncestorRow(top, leafRowId);
+		if (path) return path;
+	}
+	if (page.footer) {
+		return findRowIdPathFromAncestorRow(page.footer, leafRowId);
+	}
+	return null;
+}
+
+function findRowIdPathFromAncestorRow(
+	root: Row,
+	leafRowId: string,
+): string[] | null {
+	if (root.id === leafRowId) return [root.id];
+
+	const child = root.config.view.content.child;
+	if (child) {
+		const sub = findRowIdPathFromAncestorRow(child, leafRowId);
+		if (sub) return [root.id, ...sub];
+	}
+
+	for (const nested of root.config.view.content.children ?? []) {
+		const sub = findRowIdPathFromAncestorRow(nested, leafRowId);
+		if (sub) return [root.id, ...sub];
+	}
+
+	return null;
 }
 
 function findRowInSubtree(row: Row, rowId: string): Row | undefined {

--- a/web/app/utils/urlUtils.test.ts
+++ b/web/app/utils/urlUtils.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "bun:test";
+
+import type { UI_Page } from "../types/flow";
+import type { Row } from "../types/row";
+import {
+	buildUrlPath,
+	deriveSheetAndFocusFromRowChain,
+	isNonRoutablePreviewRowId,
+	resolveCanonicalPageIdForUrl,
+	validateRowPathSegmentsForPage,
+} from "./urlUtils";
+
+function textRow(id: string): Row {
+	return {
+		id,
+		row: null,
+		config: {
+			type: "Text",
+			source: "",
+			actions: [],
+			view: {
+				content: { title: "", text: "" },
+				max_lines: "",
+			},
+		} as Row["config"],
+	};
+}
+
+describe("isNonRoutablePreviewRowId", () => {
+	it("rejects search preview synthetic ids", () => {
+		expect(isNonRoutablePreviewRowId("s:search-preview:0")).toBe(true);
+		expect(isNonRoutablePreviewRowId("search-row:search-preview-default")).toBe(
+			true,
+		);
+		expect(isNonRoutablePreviewRowId("row-1")).toBe(false);
+	});
+});
+
+describe("validateRowPathSegmentsForPage", () => {
+	it("accepts a valid parent-child chain and truncates invalid tail", () => {
+		const child = textRow("child-1");
+		const list: Row = {
+			id: "list-1",
+			row: null,
+			config: {
+				type: "ListContainer",
+				source: "",
+				actions: [],
+				view: {
+					content: {
+						title: "",
+						children: [child],
+					},
+				},
+			} as Row["config"],
+		};
+		const page: UI_Page = {
+			id: "p1",
+			title: "P",
+			rows: [list],
+		};
+		expect(validateRowPathSegmentsForPage(page, ["list-1", "child-1"])).toEqual(
+			{
+				rootRowId: "list-1",
+				configStack: ["child-1"],
+			},
+		);
+		expect(
+			validateRowPathSegmentsForPage(page, ["list-1", "child-1", "nope"]),
+		).toEqual({
+			rootRowId: "list-1",
+			configStack: ["child-1"],
+		});
+	});
+
+	it("returns null when only preview ids are present", () => {
+		const page: UI_Page = {
+			id: "p1",
+			title: "P",
+			rows: [textRow("row-1")],
+		};
+		expect(
+			validateRowPathSegmentsForPage(page, ["x:search-preview:0"]),
+		).toBeNull();
+	});
+
+	it("filters preview segments and validates the remainder", () => {
+		const page: UI_Page = {
+			id: "p1",
+			title: "P",
+			rows: [textRow("row-1")],
+		};
+		expect(
+			validateRowPathSegmentsForPage(page, ["row-1", "x:search-preview:0"]),
+		).toEqual({
+			rootRowId: "row-1",
+			configStack: [],
+		});
+	});
+});
+
+describe("buildUrlPath", () => {
+	it("appends row segments after flow and page", () => {
+		expect(buildUrlPath("f", "p", ["a", "b"])).toBe("/f/p/a/b");
+	});
+
+	it("omits preview row ids from the path", () => {
+		expect(buildUrlPath("f", "p", ["ok", "bad:search-preview:0"])).toBe(
+			"/f/p/ok",
+		);
+	});
+});
+
+describe("deriveSheetAndFocusFromRowChain", () => {
+	it("sets focus when chain crosses SheetContainer child boundary", () => {
+		const inner = textRow("inner");
+		const sheet: Row = {
+			id: "sheet-1",
+			row: null,
+			config: {
+				type: "SheetContainer",
+				source: "",
+				actions: [],
+				view: {
+					content: {
+						title: "S",
+						child: inner,
+						children: [],
+					},
+				},
+			} as Row["config"],
+		};
+		const pages: UI_Page[] = [{ id: "p1", title: "P", rows: [sheet] }];
+		expect(
+			deriveSheetAndFocusFromRowChain(pages, "sheet-1", ["inner"]),
+		).toEqual({
+			focusMode: true,
+			secondarySheetRowId: "sheet-1",
+		});
+	});
+});
+
+describe("resolveCanonicalPageIdForUrl", () => {
+	it("maps secondary pseudo page id to the host canvas page", () => {
+		const sheet: Row = {
+			id: "sheet-host",
+			row: null,
+			config: {
+				type: "SheetContainer",
+				source: "",
+				actions: [],
+				view: {
+					content: { title: "", child: undefined, children: [] },
+				},
+			} as Row["config"],
+		};
+		const flows = [
+			{
+				id: "flow-1",
+				name: "F",
+				pages: [{ id: "real-page", title: "P", rows: [sheet] }],
+			},
+		];
+		expect(
+			resolveCanonicalPageIdForUrl(flows, "flow-1", "secondary:sheet-host"),
+		).toBe("real-page");
+	});
+});

--- a/web/app/utils/urlUtils.ts
+++ b/web/app/utils/urlUtils.ts
@@ -1,17 +1,145 @@
+import type { UI_Page } from "../types/flow";
+import type { Row } from "../types/row";
 import { findFlowById } from "./flowHelpers";
+import { findRowInSinglePage, getRowsRecursive } from "./rowTree";
 
-export function parseUrlPath(): { flowId?: string; pageId?: string } {
+export function parseUrlPath(): {
+	flowId?: string;
+	pageId?: string;
+	rowPathSegments: string[];
+} {
 	const parts = window.location.pathname.split("/").filter(Boolean);
 	return {
 		flowId: parts[0] || undefined,
 		pageId: parts[1] || undefined,
+		rowPathSegments: parts.slice(2).map((segment) => {
+			try {
+				return decodeURIComponent(segment);
+			} catch {
+				return segment;
+			}
+		}),
 	};
 }
 
-export function buildUrlPath(flowId?: string, pageId?: string): string {
+/** Synthetic search preview row ids must never appear in real URLs. */
+export function isNonRoutablePreviewRowId(rowId: string): boolean {
+	return (
+		rowId.includes(":search-preview:") ||
+		rowId.endsWith(":search-preview-default")
+	);
+}
+
+function isDirectChildRow(parent: Row, childId: string): boolean {
+	const child = parent.config.view.content.child;
+	if (child?.id === childId) return true;
+	return (
+		parent.config.view.content.children?.some((c) => c.id === childId) ?? false
+	);
+}
+
+/**
+ * Validates a `/flow/page/root/.../leaf` chain against the page tree.
+ * Truncates at the first invalid segment (stale id or broken parent/child link).
+ */
+export function validateRowPathSegmentsForPage(
+	page: UI_Page,
+	rawSegments: string[],
+): { rootRowId: string; configStack: string[] } | null {
+	const segments = rawSegments.filter(
+		(id) => id.length > 0 && !isNonRoutablePreviewRowId(id),
+	);
+	if (segments.length === 0) return null;
+
+	const firstId = segments[0];
+	if (!findRowInSinglePage(page, firstId)) return null;
+
+	const validated: string[] = [firstId];
+	for (let i = 1; i < segments.length; i++) {
+		const parentId = validated[validated.length - 1];
+		const parentRow = findRowInSinglePage(page, parentId);
+		const nextId = segments[i];
+		if (!parentRow || !isDirectChildRow(parentRow, nextId)) break;
+		if (!findRowInSinglePage(page, nextId)) break;
+		validated.push(nextId);
+	}
+
+	const rootRowId = validated[0];
+	const configStack = validated.slice(1);
+	return { rootRowId, configStack };
+}
+
+/**
+ * Matches `PUSH_CONFIG_STACK` sheet focus rules for a full root + stack chain.
+ */
+export function deriveSheetAndFocusFromRowChain(
+	pages: UI_Page[],
+	activeRowId: string,
+	configStack: string[],
+): { focusMode: boolean; secondarySheetRowId?: string } {
+	const chain = [activeRowId, ...configStack];
+	let focusMode = false;
+	let secondarySheetRowId: string | undefined;
+
+	for (let i = 0; i < chain.length - 1; i++) {
+		const parentRowId = chain[i];
+		const childId = chain[i + 1];
+		let parentRow: Row | undefined;
+		for (const p of pages) {
+			parentRow = findRowInSinglePage(p, parentRowId);
+			if (parentRow) break;
+		}
+		if (!parentRow) break;
+
+		const isSheetNested =
+			parentRow.config.type === "SheetContainer" &&
+			(parentRow.config.view.content.child?.id === childId ||
+				parentRow.config.view.content.children?.some((c) => c.id === childId));
+
+		if (isSheetNested) {
+			focusMode = true;
+			secondarySheetRowId = parentRow.id;
+		}
+	}
+
+	return { focusMode, secondarySheetRowId };
+}
+
+/** Real canvas page id for URL (never `secondary:*`). */
+export function resolveCanonicalPageIdForUrl(
+	flows: { id: string; pages: UI_Page[] }[],
+	activeFlowId: string | undefined,
+	activePageId: string | undefined,
+): string | undefined {
+	if (!activeFlowId || !activePageId) return activePageId;
+	if (!activePageId.startsWith("secondary:")) return activePageId;
+
+	const hostRowId = activePageId.slice("secondary:".length);
+	const flow = findFlowById(flows, activeFlowId);
+	if (!flow) return undefined;
+
+	const page = flow.pages.find((p) =>
+		p.rows.some((r) => getRowsRecursive(r).some((row) => row.id === hostRowId)),
+	);
+	return page?.id;
+}
+
+export function buildUrlPath(
+	flowId?: string,
+	pageId?: string,
+	rowPathSegments?: string[],
+): string {
+	const rowParts =
+		rowPathSegments?.filter(
+			(id) => id.length > 0 && !isNonRoutablePreviewRowId(id),
+		) ?? [];
+
 	if (!flowId) return "/";
 	if (!pageId) return `/${flowId}`;
-	return `/${flowId}/${pageId}`;
+	const base = `/${flowId}/${pageId}`;
+	if (rowParts.length === 0) return base;
+	const encoded = rowParts.map((segment) => encodeURIComponent(segment));
+	return `${base}/${encoded.join("/")}`;
 }
 
 export function resolveUrlIds(


### PR DESCRIPTION
## Summary

This branch updates the EVY monorepo with a large set of changes spanning the web SDUI builder, API, iOS client, marketplace service, shared types, and CI/e2e infrastructure.

### Web (SDUI builder)

- **Nested row URLs**: Path shape `/flowId/pageId` extends with additional segments for the selected row and config stack (`activeRowId` + `configStack`). Initial load and browser back/forward restore selection, focus mode, and sheet state where applicable.
- **URL utilities**: Parsing, validation against the page row tree (including footer rows), preview-only id filtering for search result previews, canonical page id for `secondary:*` sheet surfaces, and sheet/focus derivation aligned with reducer behavior.
- **Selection**: `ContainerChildren` dispatches `SET_ACTIVE_ROW` for nested canvas clicks; `SET_ACTIVE_ROW` no longer carries a redundant `pageId` (page is resolved from the row id in the reducer).
- **Row tree**: Helpers such as `findRowInSinglePage`, `findRowIdPathFromPageRoot`, and footer-aware `findRowInPages`.
- **Tests**: `urlUtils`, `rowTree`, `pageReducer`, and search preview coverage.

### API, iOS, marketplace, types

- API: data layer, WebSocket, validation, notifications, e2e helpers, and related tests.
- iOS: interpreter/functions refactor, draft model, row and view updates, and new tests.
- **Marketplace** service: new package with gRPC, Drizzle, catalog, and tests.
- **Types / scripts**: Schema and codegen updates (`generate-swift-sdui`, `generate-drizzle`, validators, RPC protos).

### CI and tooling

- Workflow and Docker updates (including CI image push), e2e script and compose changes, and documentation updates.

## Testing

- Web: `bun run lint`, `bun run test`, `bun run build` (from `web/`).
- Full repo: follow `README.md` / `AGENTS.md` for api, e2e, and iOS as needed.

## JIRA

<!-- Fill in if applicable -->

## Figma

<!-- Fill in if applicable -->

## Stream video

<!-- Fill in if applicable -->
