### PR TITLE
[FEAT] Treat close as SDUI action function

### DIFF
--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -343,7 +343,11 @@ describe("get", () => {
 			description: serviceData.description,
 			createdAt: serviceData.createdAt,
 		});
-		expect(typeof (result[0] as DATA_EVY_Service).updatedAt).toBe("string");
+		const serviceRow = result[0];
+		if (!("updatedAt" in serviceRow)) {
+			throw new Error("Expected service row with updatedAt");
+		}
+		expect(typeof serviceRow.updatedAt).toBe("string");
 	});
 
 	it("should return empty array for non-SDUI resource when no data", async () => {
@@ -434,7 +438,7 @@ describe("upsert", () => {
 									label: "Click me",
 								},
 							},
-							actions: [{ condition: "", false: "", true: "close" }],
+							actions: [{ condition: "", false: "", true: "{close()}" }],
 						},
 					],
 				},

--- a/docs/evy/sdui/readme.md
+++ b/docs/evy/sdui/readme.md
@@ -18,7 +18,7 @@ So a flow might reference “10 min, 20 min, 30 min” options via `source: "{du
 
 ## Flow
 
-Flows are not visually used in the UI but represent a full user journey (eg: creating an item)  
+Flows are not visually used in the UI but represent a full user journey (eg: creating an item)
 They are needed in order to submit all fields of all pages of a flow at the end upon clicking a single button on a page
 
 The canonical shape matches `types/schema/sdui/evy.schema.json`:
@@ -100,10 +100,10 @@ Each row has an `actions` array of `UI_RowAction` objects (`condition`, `false`,
 
 - Wrap the whole condition in curly braces: `{ ... }`.
 - Empty `condition` — treated as always true (the `true` branch is taken unless you rely on client-specific rules).
-- Single comparison: `{left op right}`  
-	Operators: `==`, `!=`, `>`, `<`, `>=`, `<=`  
+- Single comparison: `{left op right}`
+	Operators: `==`, `!=`, `>`, `<`, `>=`, `<=`
 	Left and right operands are usually variable names or literals (client interprets values).
-- OR: join comparisons with `||` inside the braces:  
+- OR: join comparisons with `||` inside the braces:
 	`{count(pickup_timeslots) > 0 || count(delivery_timeslots) > 0 || count(shipping_destination_areas) > 0}`
 - Condition helpers (used like functions in the expression):
 	- `count(var)` — e.g. `{count(photo_ids) > 0}`
@@ -111,16 +111,13 @@ Each row has an `actions` array of `UI_RowAction` objects (`condition`, `false`,
 
 #### Branches (`true` / `false`)
 
-Each branch is a string. Empty string means “do nothing” for that branch.
-
-- Literal `close` — no braces — closes the current screen/flow step.
-- Function call form: `{functionName(arg1, arg2, ...)}`
+Each branch is a string. Empty string means “do nothing” for that branch. Function call form: `{functionName(arg1, arg2, ...)}`
 
 Supported action functions:
 
 | Function | Meaning |
 | -------- | ------- |
-| `close` | Close current UI (same as bare `close` in simple cases) |
+| `close()` | Close current UI, e.g. `{close()}` |
 | `create(model)` | Submit / create domain entity, e.g. `{create(item)}` |
 | `navigate(flowId, pageId)` | Go to a page within a flow (UUIDs as in `docs/services/service_sdui.json`). iOS also accepts a colon-separated form (e.g. `navigate:flowId:pageId`)—see `EVYActionRunner` tests. |
 | `highlight_required(field)` | Mark a field as required / show validation, e.g. `{highlight_required(title)}` |

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -31,7 +31,7 @@
 						{
 							"condition": "",
 							"false": "",
-							"true": "close"
+							"true": "{close()}"
 						}
 					],
 					"view": {
@@ -342,11 +342,7 @@
 						"view": {
 							"content": {
 								"title": "",
-								"segments": [
-									"Pickup",
-									"Delivery",
-									"Shipping"
-								],
+								"segments": ["Pickup", "Delivery", "Shipping"],
 								"children": [
 									{
 										"id": "22222222-2222-4222-8222-222222222201",

--- a/ios/evy/UI/EVYActionRunner.swift
+++ b/ios/evy/UI/EVYActionRunner.swift
@@ -11,17 +11,17 @@ enum EVYActionRunner {
                     navigate: @escaping (NavOperation) -> Void)
     {
         guard !actions.isEmpty else { return }
-        
+
         for action in actions {
             let condition = action.condition.trimmingCharacters(in: .whitespacesAndNewlines)
             let executeTrueBranch: Bool
-            
+
             if condition.isEmpty {
                 executeTrueBranch = true
             } else {
                 executeTrueBranch = (try? EVY.evaluateFromText(condition)) ?? false
             }
-            
+
             if !executeTrueBranch {
                 let falseBranch = action.`false`.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !falseBranch.isEmpty {
@@ -33,10 +33,10 @@ enum EVYActionRunner {
                 }
                 return
             }
-            
+
             let trueBranch = action.`true`.trimmingCharacters(in: .whitespacesAndNewlines)
             if trueBranch.isEmpty { continue }
-            
+
             do {
                 try execute(branch: trueBranch, navigate: navigate)
             } catch {
@@ -44,7 +44,7 @@ enum EVYActionRunner {
             }
         }
     }
-    
+
     private static func execute(branch: String,
                                 navigate: @escaping (NavOperation) -> Void) throws
     {
@@ -54,6 +54,8 @@ enum EVYActionRunner {
             navigate(operation)
             return
         }
+
+        guard branch.hasPrefix("{"), branch.hasSuffix("}") else { return }
 
         if let (functionName, functionArgs) = parseFunctionCall(unwrappedBranch) {
             switch functionName {
@@ -83,7 +85,7 @@ enum EVYActionRunner {
                 throw EVYError.invalidData(context: "Unsupported action function: \(functionName)")
             }
         } else {
-            throw EVYError.invalidData(context: "Unknown action branch: \(branch)")
+            return
         }
     }
 
@@ -97,13 +99,12 @@ enum EVYActionRunner {
         case "create":
             guard parts.count == 2 else { return nil }
             return .create(String(parts[1]))
-        case "close":
-            return .close
+
         default:
             return nil
         }
     }
-    
+
     private static func unwrapActionBranch(_ branch: String) -> String {
         guard branch.hasPrefix("{"), branch.hasSuffix("}") else { return branch }
         return String(branch.dropFirst().dropLast())

--- a/ios/evyTests/EVYActionRunnerTests.swift
+++ b/ios/evyTests/EVYActionRunnerTests.swift
@@ -10,9 +10,23 @@ import XCTest
 final class EVYActionRunnerTests: XCTestCase {
     func testCloseAction() {
         var received: NavOperation?
-        let action = UI_RowAction(condition: "", false: "", true: "{close}")
+        let action = UI_RowAction(condition: "", false: "", true: "{close()}")
         EVYActionRunner.run(actions: [action]) { received = $0 }
         XCTAssertEqual(received, .close)
+    }
+
+    func testBareCloseActionIsInert() {
+        var received: NavOperation?
+        let action = UI_RowAction(condition: "", false: "", true: "close")
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        XCTAssertNil(received)
+    }
+
+    func testUnwrappedCloseFunctionIsInert() {
+        var received: NavOperation?
+        let action = UI_RowAction(condition: "", false: "", true: "close()")
+        EVYActionRunner.run(actions: [action]) { received = $0 }
+        XCTAssertNil(received)
     }
 
     func testCreateAction() {

--- a/web/README.md
+++ b/web/README.md
@@ -152,6 +152,8 @@ graph TD
 | usePageDropTarget  | Hook setting up page-level drop targets for drag-and-drop           |
 | defineRow          | Factory function used to declare all row components                 |
 
+Action branches are stored as strings. The builder emits executable actions in function-call form; use `{close()}` for close, while a bare `close` string is treated as non-executable text by runtimes.
+
 ## Getting Started
 
 Setup (Bun, Docker, copying `.env`): [README § Setup](../README.md#setup) and [§ Running Services](../README.md#running-services). The web app only needs a reachable API over `API_URL` (no direct Postgres).

--- a/web/app/rows/action/ButtonRow.tsx
+++ b/web/app/rows/action/ButtonRow.tsx
@@ -13,12 +13,12 @@ export default defineRow("ButtonRow", {
 				label: "Button row text",
 			},
 		},
-		actions: [{ condition: "", false: "", true: "close" }],
+		actions: [{ condition: "", false: "", true: "{close()}" }],
 	} satisfies RowConfig,
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
 			<div className="evy-p-2 evy-flex evy-justify-center">
-				<Button label={row.config.view.content.label} />
+				<Button label={row.config.view.content.label ?? ""} />
 			</div>
 		</RowLayout>
 	),

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -393,7 +393,7 @@ describe("pageReducer", () => {
 
 	it("UPDATE_ROW_ACTIONS sets actions", () => {
 		const state = initialState();
-		const actions = [{ condition: "", true: "close", false: "" }];
+		const actions = [{ condition: "", true: "{close()}", false: "" }];
 		const next = pageReducer(state, {
 			type: "UPDATE_ROW_ACTIONS",
 			rowId: "row-1",

--- a/web/app/utils/actionBranch.ts
+++ b/web/app/utils/actionBranch.ts
@@ -30,16 +30,8 @@ export function parseBranch(branchString: string): ParsedBranch | null {
 	const trimmed = branchString.trim();
 	if (!trimmed) return null;
 
-	if (trimmed === "close") {
-		return { functionName: "close", args: [] };
-	}
-
 	if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
 		const inner = unwrapOptionalBraces(trimmed);
-
-		if (inner === "close") {
-			return { functionName: "close", args: [] };
-		}
 
 		const parenIndex = inner.indexOf("(");
 		if (parenIndex !== -1 && inner.endsWith(")")) {
@@ -55,7 +47,7 @@ export function parseBranch(branchString: string): ParsedBranch | null {
 
 	const colonParts = trimmed.split(":");
 	const functionName = colonParts[0];
-	if (isActionFunction(functionName)) {
+	if (functionName !== "close" && isActionFunction(functionName)) {
 		return { functionName, args: colonParts.slice(1) };
 	}
 
@@ -70,7 +62,7 @@ export function serializeBranch(
 
 	const filteredArgs = args.filter(Boolean);
 
-	if (functionName === "close") return "close";
+	if (functionName === "close") return "{close()}";
 
 	if (filteredArgs.length === 0) return `{${functionName}()}`;
 	return `{${functionName}(${filteredArgs.join(",")})}`;

--- a/web/app/utils/decodeFlow.test.ts
+++ b/web/app/utils/decodeFlow.test.ts
@@ -27,7 +27,7 @@ describe("normalizeServerRow", () => {
 					label: "OK",
 				},
 			},
-			actions: [{ condition: "", false: "", true: "close" }],
+			actions: [{ condition: "", false: "", true: "{close()}" }],
 		} as unknown as ServerRow;
 
 		const n = normalizeServerRow(partial);

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -191,7 +191,7 @@ test.describe("Row configuration", () => {
 								label: "Test Button",
 							},
 						},
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -240,7 +240,7 @@ test.describe("Row configuration", () => {
 								label: "Nav Button",
 							},
 						},
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -299,7 +299,7 @@ test.describe("Row configuration", () => {
 								label: "Submit",
 							},
 						},
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -532,7 +532,7 @@ test.describe("Row configuration", () => {
 					{
 						type: "Button",
 						view: { content: { title: "", label: "Check" } },
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -587,7 +587,7 @@ test.describe("Row configuration", () => {
 					{
 						type: "Button",
 						view: { content: { title: "", label: "Validate" } },
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -654,7 +654,7 @@ test.describe("Row configuration", () => {
 					{
 						type: "Button",
 						view: { content: { title: "", label: "Send" } },
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -702,7 +702,7 @@ test.describe("Row configuration", () => {
 					{
 						type: "Button",
 						view: { content: { title: "", label: "Cancel Test" } },
-						actions: [{ condition: "", false: "", true: "close" }],
+						actions: [{ condition: "", false: "", true: "{close()}" }],
 					},
 				],
 			},
@@ -744,7 +744,7 @@ test.describe("Row configuration", () => {
 							content: { title: "", label: "Multi Action" },
 						},
 						actions: [
-							{ condition: "", false: "", true: "close" },
+							{ condition: "", false: "", true: "{close()}" },
 							{ condition: "", false: "", true: "{create()}" },
 						],
 					},
@@ -801,7 +801,7 @@ test.describe("Row configuration", () => {
 									{
 										condition: "{name == true}",
 										true: "{navigate(flow_x,page_x)}",
-										false: "close",
+										false: "{close()}",
 									},
 								],
 							},
@@ -870,7 +870,7 @@ test.describe("Row configuration", () => {
 								condition:
 									"{count(pickup_timeslots) > 0 || count(delivery_timeslots) > 0}",
 								false: "",
-								true: "close",
+								true: "{close()}",
 							},
 						],
 					},
@@ -907,7 +907,7 @@ test.describe("Row configuration", () => {
 								condition:
 									"{count(pickup_timeslots) > 0 && (count(delivery_timeslots) > 0 || count(shipping_destination_areas) > 0)}",
 								false: "",
-								true: "close",
+								true: "{close()}",
 							},
 						],
 					},
@@ -967,7 +967,7 @@ test.describe("Row configuration", () => {
 							{
 								condition: "{name == true || email == true}",
 								false: "",
-								true: "close",
+								true: "{close()}",
 							},
 						],
 					},
@@ -1042,7 +1042,7 @@ test.describe("Row configuration", () => {
 							{
 								condition: "{name == true || email == true}",
 								false: "",
-								true: "close",
+								true: "{close()}",
 							},
 						],
 					},


### PR DESCRIPTION
## Summary
- serialize web close actions as `{close()}` and treat bare `close` as non-executable text
- update iOS action execution so only braced function-call close actions run
- update SDUI docs, examples, and tests to use `{close()}`

## Tests
- `bun run build && bun run lint && bun run test` in `api`
- `bun run build && bun run lint && bun run test:unit` in `web`
- `bun run test:integration` in `web`
- `./run-e2e.sh --skip-ios`

Note: iOS Xcode build was not run from this environment.