### PR TITLE
[FEAT] Load the right data from API and parse datum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Always use `bun` to run commands or install dependencies.
 ## Development
 
 For web or api, make sure you run `bun run build`, `bun run lint` and `bun run test` anytime you make major changes and fix issues that arise.
-For iOS, make sure you build with Xcode targeting iPhone Air iOS 26.2 and fix any errors.
+For iOS, make sure you build with Xcode targeting iPhone 17 iOS 26.4.1 and fix any errors.
 Ensure you run `./run-e2e.sh --skip-ios` from root to run the e2e tests (see README.md for `--no-docker` option).
 If you need to run iOS tests, keep services running and just run the iOS tests separately rather than re-running the whole e2e suite.
 NEVER skip tests of any kind

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ flowchart LR
     marketplace -- Drizzle --> pg
 ```
 
-Resource routing, `flowUpdated` / `dataUpdated`, and gRPC forwarding are covered in [`api/README.md`](./api/README.md).
+Resource routing, `flowUpdated` / `dataUpdated`, service data sync, and gRPC forwarding are covered in [`api/README.md`](./api/README.md).
+
+## Service data sync and local keying
+
+Clients can refresh backend service data with the protected `syncServiceData` JSON-RPC method. The request includes a syncable service name and an ISO `lastSyncTime`; the response returns changed resource rows shaped as `{ service, resource, value }`.
+
+Clients should store synced backend resources with service-qualified keys such as `marketplace:items` and `marketplace:conditions`. SDUI source bindings may still use short resource names like `{items}` or `{conditions}`; client data lookup resolves exact local keys first, then falls back to synced service resources. This keeps drafts and local flow state separate from backend catalog data while preserving concise flow bindings.
 
 # Documentation
 

--- a/api/README.md
+++ b/api/README.md
@@ -17,7 +17,8 @@ The API is the only public edge for iOS and the web builder. Requests are valida
 `get` is public, `upsert` is protected (requires a valid device token via `validateAuth`). Params include `service`, `resource`, optional `filter.id`, and for `upsert` a `data` object (see JSON Schemas under `types/schema/rpc/`).
 
 - `service: "evy"` &mdash; handled entirely in [`src/data.ts`](./src/data.ts). Supported resources include `sdui` (flows / `flow` table), `devices` (via auth only for writes), `organisations`, `services`, and `providers` (typed catalog tables). There is no generic `evy` “data” table routed through `services.ts`.
-- `service` ≠ `"evy"` (e.g. `marketplace`) &mdash; [`src/rpc.ts`](./src/rpc.ts) calls `forwardUnary` in [`src/services.ts`](./src/services.ts), which issues `Get` / `Upsert` on `evy.Service` and validates JSON responses.
+- `service` ≠ `"evy"` (e.g. `marketplace`) &mdash; [`src/rpc.ts`](./src/rpc.ts) calls `forwardGet` / `forwardUpsert` in [`src/services.ts`](./src/services.ts), which issue `Get` / `Upsert` on `evy.Service` and validate JSON responses.
+- `syncServiceData` is a protected RPC for client-side service cache refresh. Params are `{ service, lastSyncTime }`, where `service` is a syncable non-`evy` service and `lastSyncTime` is an ISO date-time. The API forwards one `get` per service resource with `filter.updatedAfter = lastSyncTime`, omits empty result arrays, and returns `{ data: [{ service, resource, value }] }`. Clients should persist synced rows with service-qualified keys like `marketplace:items`; SDUI bindings such as `{items}` may resolve through client fallback, while `{$api:...}`, `{$local:...}`, and `{$datum:...}` are client-side binding namespaces rather than backend flow state.
 
 ```mermaid
 sequenceDiagram

--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -1,7 +1,6 @@
-import { eq, desc } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 
 import {
-	type DATA_EVY_Rows,
 	type DATA_EVY_Service,
 	type GetResponse,
 	RESOURCES_BY_SERVICE,
@@ -9,6 +8,7 @@ import {
 	type GetRequest,
 	type OS,
 	type UpsertRequest,
+	type UpsertResponse,
 } from "evy-types";
 import {
 	device,
@@ -82,7 +82,7 @@ export async function getCoreForValidatedRequest(
  */
 export async function upsertCoreForValidatedRequest(
 	params: UpsertRequest,
-): Promise<DATA_EVY_Rows> {
+): Promise<UpsertResponse> {
 	assertEvyCoreAccess(params);
 	return upsertCoreBody(params);
 }
@@ -112,12 +112,21 @@ type CatalogTable =
 
 async function listCoreCatalogRows<TRow>(
 	table: CatalogTable,
-	filterId: string | undefined,
+	filter: GetRequest["filter"] | undefined,
 	mapRow: (r: TRow) => unknown,
 ): Promise<GetResponse> {
 	const base = db.select().from(table);
-	const rows = filterId
-		? await base.where(eq(table.id, filterId)).orderBy(desc(table.updatedAt))
+	const whereClauses = [];
+
+	if (filter?.id) {
+		whereClauses.push(eq(table.id, filter.id));
+	}
+	if (filter?.updatedAfter) {
+		whereClauses.push(gt(table.updatedAt, filter.updatedAfter));
+	}
+
+	const rows = whereClauses.length
+		? await base.where(and(...whereClauses)).orderBy(desc(table.updatedAt))
 		: await base.orderBy(desc(table.updatedAt));
 	const mapped = rows.map((r) => mapRow(r as TRow));
 	return validateGetResponse(mapped);
@@ -131,8 +140,8 @@ async function upsertCatalogEntity<TSelect>(
 	filterId: string | undefined,
 	doUpdate: () => Promise<TSelect[]>,
 	doInsert: () => Promise<TSelect[]>,
-	mapRow: (row: TSelect) => DATA_EVY_Rows,
-): Promise<DATA_EVY_Rows> {
+	mapRow: (row: TSelect) => UpsertResponse,
+): Promise<UpsertResponse> {
 	if (filterId) {
 		const updated = await doUpdate();
 		if (updated.length > 0) {
@@ -185,23 +194,20 @@ async function getCoreBody(params: GetRequest): Promise<GetResponse> {
 	}
 
 	if (resource === "sdui") {
+		const base = db.select({ data: flow.data }).from(flow);
+		const whereClauses = [];
+
 		if (filter?.id) {
-			const rows = await db
-				.select({ data: flow.data })
-				.from(flow)
-				.where(eq(flow.id, filter.id))
-				.limit(1);
-			const payload = rows.length ? [rows[0].data] : [];
-			for (const item of payload) {
-				validateFlowData(item);
-			}
-			return validateGetResponse(payload);
+			whereClauses.push(eq(flow.id, filter.id));
 		}
-		const flows = await db
-			.select({ data: flow.data })
-			.from(flow)
-			.orderBy(desc(flow.updatedAt));
-		const payload = flows.map((f) => f.data);
+		if (filter?.updatedAfter) {
+			whereClauses.push(gt(flow.updatedAt, filter.updatedAfter));
+		}
+
+		const rows = whereClauses.length
+			? await base.where(and(...whereClauses)).orderBy(desc(flow.updatedAt))
+			: await base.orderBy(desc(flow.updatedAt));
+		const payload = rows.map((f) => f.data);
 		for (const item of payload) {
 			validateFlowData(item);
 		}
@@ -209,15 +215,15 @@ async function getCoreBody(params: GetRequest): Promise<GetResponse> {
 	}
 
 	if (resource === "services") {
-		return listCoreCatalogRows(service, filter?.id, mapServiceRow);
+		return listCoreCatalogRows(service, filter, mapServiceRow);
 	}
 
 	if (resource === "organisations") {
-		return listCoreCatalogRows(organization, filter?.id, (r) => r);
+		return listCoreCatalogRows(organization, filter, (r) => r);
 	}
 
 	if (resource === "providers") {
-		return listCoreCatalogRows(serviceProvider, filter?.id, (r) => r);
+		return listCoreCatalogRows(serviceProvider, filter, (r) => r);
 	}
 
 	throw new Error("Unsupported resource for core API");
@@ -228,7 +234,7 @@ export async function getCore(params: unknown): Promise<GetResponse> {
 	return getCoreBody(params);
 }
 
-async function upsertCoreBody(params: UpsertRequest): Promise<DATA_EVY_Rows> {
+async function upsertCoreBody(params: UpsertRequest): Promise<UpsertResponse> {
 	const { resource, filter, data: dataPayload } = params;
 	const nowIso = new Date().toISOString();
 
@@ -394,7 +400,7 @@ async function upsertCoreBody(params: UpsertRequest): Promise<DATA_EVY_Rows> {
 	throw new Error("Unsupported resource for core API");
 }
 
-export async function upsertCore(params: unknown): Promise<DATA_EVY_Rows> {
+export async function upsertCore(params: unknown): Promise<UpsertResponse> {
 	validateCoreUpsertParams(params);
 	return upsertCoreBody(params);
 }

--- a/api/src/expressionParser.ts
+++ b/api/src/expressionParser.ts
@@ -1,0 +1,337 @@
+const BRACED_BINDING_PATTERN = /\{([^}]+)\}/g;
+const FUNCTION_CALL_PATTERN = /^([a-zA-Z_]+)\((.*)\)$/;
+const COMPARISON_OPERATOR_TOKENS = new Set([">=", "<=", "==", "!=", ">", "<"]);
+const LOGICAL_OPERATOR_TOKENS = new Set(["&&", "||"]);
+const PARENTHESIS_TOKENS = new Set(["(", ")"]);
+
+export function extractBindingsFromString(text: string): string[] {
+	const bindings: string[] = [];
+	for (const match of text.matchAll(BRACED_BINDING_PATTERN)) {
+		const bindingBody = match[1]?.trim();
+		if (bindingBody) {
+			bindings.push(bindingBody);
+		}
+	}
+	return bindings;
+}
+
+export function extractCandidatesFromBinding(bindingBody: string): string[] {
+	const trimmedBindingBody = bindingBody.trim();
+	if (!trimmedBindingBody || isExcludedBinding(trimmedBindingBody)) {
+		return [];
+	}
+
+	if (containsComparisonOperator(trimmedBindingBody)) {
+		return uniqueCandidates(
+			extractCandidatesFromExpression(trimmedBindingBody),
+		);
+	}
+
+	if (isFunctionCall(trimmedBindingBody)) {
+		return uniqueCandidates(
+			extractCandidatesFromFunctionCall(trimmedBindingBody),
+		);
+	}
+
+	return uniqueCandidates(
+		[candidateFromValue(trimmedBindingBody)].filter(isCandidate),
+	);
+}
+
+export function isExcludedBinding(bindingBody: string): boolean {
+	const trimmedBindingBody = bindingBody.trim();
+	return (
+		trimmedBindingBody.startsWith("$api:") ||
+		trimmedBindingBody.startsWith("$local:") ||
+		trimmedBindingBody.startsWith("$datum:")
+	);
+}
+
+export function tokenize(input: string): string[] {
+	const tokens: string[] = [];
+	let index = 0;
+
+	while (index < input.length) {
+		const currentChar = input[index];
+
+		if (currentChar === " " || currentChar === "\t" || currentChar === "\n") {
+			index++;
+			continue;
+		}
+
+		if (currentChar === "(" || currentChar === ")") {
+			tokens.push(currentChar);
+			index++;
+			continue;
+		}
+
+		const twoCharOperator = input.slice(index, index + 2);
+		if (
+			twoCharOperator === "&&" ||
+			twoCharOperator === "||" ||
+			twoCharOperator === ">=" ||
+			twoCharOperator === "<=" ||
+			twoCharOperator === "!=" ||
+			twoCharOperator === "=="
+		) {
+			tokens.push(twoCharOperator);
+			index += 2;
+			continue;
+		}
+
+		if (currentChar === ">" || currentChar === "<") {
+			tokens.push(currentChar);
+			index++;
+			continue;
+		}
+
+		let word = "";
+		while (
+			index < input.length &&
+			!isWhitespace(input[index]) &&
+			input[index] !== "(" &&
+			input[index] !== ")" &&
+			!startsWithOperator(input, index)
+		) {
+			word += input[index];
+			index++;
+		}
+
+		if (index < input.length && input[index] === "(") {
+			word += input[index];
+			index++;
+
+			let depth = 1;
+			let inString = false;
+			while (index < input.length && depth > 0) {
+				const char = input[index];
+
+				if (inString) {
+					word += char;
+					if (char === '"') {
+						inString = false;
+					}
+					index++;
+					continue;
+				}
+
+				if (char === '"') {
+					inString = true;
+				} else if (char === "(") {
+					depth++;
+				} else if (char === ")") {
+					depth--;
+				}
+
+				word += char;
+				index++;
+			}
+
+			if (word) {
+				tokens.push(word);
+			}
+			continue;
+		}
+
+		if (word) {
+			tokens.push(word);
+			continue;
+		}
+
+		index++;
+	}
+
+	return tokens;
+}
+
+export function isFunctionCall(value: string): boolean {
+	return FUNCTION_CALL_PATTERN.test(value.trim());
+}
+
+export function extractFunctionArgs(functionCall: string): string[] {
+	const match = functionCall.trim().match(FUNCTION_CALL_PATTERN);
+	if (!match) {
+		return [];
+	}
+	return splitFunctionArguments(match[2] ?? "");
+}
+
+export function rootSegment(path: string): string {
+	const withoutArrayAccessor = path.trim().replace(/\[[^\]]*\]/g, "");
+	const [root] = withoutArrayAccessor.split(".");
+	return root?.trim() ?? "";
+}
+
+export function isNumericLiteral(value: string): boolean {
+	return /^-?\d+(\.\d+)?$/.test(value.trim());
+}
+
+export function isUuidLike(value: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+		value.trim(),
+	);
+}
+
+function extractCandidatesFromExpression(expression: string): string[] {
+	const candidates: string[] = [];
+	for (const token of tokenize(expression)) {
+		if (shouldSkipExpressionToken(token)) {
+			continue;
+		}
+
+		if (isFunctionCall(token)) {
+			candidates.push(...extractCandidatesFromFunctionCall(token));
+			continue;
+		}
+
+		const candidate = candidateFromValue(token);
+		if (isCandidate(candidate)) {
+			candidates.push(candidate);
+		}
+	}
+	return candidates;
+}
+
+function extractCandidatesFromFunctionCall(functionCall: string): string[] {
+	const candidates: string[] = [];
+	for (const arg of extractFunctionArgs(functionCall)) {
+		const trimmedArg = arg.trim();
+
+		if (!trimmedArg || shouldSkipLiteralOrUuid(trimmedArg)) {
+			continue;
+		}
+
+		if (isFunctionCall(trimmedArg)) {
+			candidates.push(...extractCandidatesFromFunctionCall(trimmedArg));
+			continue;
+		}
+
+		const candidate = candidateFromValue(trimmedArg);
+		if (isCandidate(candidate)) {
+			candidates.push(candidate);
+		}
+	}
+	return candidates;
+}
+
+function splitFunctionArguments(args: string): string[] {
+	const components: string[] = [];
+	let current = "";
+	let depth = 0;
+	let inString = false;
+
+	for (const char of args) {
+		if (inString) {
+			current += char;
+			if (char === '"') {
+				inString = false;
+			}
+			continue;
+		}
+
+		if (char === '"') {
+			inString = true;
+			current += char;
+			continue;
+		}
+
+		if (char === "(") {
+			depth++;
+			current += char;
+			continue;
+		}
+
+		if (char === ")") {
+			depth--;
+			current += char;
+			continue;
+		}
+
+		if (char === "," && depth === 0) {
+			const trimmedCurrent = current.trim();
+			if (trimmedCurrent) {
+				components.push(trimmedCurrent);
+			}
+			current = "";
+			continue;
+		}
+
+		current += char;
+	}
+
+	const trimmedCurrent = current.trim();
+	if (trimmedCurrent) {
+		components.push(trimmedCurrent);
+	}
+
+	return components;
+}
+
+function candidateFromValue(value: string): string {
+	const trimmedValue = value.trim();
+	if (shouldSkipLiteralOrUuid(trimmedValue)) {
+		return "";
+	}
+	return rootSegment(trimmedValue);
+}
+
+function isCandidate(value: string): value is string {
+	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
+function shouldSkipExpressionToken(token: string): boolean {
+	const trimmedToken = token.trim();
+	return (
+		!trimmedToken ||
+		COMPARISON_OPERATOR_TOKENS.has(trimmedToken) ||
+		LOGICAL_OPERATOR_TOKENS.has(trimmedToken) ||
+		PARENTHESIS_TOKENS.has(trimmedToken) ||
+		shouldSkipLiteralOrUuid(trimmedToken)
+	);
+}
+
+function shouldSkipLiteralOrUuid(value: string): boolean {
+	const trimmedValue = value.trim();
+	return (
+		isNumericLiteral(trimmedValue) ||
+		isUuidLike(trimmedValue) ||
+		isStringLiteral(trimmedValue) ||
+		trimmedValue === "true" ||
+		trimmedValue === "false" ||
+		trimmedValue === "null"
+	);
+}
+
+function containsComparisonOperator(value: string): boolean {
+	return /[><=!]/.test(value);
+}
+
+function startsWithOperator(input: string, index: number): boolean {
+	const twoCharOperator = input.slice(index, index + 2);
+	return (
+		twoCharOperator === "&&" ||
+		twoCharOperator === "||" ||
+		twoCharOperator === ">=" ||
+		twoCharOperator === "<=" ||
+		twoCharOperator === "!=" ||
+		twoCharOperator === "==" ||
+		input[index] === ">" ||
+		input[index] === "<"
+	);
+}
+
+function isWhitespace(value: string | undefined): boolean {
+	return value === " " || value === "\t" || value === "\n";
+}
+
+function isStringLiteral(value: string): boolean {
+	const trimmedValue = value.trim();
+	return (
+		(trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
+		(trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
+	);
+}
+
+function uniqueCandidates(candidates: string[]): string[] {
+	return [...new Set(candidates)];
+}

--- a/api/src/expressionParser.ts
+++ b/api/src/expressionParser.ts
@@ -38,12 +38,11 @@ export function extractCandidatesFromBinding(bindingBody: string): string[] {
 	);
 }
 
-export function isExcludedBinding(bindingBody: string): boolean {
-	const trimmedBindingBody = bindingBody.trim();
+function isExcludedBinding(bindingBody: string): boolean {
 	return (
-		trimmedBindingBody.startsWith("$api:") ||
-		trimmedBindingBody.startsWith("$local:") ||
-		trimmedBindingBody.startsWith("$datum:")
+		bindingBody.startsWith("$api:") ||
+		bindingBody.startsWith("$local:") ||
+		bindingBody.startsWith("$datum:")
 	);
 }
 
@@ -144,31 +143,31 @@ export function tokenize(input: string): string[] {
 	return tokens;
 }
 
-export function isFunctionCall(value: string): boolean {
-	return FUNCTION_CALL_PATTERN.test(value.trim());
+function isFunctionCall(value: string): boolean {
+	return FUNCTION_CALL_PATTERN.test(value);
 }
 
-export function extractFunctionArgs(functionCall: string): string[] {
-	const match = functionCall.trim().match(FUNCTION_CALL_PATTERN);
+function extractFunctionArgs(functionCall: string): string[] {
+	const match = functionCall.match(FUNCTION_CALL_PATTERN);
 	if (!match) {
 		return [];
 	}
 	return splitFunctionArguments(match[2] ?? "");
 }
 
-export function rootSegment(path: string): string {
-	const withoutArrayAccessor = path.trim().replace(/\[[^\]]*\]/g, "");
+function rootSegment(path: string): string {
+	const withoutArrayAccessor = path.replace(/\[[^\]]*\]/g, "");
 	const [root] = withoutArrayAccessor.split(".");
-	return root?.trim() ?? "";
+	return root ?? "";
 }
 
-export function isNumericLiteral(value: string): boolean {
-	return /^-?\d+(\.\d+)?$/.test(value.trim());
+function isNumericLiteral(value: string): boolean {
+	return /^-?\d+(\.\d+)?$/.test(value);
 }
 
-export function isUuidLike(value: string): boolean {
+function isUuidLike(value: string): boolean {
 	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-		value.trim(),
+		value,
 	);
 }
 
@@ -268,37 +267,34 @@ function splitFunctionArguments(args: string): string[] {
 }
 
 function candidateFromValue(value: string): string {
-	const trimmedValue = value.trim();
-	if (shouldSkipLiteralOrUuid(trimmedValue)) {
+	if (shouldSkipLiteralOrUuid(value)) {
 		return "";
 	}
-	return rootSegment(trimmedValue);
+	return rootSegment(value);
 }
 
-function isCandidate(value: string): value is string {
+function isCandidate(value: string): boolean {
 	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 function shouldSkipExpressionToken(token: string): boolean {
-	const trimmedToken = token.trim();
 	return (
-		!trimmedToken ||
-		COMPARISON_OPERATOR_TOKENS.has(trimmedToken) ||
-		LOGICAL_OPERATOR_TOKENS.has(trimmedToken) ||
-		PARENTHESIS_TOKENS.has(trimmedToken) ||
-		shouldSkipLiteralOrUuid(trimmedToken)
+		!token ||
+		COMPARISON_OPERATOR_TOKENS.has(token) ||
+		LOGICAL_OPERATOR_TOKENS.has(token) ||
+		PARENTHESIS_TOKENS.has(token) ||
+		shouldSkipLiteralOrUuid(token)
 	);
 }
 
 function shouldSkipLiteralOrUuid(value: string): boolean {
-	const trimmedValue = value.trim();
 	return (
-		isNumericLiteral(trimmedValue) ||
-		isUuidLike(trimmedValue) ||
-		isStringLiteral(trimmedValue) ||
-		trimmedValue === "true" ||
-		trimmedValue === "false" ||
-		trimmedValue === "null"
+		isNumericLiteral(value) ||
+		isUuidLike(value) ||
+		isStringLiteral(value) ||
+		value === "true" ||
+		value === "false" ||
+		value === "null"
 	);
 }
 
@@ -307,16 +303,12 @@ function containsComparisonOperator(value: string): boolean {
 }
 
 function startsWithOperator(input: string, index: number): boolean {
-	const twoCharOperator = input.slice(index, index + 2);
+	const twoChar = input.slice(index, index + 2);
+	const oneChar = input[index] ?? "";
 	return (
-		twoCharOperator === "&&" ||
-		twoCharOperator === "||" ||
-		twoCharOperator === ">=" ||
-		twoCharOperator === "<=" ||
-		twoCharOperator === "!=" ||
-		twoCharOperator === "==" ||
-		input[index] === ">" ||
-		input[index] === "<"
+		LOGICAL_OPERATOR_TOKENS.has(twoChar) ||
+		COMPARISON_OPERATOR_TOKENS.has(twoChar) ||
+		COMPARISON_OPERATOR_TOKENS.has(oneChar)
 	);
 }
 
@@ -325,10 +317,9 @@ function isWhitespace(value: string | undefined): boolean {
 }
 
 function isStringLiteral(value: string): boolean {
-	const trimmedValue = value.trim();
 	return (
-		(trimmedValue.startsWith('"') && trimmedValue.endsWith('"')) ||
-		(trimmedValue.startsWith("'") && trimmedValue.endsWith("'"))
+		(value.startsWith('"') && value.endsWith('"')) ||
+		(value.startsWith("'") && value.endsWith("'"))
 	);
 }
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,6 @@
 import { initServer, type WSParams } from "./ws";
 import { validateAuth } from "./data";
-import { get, upsert, wireServerEvents } from "./rpc";
+import { get, syncServiceData, upsert, wireServerEvents } from "./rpc";
 
 function authHandler(data: WSParams): Promise<boolean> {
 	return validateAuth(data.token, data.os);
@@ -13,6 +13,8 @@ async function main() {
 	server.register("get", get);
 
 	server.register("upsert", upsert).protected();
+
+	server.register("syncServiceData", syncServiceData).protected();
 }
 
 main();

--- a/api/src/rpc.ts
+++ b/api/src/rpc.ts
@@ -8,7 +8,7 @@ import {
 	upsertCoreForValidatedRequest,
 } from "./data";
 import { syncServiceData as syncServiceDataBody } from "./serviceDataSync";
-import { forwardUnary, wireGrpcClientsTo } from "./services";
+import { forwardGet, forwardUpsert, wireGrpcClientsTo } from "./services";
 import {
 	validateStrictGetRequest,
 	validateStrictUpsertRequest,
@@ -27,7 +27,7 @@ export async function get(params: unknown): Promise<GetResponse> {
 	if (params.service === "evy") {
 		return getCoreForValidatedRequest(params);
 	}
-	return forwardUnary(params.service, "get", params);
+	return forwardGet(params.service, params);
 }
 
 export async function upsert(params: unknown): Promise<UpsertResponse> {
@@ -43,7 +43,7 @@ export async function upsert(params: unknown): Promise<UpsertResponse> {
 		}
 		return result;
 	}
-	return forwardUnary(params.service, "upsert", params);
+	return forwardUpsert(params.service, params);
 }
 
 export async function syncServiceData(

--- a/api/src/rpc.ts
+++ b/api/src/rpc.ts
@@ -1,8 +1,13 @@
-import type { GetResponse, UpsertResponse } from "evy-types";
+import type {
+	GetResponse,
+	SyncServiceDataResponse,
+	UpsertResponse,
+} from "evy-types";
 import {
 	getCoreForValidatedRequest,
 	upsertCoreForValidatedRequest,
 } from "./data";
+import { syncServiceData as syncServiceDataBody } from "./serviceDataSync";
 import { forwardUnary, wireGrpcClientsTo } from "./services";
 import {
 	validateStrictGetRequest,
@@ -39,4 +44,10 @@ export async function upsert(params: unknown): Promise<UpsertResponse> {
 		return result;
 	}
 	return forwardUnary(params.service, "upsert", params);
+}
+
+export async function syncServiceData(
+	params: unknown,
+): Promise<SyncServiceDataResponse> {
+	return syncServiceDataBody(params);
 }

--- a/api/src/serviceDataSync.ts
+++ b/api/src/serviceDataSync.ts
@@ -1,5 +1,10 @@
 import pluralize from "pluralize";
-import type { GetRequest, SyncServiceDataResponse, UI_Flow } from "evy-types";
+import type {
+	GetRequest,
+	GetResponse,
+	SyncServiceDataResponse,
+	UI_Flow,
+} from "evy-types";
 import { RESOURCES_BY_SERVICE } from "evy-types";
 import { validateStrictSyncServiceDataRequest } from "evy-types/rpcRequestHelpers";
 import { validateSyncServiceDataResponse } from "evy-types/validators";
@@ -10,6 +15,14 @@ import {
 import { forwardGet } from "./services";
 
 type SyncableService = Exclude<keyof typeof RESOURCES_BY_SERVICE, "evy">;
+
+type SyncServiceDataDependencies = {
+	forwardGet: (serviceName: string, params: GetRequest) => Promise<GetResponse>;
+};
+
+const DEFAULT_SYNC_SERVICE_DATA_DEPENDENCIES: SyncServiceDataDependencies = {
+	forwardGet,
+};
 
 const SYNCABLE_SERVICES = Object.keys(RESOURCES_BY_SERVICE).filter(
 	(serviceName) => serviceName !== "evy",
@@ -59,6 +72,7 @@ export function resolveCandidateToService(candidate: string): string | null {
 
 export async function syncServiceData(
 	params: unknown,
+	dependencies: SyncServiceDataDependencies = DEFAULT_SYNC_SERVICE_DATA_DEPENDENCIES,
 ): Promise<SyncServiceDataResponse> {
 	validateStrictSyncServiceDataRequest(params);
 
@@ -79,7 +93,7 @@ export async function syncServiceData(
 			},
 		};
 
-		const value = await forwardGet(serviceName, request);
+		const value = await dependencies.forwardGet(serviceName, request);
 		if (Array.isArray(value) && value.length === 0) {
 			continue;
 		}

--- a/api/src/serviceDataSync.ts
+++ b/api/src/serviceDataSync.ts
@@ -7,7 +7,7 @@ import {
 	extractBindingsFromString,
 	extractCandidatesFromBinding,
 } from "./expressionParser";
-import { forwardUnary } from "./services";
+import { forwardGet } from "./services";
 
 type SyncableService = Exclude<keyof typeof RESOURCES_BY_SERVICE, "evy">;
 
@@ -79,7 +79,7 @@ export async function syncServiceData(
 			},
 		};
 
-		const value = await forwardUnary(serviceName, "get", request);
+		const value = await forwardGet(serviceName, request);
 		if (Array.isArray(value) && value.length === 0) {
 			continue;
 		}

--- a/api/src/serviceDataSync.ts
+++ b/api/src/serviceDataSync.ts
@@ -39,15 +39,11 @@ export function discoverReferencedServices(flows: UI_Flow[]): Set<string> {
 }
 
 export function resolveCandidateToService(candidate: string): string | null {
-	const trimmedCandidate = candidate.trim();
-	if (!trimmedCandidate) {
+	if (!candidate) {
 		return null;
 	}
 
-	const candidateVariants = [
-		trimmedCandidate,
-		pluralize.plural(trimmedCandidate),
-	];
+	const candidateVariants = [candidate, pluralize.plural(candidate)];
 
 	for (const serviceName of SYNCABLE_SERVICES) {
 		const resources = RESOURCES_BY_SERVICE[serviceName] as readonly string[];

--- a/api/src/serviceDataSync.ts
+++ b/api/src/serviceDataSync.ts
@@ -1,0 +1,126 @@
+import pluralize from "pluralize";
+import type { GetRequest, SyncServiceDataResponse, UI_Flow } from "evy-types";
+import { RESOURCES_BY_SERVICE } from "evy-types";
+import { validateStrictSyncServiceDataRequest } from "evy-types/rpcRequestHelpers";
+import { validateSyncServiceDataResponse } from "evy-types/validators";
+import {
+	extractBindingsFromString,
+	extractCandidatesFromBinding,
+} from "./expressionParser";
+import { forwardUnary } from "./services";
+
+type SyncableService = Exclude<keyof typeof RESOURCES_BY_SERVICE, "evy">;
+
+const SYNCABLE_SERVICES = Object.keys(RESOURCES_BY_SERVICE).filter(
+	(serviceName) => serviceName !== "evy",
+) as SyncableService[];
+
+export function extractCandidatesFromFlows(flows: UI_Flow[]): Set<string> {
+	const candidates = new Set<string>();
+
+	for (const flow of flows) {
+		collectCandidatesFromValue(flow, candidates);
+	}
+
+	return candidates;
+}
+
+export function discoverReferencedServices(flows: UI_Flow[]): Set<string> {
+	const services = new Set<string>();
+
+	for (const candidate of extractCandidatesFromFlows(flows)) {
+		const serviceName = resolveCandidateToService(candidate);
+		if (serviceName) {
+			services.add(serviceName);
+		}
+	}
+
+	return services;
+}
+
+export function resolveCandidateToService(candidate: string): string | null {
+	const trimmedCandidate = candidate.trim();
+	if (!trimmedCandidate) {
+		return null;
+	}
+
+	const candidateVariants = [
+		trimmedCandidate,
+		pluralize.plural(trimmedCandidate),
+	];
+
+	for (const serviceName of SYNCABLE_SERVICES) {
+		const resources = RESOURCES_BY_SERVICE[serviceName] as readonly string[];
+		for (const candidateVariant of candidateVariants) {
+			if (resources.includes(candidateVariant)) {
+				return serviceName;
+			}
+		}
+	}
+
+	return null;
+}
+
+export async function syncServiceData(
+	params: unknown,
+): Promise<SyncServiceDataResponse> {
+	validateStrictSyncServiceDataRequest(params);
+
+	if (params.service !== "marketplace") {
+		throw new Error(`Invalid or unsupported service ${params.service}`);
+	}
+
+	const serviceName = params.service;
+	const resources = RESOURCES_BY_SERVICE.marketplace;
+
+	const data: SyncServiceDataResponse["data"] = [];
+	for (const resource of resources) {
+		const request: GetRequest = {
+			service: serviceName,
+			resource,
+			filter: {
+				updatedAfter: params.lastSyncTime,
+			},
+		};
+
+		const value = await forwardUnary(serviceName, "get", request);
+		if (Array.isArray(value) && value.length === 0) {
+			continue;
+		}
+
+		data.push({
+			service: serviceName,
+			resource,
+			value,
+		});
+	}
+
+	return validateSyncServiceDataResponse({ data });
+}
+
+function collectCandidatesFromValue(
+	value: unknown,
+	candidates: Set<string>,
+): void {
+	if (typeof value === "string") {
+		for (const bindingBody of extractBindingsFromString(value)) {
+			for (const candidate of extractCandidatesFromBinding(bindingBody)) {
+				candidates.add(candidate);
+			}
+		}
+		return;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectCandidatesFromValue(item, candidates);
+		}
+		return;
+	}
+
+	if (value !== null && typeof value === "object") {
+		for (const child of Object.values(value)) {
+			collectCandidatesFromValue(child, candidates);
+		}
+	}
+}

--- a/api/src/services.ts
+++ b/api/src/services.ts
@@ -263,29 +263,26 @@ function getGrpcAdapters(): Map<string, ServiceAdapter> {
 	return grpcAdapters;
 }
 
-export function forwardUnary(
-	serviceName: string,
-	method: "get",
-	params: GetRequest,
-): Promise<GetResponse>;
-export function forwardUnary(
-	serviceName: string,
-	method: "upsert",
-	params: UpsertRequest,
-): Promise<UpsertResponse>;
-export function forwardUnary(
-	serviceName: string,
-	method: "get" | "upsert",
-	params: GetRequest | UpsertRequest,
-): Promise<GetResponse | UpsertResponse> {
+function getServiceAdapter(serviceName: string): ServiceAdapter {
 	const adapter = getGrpcAdapters().get(serviceName);
 	if (!adapter) {
 		throw new Error(`No service registered for service ${serviceName}`);
 	}
-	if (method === "get") {
-		return adapter.get(params as GetRequest);
-	}
-	return adapter.upsert(params as UpsertRequest);
+	return adapter;
+}
+
+export function forwardGet(
+	serviceName: string,
+	params: GetRequest,
+): Promise<GetResponse> {
+	return getServiceAdapter(serviceName).get(params);
+}
+
+export function forwardUpsert(
+	serviceName: string,
+	params: UpsertRequest,
+): Promise<UpsertResponse> {
+	return getServiceAdapter(serviceName).upsert(params);
 }
 
 export function wireGrpcClientsTo(server: RpcServer): void {

--- a/api/src/services.ts
+++ b/api/src/services.ts
@@ -68,7 +68,7 @@ type GrpcServiceClient = grpc.Client & {
 		request: {
 			service: string;
 			resource: string;
-			filter?: { id: string };
+			filter?: { id?: string; updated_after?: string };
 		},
 		callback: grpc.requestCallback<{ result_json: string }>,
 	) => grpc.ClientUnaryCall;
@@ -76,7 +76,7 @@ type GrpcServiceClient = grpc.Client & {
 		request: {
 			service: string;
 			resource: string;
-			filter?: { id: string };
+			filter?: { id?: string; updated_after?: string };
 			data_json: string;
 		},
 		callback: grpc.requestCallback<{ result_json: string }>,
@@ -90,10 +90,17 @@ type GrpcServiceClient = grpc.Client & {
 };
 
 function buildProtoGetRequest(params: GetRequest) {
+	const filter = {
+		...(params.filter?.id ? { id: params.filter.id } : {}),
+		...(params.filter?.updatedAfter
+			? { updated_after: params.filter.updatedAfter }
+			: {}),
+	};
+
 	return {
 		service: params.service,
 		resource: params.resource,
-		...(params.filter?.id ? { filter: { id: params.filter.id } } : {}),
+		...(Object.keys(filter).length > 0 ? { filter } : {}),
 	};
 }
 
@@ -105,7 +112,7 @@ function makeGrpcAdapter(
 	const client = new ServiceClientCtor(
 		url,
 		grpc.credentials.createInsecure(),
-	) as GrpcServiceClient;
+	) as unknown as GrpcServiceClient;
 
 	let eventListener: ((eventName: string, payload: unknown) => void) | null =
 		null;

--- a/api/src/services.ts
+++ b/api/src/services.ts
@@ -90,12 +90,10 @@ type GrpcServiceClient = grpc.Client & {
 };
 
 function buildProtoGetRequest(params: GetRequest) {
-	const filter = {
-		...(params.filter?.id ? { id: params.filter.id } : {}),
-		...(params.filter?.updatedAfter
-			? { updated_after: params.filter.updatedAfter }
-			: {}),
-	};
+	const filter: Record<string, string> = {};
+	if (params.filter?.id) filter.id = params.filter.id;
+	if (params.filter?.updatedAfter)
+		filter.updated_after = params.filter.updatedAfter;
 
 	return {
 		service: params.service,

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -15,8 +15,8 @@ import type {
 	UI_Row,
 	DATA_EVY_Flow,
 	DATA_EVY_Service,
-	DATA_EVY_Rows,
 	GetRequest,
+	UpsertResponse,
 } from "evy-types";
 import * as schema from "../db/drizzleTables";
 import { validateFlowData } from "../validation";
@@ -56,7 +56,7 @@ mock.module("../db", () => ({
 
 const { validateAuth, getCore, upsertCore } = await import("../data");
 
-function isDATA_EVY_Flow(row: DATA_EVY_Rows): row is DATA_EVY_Flow {
+function isDATA_EVY_Flow(row: UpsertResponse): row is DATA_EVY_Flow {
 	return (
 		"data" in row &&
 		typeof row.data === "object" &&
@@ -66,7 +66,7 @@ function isDATA_EVY_Flow(row: DATA_EVY_Rows): row is DATA_EVY_Flow {
 }
 
 function expectToBeDATA_EVY_Flow(
-	row: DATA_EVY_Rows,
+	row: UpsertResponse,
 ): asserts row is DATA_EVY_Flow {
 	expect(isDATA_EVY_Flow(row)).toBe(true);
 	if (!isDATA_EVY_Flow(row)) {

--- a/api/src/tests/serviceDataSync.test.ts
+++ b/api/src/tests/serviceDataSync.test.ts
@@ -12,10 +12,6 @@ const forwardGetMock = mock(
 	],
 );
 
-mock.module("../services", () => ({
-	forwardGet: forwardGetMock,
-}));
-
 const { extractBindingsFromString, extractCandidatesFromBinding } =
 	await import("../expressionParser");
 const {
@@ -24,6 +20,10 @@ const {
 	resolveCandidateToService,
 	syncServiceData,
 } = await import("../serviceDataSync");
+
+function syncServiceDataWithMock(params: unknown) {
+	return syncServiceData(params, { forwardGet: forwardGetMock });
+}
 
 const EPOCH = "1970-01-01T00:00:00.000Z";
 
@@ -236,7 +236,7 @@ describe("service data sync utilities", () => {
 
 describe("syncServiceData", () => {
 	it("returns all changed marketplace resources", async () => {
-		const result = await syncServiceData({
+		const result = await syncServiceDataWithMock({
 			service: "marketplace",
 			lastSyncTime: EPOCH,
 		});
@@ -254,7 +254,7 @@ describe("syncServiceData", () => {
 	});
 
 	it("passes updatedAfter to each underlying get request", async () => {
-		await syncServiceData({
+		await syncServiceDataWithMock({
 			service: "marketplace",
 			lastSyncTime: EPOCH,
 		});
@@ -269,7 +269,7 @@ describe("syncServiceData", () => {
 	it("returns an empty data array when no resources changed", async () => {
 		forwardGetMock.mockImplementation(async (): Promise<GetResponse> => []);
 
-		const result = await syncServiceData({
+		const result = await syncServiceDataWithMock({
 			service: "marketplace",
 			lastSyncTime: "2999-01-01T00:00:00.000Z",
 		});
@@ -279,13 +279,13 @@ describe("syncServiceData", () => {
 
 	it("rejects missing or invalid lastSyncTime", async () => {
 		await expect(
-			syncServiceData({
+			syncServiceDataWithMock({
 				service: "marketplace",
 			}),
 		).rejects.toThrow("Invalid or missing lastSyncTime");
 
 		await expect(
-			syncServiceData({
+			syncServiceDataWithMock({
 				service: "marketplace",
 				lastSyncTime: "not-a-date",
 			}),
@@ -294,20 +294,20 @@ describe("syncServiceData", () => {
 
 	it("rejects missing, invalid, or core services", async () => {
 		await expect(
-			syncServiceData({
+			syncServiceDataWithMock({
 				lastSyncTime: EPOCH,
 			}),
 		).rejects.toThrow("Invalid or missing service");
 
 		await expect(
-			syncServiceData({
+			syncServiceDataWithMock({
 				service: "unknown",
 				lastSyncTime: EPOCH,
 			}),
 		).rejects.toThrow("Invalid or unsupported service");
 
 		await expect(
-			syncServiceData({
+			syncServiceDataWithMock({
 				service: "evy",
 				lastSyncTime: EPOCH,
 			}),
@@ -315,7 +315,7 @@ describe("syncServiceData", () => {
 	});
 
 	it("returns items as an array", async () => {
-		const result = await syncServiceData({
+		const result = await syncServiceDataWithMock({
 			service: "marketplace",
 			lastSyncTime: EPOCH,
 		});

--- a/api/src/tests/serviceDataSync.test.ts
+++ b/api/src/tests/serviceDataSync.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	RESOURCES_BY_SERVICE,
+	type GetRequest,
+	type GetResponse,
+	type UI_Flow,
+} from "evy-types";
+
+const forwardUnaryMock = mock(
+	async (
+		_serviceName: string,
+		_method: "get",
+		params: GetRequest,
+	): Promise<GetResponse> => [{ id: `${params.resource}-1` }],
+);
+
+mock.module("../services", () => ({
+	forwardUnary: forwardUnaryMock,
+}));
+
+const { extractBindingsFromString, extractCandidatesFromBinding, tokenize } =
+	await import("../expressionParser");
+const {
+	discoverReferencedServices,
+	extractCandidatesFromFlows,
+	resolveCandidateToService,
+	syncServiceData,
+} = await import("../serviceDataSync");
+
+const EPOCH = "1970-01-01T00:00:00.000Z";
+
+function testRow(overrides: Partial<UI_Flow["pages"][number]["rows"][number]>) {
+	return {
+		id: crypto.randomUUID(),
+		type: "Text",
+		source: "",
+		destination: "",
+		actions: [],
+		view: {
+			content: {
+				title: "",
+			},
+		},
+		...overrides,
+	} satisfies UI_Flow["pages"][number]["rows"][number];
+}
+
+function testFlow(): UI_Flow {
+	const navigateFlowId = crypto.randomUUID();
+	const navigatePageId = crypto.randomUUID();
+
+	return {
+		id: crypto.randomUUID(),
+		name: "Binding extraction flow",
+		pages: [
+			{
+				id: crypto.randomUUID(),
+				title: "Page",
+				rows: [
+					testRow({
+						type: "SheetContainer",
+						source: "{item}",
+						destination: "{buildCurrency(price)}",
+						actions: [
+							{
+								condition: "{length(title) > 0 && price.value >= 1}",
+								false: "{highlight_required(title)}",
+								true: `{navigate(${navigateFlowId},${navigatePageId})}`,
+							},
+						],
+						view: {
+							content: {
+								title: "{conditions}",
+								child: testRow({
+									type: "InputList",
+									source: "{tags}",
+									view: {
+										content: {
+											title: "Tags",
+											format: "{$datum:value}",
+										},
+									},
+								}),
+								children: [
+									testRow({
+										type: "Search",
+										source: "{$api:tags}",
+										destination: "{tags}",
+										view: {
+											content: {
+												title: "",
+												placeholder: "Search",
+												child: testRow({
+													type: "Info",
+													source: "",
+													view: {
+														content: {
+															title: "{$datum:value}",
+															subtitle: "{$local:address}",
+														},
+													},
+												}),
+											},
+										},
+									}),
+									testRow({
+										type: "Text",
+										source: "",
+										view: {
+											content: {
+												title: "",
+												text: "{formatCurrency(price)}",
+											},
+										},
+									}),
+								],
+							},
+						},
+					}),
+				],
+				footer: testRow({
+					type: "Button",
+					source: "{item}",
+					actions: [{ condition: "", false: "", true: "{create(item)}" }],
+					view: {
+						content: {
+							title: "",
+							label: "Create",
+						},
+					},
+				}),
+			},
+		],
+	};
+}
+
+beforeEach(() => {
+	forwardUnaryMock.mockClear();
+	forwardUnaryMock.mockImplementation(
+		async (
+			_serviceName: string,
+			_method: "get",
+			params: GetRequest,
+		): Promise<GetResponse> => [{ id: `${params.resource}-1` }],
+	);
+});
+
+describe("expression parser utility", () => {
+	it("extracts all braced bindings from a string", () => {
+		expect(
+			extractBindingsFromString(
+				"{item.title} costs {formatCurrency(price)} and {$datum:value}",
+			),
+		).toEqual(["item.title", "formatCurrency(price)", "$datum:value"]);
+	});
+
+	it("extracts plain identifiers and root path segments", () => {
+		expect(extractCandidatesFromBinding("selling_reasons")).toEqual([
+			"selling_reasons",
+		]);
+		expect(extractCandidatesFromBinding("item.title")).toEqual(["item"]);
+		expect(extractCandidatesFromBinding("price.value")).toEqual(["price"]);
+	});
+
+	it("extracts function arguments without extracting function names", () => {
+		expect(extractCandidatesFromBinding("formatCurrency(price)")).toEqual([
+			"price",
+		]);
+		expect(extractCandidatesFromBinding("create(item)")).toEqual(["item"]);
+		expect(extractCandidatesFromBinding("highlight_required(title)")).toEqual([
+			"title",
+		]);
+		expect(extractCandidatesFromBinding("close()")).toEqual([]);
+	});
+
+	it("skips uuid-like function arguments", () => {
+		expect(
+			extractCandidatesFromBinding(
+				"navigate(ca47e6c5-0000-4000-8000-000000000000,06b21b52-0000-4000-8000-000000000000)",
+			),
+		).toEqual([]);
+	});
+
+	it("extracts operands from comparison expressions", () => {
+		expect(extractCandidatesFromBinding("length(title) > 0")).toEqual([
+			"title",
+		]);
+		expect(
+			extractCandidatesFromBinding("length(title) > 0 && price.value >= 1"),
+		).toEqual(["title", "price"]);
+	});
+
+	it("does not extract numeric, string, boolean, or null literals", () => {
+		expect(
+			extractCandidatesFromBinding(
+				'length(title) > 0 && status == "active" && enabled != false && deletedAt == null',
+			),
+		).toEqual(["title", "status", "enabled", "deletedAt"]);
+	});
+
+	it("excludes api, local, and datum bindings", () => {
+		expect(extractCandidatesFromBinding("$api:tags")).toEqual([]);
+		expect(extractCandidatesFromBinding("$local:address")).toEqual([]);
+		expect(extractCandidatesFromBinding("$datum:value")).toEqual([]);
+	});
+
+	it("tokenizes boolean expressions while keeping function calls intact", () => {
+		expect(tokenize("length(title) > 0 && price.value >= 1")).toEqual([
+			"length(title)",
+			">",
+			"0",
+			"&&",
+			"price.value",
+			">=",
+			"1",
+		]);
+	});
+});
+
+describe("service data sync utilities", () => {
+	it("extracts candidates recursively from source, destination, actions, nested child rows, nested children arrays, and footers", () => {
+		const candidates = extractCandidatesFromFlows([testFlow()]);
+
+		expect(candidates.has("item")).toBe(true);
+		expect(candidates.has("conditions")).toBe(true);
+		expect(candidates.has("price")).toBe(true);
+		expect(candidates.has("title")).toBe(true);
+		expect(candidates.has("tags")).toBe(true);
+
+		expect(candidates.has("$api:tags")).toBe(false);
+		expect(candidates.has("$local:address")).toBe(false);
+		expect(candidates.has("$datum:value")).toBe(false);
+		expect(candidates.has("formatCurrency")).toBe(false);
+		expect(candidates.has("create")).toBe(false);
+		expect(candidates.has("navigate")).toBe(false);
+	});
+
+	it("maps singular and plural resource candidates to services", () => {
+		expect(resolveCandidateToService("conditions")).toBe("marketplace");
+		expect(resolveCandidateToService("item")).toBe("marketplace");
+		expect(resolveCandidateToService("items")).toBe("marketplace");
+		expect(resolveCandidateToService("price")).toBeNull();
+		expect(resolveCandidateToService("title")).toBeNull();
+	});
+
+	it("discovers referenced services from flow bindings", () => {
+		expect([...discoverReferencedServices([testFlow()])]).toEqual([
+			"marketplace",
+		]);
+	});
+});
+
+describe("syncServiceData", () => {
+	it("returns all changed marketplace resources", async () => {
+		const result = await syncServiceData({
+			service: "marketplace",
+			lastSyncTime: EPOCH,
+		});
+
+		expect(result.data.map((row) => row.resource)).toEqual([
+			...RESOURCES_BY_SERVICE.marketplace,
+		]);
+		expect(result.data.every((row) => row.service === "marketplace")).toBe(
+			true,
+		);
+		expect(result.data.every((row) => Array.isArray(row.value))).toBe(true);
+		expect(forwardUnaryMock).toHaveBeenCalledTimes(
+			RESOURCES_BY_SERVICE.marketplace.length,
+		);
+	});
+
+	it("passes updatedAfter to each underlying get request", async () => {
+		await syncServiceData({
+			service: "marketplace",
+			lastSyncTime: EPOCH,
+		});
+
+		for (const call of forwardUnaryMock.mock.calls) {
+			const [serviceName, method, params] = call;
+			expect(serviceName).toBe("marketplace");
+			expect(method).toBe("get");
+			expect(params.filter?.updatedAfter).toBe(EPOCH);
+		}
+	});
+
+	it("returns an empty data array when no resources changed", async () => {
+		forwardUnaryMock.mockImplementation(async (): Promise<GetResponse> => []);
+
+		const result = await syncServiceData({
+			service: "marketplace",
+			lastSyncTime: "2999-01-01T00:00:00.000Z",
+		});
+
+		expect(result).toEqual({ data: [] });
+	});
+
+	it("rejects missing or invalid lastSyncTime", async () => {
+		await expect(
+			syncServiceData({
+				service: "marketplace",
+			}),
+		).rejects.toThrow("Invalid or missing lastSyncTime");
+
+		await expect(
+			syncServiceData({
+				service: "marketplace",
+				lastSyncTime: "not-a-date",
+			}),
+		).rejects.toThrow("SyncServiceDataRequest validation failed");
+	});
+
+	it("rejects missing, invalid, or core services", async () => {
+		await expect(
+			syncServiceData({
+				lastSyncTime: EPOCH,
+			}),
+		).rejects.toThrow("Invalid or missing service");
+
+		await expect(
+			syncServiceData({
+				service: "unknown",
+				lastSyncTime: EPOCH,
+			}),
+		).rejects.toThrow("Invalid or unsupported service");
+
+		await expect(
+			syncServiceData({
+				service: "evy",
+				lastSyncTime: EPOCH,
+			}),
+		).rejects.toThrow("Invalid or unsupported service");
+	});
+
+	it("returns items as an array", async () => {
+		const result = await syncServiceData({
+			service: "marketplace",
+			lastSyncTime: EPOCH,
+		});
+
+		const itemsRow = result.data.find((row) => row.resource === "items");
+		expect(itemsRow).toBeDefined();
+		expect(Array.isArray(itemsRow?.value)).toBe(true);
+	});
+});

--- a/api/src/tests/serviceDataSync.test.ts
+++ b/api/src/tests/serviceDataSync.test.ts
@@ -6,19 +6,17 @@ import {
 	type UI_Flow,
 } from "evy-types";
 
-const forwardUnaryMock = mock(
-	async (
-		_serviceName: string,
-		_method: "get",
-		params: GetRequest,
-	): Promise<GetResponse> => [{ id: `${params.resource}-1` }],
+const forwardGetMock = mock(
+	async (_serviceName: string, params: GetRequest): Promise<GetResponse> => [
+		{ id: `${params.resource}-1` },
+	],
 );
 
 mock.module("../services", () => ({
-	forwardUnary: forwardUnaryMock,
+	forwardGet: forwardGetMock,
 }));
 
-const { extractBindingsFromString, extractCandidatesFromBinding, tokenize } =
+const { extractBindingsFromString, extractCandidatesFromBinding } =
 	await import("../expressionParser");
 const {
 	discoverReferencedServices,
@@ -135,13 +133,11 @@ function testFlow(): UI_Flow {
 }
 
 beforeEach(() => {
-	forwardUnaryMock.mockClear();
-	forwardUnaryMock.mockImplementation(
-		async (
-			_serviceName: string,
-			_method: "get",
-			params: GetRequest,
-		): Promise<GetResponse> => [{ id: `${params.resource}-1` }],
+	forwardGetMock.mockClear();
+	forwardGetMock.mockImplementation(
+		async (_serviceName: string, params: GetRequest): Promise<GetResponse> => [
+			{ id: `${params.resource}-1` },
+		],
 	);
 });
 
@@ -203,18 +199,6 @@ describe("expression parser utility", () => {
 		expect(extractCandidatesFromBinding("$local:address")).toEqual([]);
 		expect(extractCandidatesFromBinding("$datum:value")).toEqual([]);
 	});
-
-	it("tokenizes boolean expressions while keeping function calls intact", () => {
-		expect(tokenize("length(title) > 0 && price.value >= 1")).toEqual([
-			"length(title)",
-			">",
-			"0",
-			"&&",
-			"price.value",
-			">=",
-			"1",
-		]);
-	});
 });
 
 describe("service data sync utilities", () => {
@@ -264,7 +248,7 @@ describe("syncServiceData", () => {
 			true,
 		);
 		expect(result.data.every((row) => Array.isArray(row.value))).toBe(true);
-		expect(forwardUnaryMock).toHaveBeenCalledTimes(
+		expect(forwardGetMock).toHaveBeenCalledTimes(
 			RESOURCES_BY_SERVICE.marketplace.length,
 		);
 	});
@@ -275,16 +259,15 @@ describe("syncServiceData", () => {
 			lastSyncTime: EPOCH,
 		});
 
-		for (const call of forwardUnaryMock.mock.calls) {
-			const [serviceName, method, params] = call;
+		for (const call of forwardGetMock.mock.calls) {
+			const [serviceName, params] = call;
 			expect(serviceName).toBe("marketplace");
-			expect(method).toBe("get");
 			expect(params.filter?.updatedAfter).toBe(EPOCH);
 		}
 	});
 
 	it("returns an empty data array when no resources changed", async () => {
-		forwardUnaryMock.mockImplementation(async (): Promise<GetResponse> => []);
+		forwardGetMock.mockImplementation(async (): Promise<GetResponse> => []);
 
 		const result = await syncServiceData({
 			service: "marketplace",

--- a/docs/evy/sdui/readme.md
+++ b/docs/evy/sdui/readme.md
@@ -16,7 +16,10 @@ UI flows (`UI_Flow`) only describe structure: `id`, `name`, and `pages`. Referen
 	- `{$datum:value}` — current list/search result item field, used in row `format` strings and Search result templates.
 	- `{$api:resource}` — API-backed client source.
 	- `{$local:resource}` — client-local source.
-- That catalog/API/local data is loaded separately via JSON-RPC `get` (`service` / `resource`) or client-specific local/API handlers; routing and persistence are described in [`api/README`](../../api/README.md). `evy` catalog data uses [`types/schema/data/data.schema.json`](../../../types/schema/data/data.schema.json); marketplace resources are served by the marketplace worker ([`services/marketplace`](../../services/marketplace/README.md)). Clients merge loaded data with flow state when rendering rows (e.g. Dropdown, InlinePicker, Search, InputList).
+- Catalog/API/local data is loaded outside the flow document. Clients can request individual lists with JSON-RPC `get` (`service` / `resource`) or sync service data in batches with `syncServiceData`.
+- `syncServiceData` accepts `{ "service": "marketplace", "lastSyncTime": "ISO-8601 timestamp" }` and returns changed resource arrays as `{ service, resource, value }` rows. Clients should store synced rows under service-qualified keys such as `marketplace:items` and `marketplace:conditions`.
+- Flow bindings use the resource name without the service prefix (`{items}`, `{conditions}`, `{tags}`). The client data layer resolves those bindings to synced service data when no exact local key exists. Exact local keys still take precedence for drafts and flow state.
+- `evy` catalog data uses [`types/schema/data/data.schema.json`](../../../types/schema/data/data.schema.json); marketplace resources are served by the marketplace worker ([`services/marketplace`](../../services/marketplace/README.md)). Routing and persistence are described in [`api/README`](../../api/README.md). Clients merge loaded data with flow state when rendering rows (e.g. Dropdown, InlinePicker, Search, InputList).
 
 So a flow might reference “10 min, 20 min, 30 min” options via `source: "{durations}"` while the selected value is still written to a field via `destination`; the actual list of options lives in the data layer the app fetches, not inside the flow document.
 

--- a/docs/evy/sdui/readme.md
+++ b/docs/evy/sdui/readme.md
@@ -8,11 +8,15 @@ UI flows (`UI_Flow`) only describe structure: `id`, `name`, and `pages`. Referen
 
 - Each row declares a required **`source`** string at the row root (next to `destination`) describing where the row **reads** data from when rendering or editing:
 	- `"{item}"` — bind to the current flow entity / draft (e.g. listing fields, `{formatWeight(weight)}`, `{item.title}`).
-	- `"{conditions}"`, `"{selling_reasons}"`, `"{durations}"`, `"{areas}"`, `"{tags}"` — catalog or in-memory keys the client resolves to option lists.
-	- `"{api:tags}"` — remote search / API-backed data.
-	- `"local:address"` — client-local data source.
+	- `"{conditions}"`, `"{selling_reasons}"`, `"{durations}"`, `"{areas}"`, `"{tags}"` — backend/catalog or in-memory keys the client resolves to option lists.
+	- `"{$api:tags}"` — remote search / API-backed client source.
+	- `"{$local:address}"` — client-local source.
 	- `""` — no external read binding (e.g. pure navigation buttons, static Info).
-- That catalog/API/local data is loaded separately via JSON-RPC `get` (`service` / `resource`); routing and persistence are described in [`api/README`](../../api/README.md). `evy` catalog data uses [`types/schema/data/data.schema.json`](../../../types/schema/data/data.schema.json); marketplace resources are served by the marketplace worker ([`services/marketplace`](../../services/marketplace/README.md)). Clients merge loaded data with flow state when rendering rows (e.g. Dropdown, InlinePicker, Search, InputList).
+- Braced `{...}` expressions are used for all SDUI bindings. Prefixed `{$...:...}` bindings identify data that does not belong to backend flow state:
+	- `{$datum:value}` — current list/search result item field, used in row `format` strings and Search result templates.
+	- `{$api:resource}` — API-backed client source.
+	- `{$local:resource}` — client-local source.
+- That catalog/API/local data is loaded separately via JSON-RPC `get` (`service` / `resource`) or client-specific local/API handlers; routing and persistence are described in [`api/README`](../../api/README.md). `evy` catalog data uses [`types/schema/data/data.schema.json`](../../../types/schema/data/data.schema.json); marketplace resources are served by the marketplace worker ([`services/marketplace`](../../services/marketplace/README.md)). Clients merge loaded data with flow state when rendering rows (e.g. Dropdown, InlinePicker, Search, InputList).
 
 So a flow might reference “10 min, 20 min, 30 min” options via `source: "{durations}"` while the selected value is still written to a field via `destination`; the actual list of options lives in the data layer the app fetches, not inside the flow document.
 
@@ -187,6 +191,6 @@ Row types are defined in the schema (`types/schema/sdui/evy.schema.json`) and th
 
 Each row type’s `view.content` may include type-specific keys (e.g. `label`, `value`, `placeholder`, `format`, `child`, `children`). See `row-content.spec.json` for the exact keys per type.
 
-For list-backed rows (Dropdown, InlinePicker, InputList, etc.), `format` is evaluated per item from the list resolved via `source`. Use `datum` as the placeholder for the current item in expressions, e.g. `{datum.value}` or `{datum.unit} {datum.street}, {datum.city}`.
+For list-backed rows (Dropdown, InlinePicker, InputList, etc.), `format` is evaluated per item from the list resolved via `source`. Use `{$datum:...}` as the placeholder for the current item, e.g. `{$datum:value}` or `{$datum:unit} {$datum:street}, {$datum:city}`.
 
-For **Search** rows, iOS renders each hit using `view.content.child` (typically an `Info` row template) instead of `format`; string fields in that child row are evaluated with `datum` the same way. The web builder’s Search row stub does not render live results.
+For **Search** rows, iOS renders each hit using `view.content.child` (typically an `Info` row template) instead of `format`; string fields in that child row are evaluated with `{$datum:...}` the same way. The web builder’s Search row stub does not render live results.

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -105,7 +105,7 @@
 							"content": {
 								"title": "Condition",
 								"placeholder": "Choose one",
-								"format": "{datum.value}"
+								"format": "{$datum:value}"
 							}
 						}
 					},
@@ -119,7 +119,7 @@
 							"content": {
 								"title": "Selling Reason",
 								"placeholder": "Choose one",
-								"format": "{datum.value}"
+								"format": "{$datum:value}"
 							}
 						}
 					},
@@ -198,7 +198,7 @@
 										"content": {
 											"title": "Tags",
 											"placeholder": "Search for tags",
-											"format": "{datum.value}"
+											"format": "{$datum:value}"
 										}
 									}
 								},
@@ -206,7 +206,7 @@
 									{
 										"id": "8f8c442e-ee2d-4974-9ef1-29005f3311e6",
 										"type": "Search",
-										"source": "{api:tags}",
+										"source": "{$api:tags}",
 										"destination": "{tags}",
 										"actions": [],
 										"view": {
@@ -221,7 +221,7 @@
 													"actions": [],
 													"view": {
 														"content": {
-															"title": "{datum.value}",
+															"title": "{$datum:value}",
 															"subtitle": "",
 															"icon": ""
 														}
@@ -396,7 +396,7 @@
 																	{
 																		"id": "22222222-2222-4222-8222-222222222205",
 																		"type": "Search",
-																		"source": "local:address",
+																		"source": "{$local:address}",
 																		"destination": "{address}",
 																		"actions": [],
 																		"view": {
@@ -411,7 +411,7 @@
 																					"actions": [],
 																					"view": {
 																						"content": {
-																							"title": "{datum.unit} {datum.street}, {datum.city} {datum.state} {datum.postcode}",
+																							"title": "{$datum:unit} {$datum:street}, {$datum:city} {$datum:state} {$datum:postcode}",
 																							"subtitle": "",
 																							"icon": ""
 																						}
@@ -531,7 +531,7 @@
 														"view": {
 															"content": {
 																"title": "",
-																"format": "{datum.value}"
+																"format": "{$datum:value}"
 															}
 														}
 													},
@@ -628,7 +628,7 @@
 														"view": {
 															"content": {
 																"title": "",
-																"format": "{datum.value}"
+																"format": "{$datum:value}"
 															}
 														}
 													},

--- a/ios/README.md
+++ b/ios/README.md
@@ -6,6 +6,12 @@ For local and e2e runs, set `API_HOST` in the repository root `.env` (see [READM
 
 **Types:** Schema and codegen are documented in [`docs/evy/types.md`](../docs/evy/types.md) and [`docs/evy/sdui/readme.md`](../docs/evy/sdui/readme.md). Run `bun run types:generate` from the repo root after cloning or schema changes ([Shared type system](../README.md#shared-type-system)). Generated Swift under `types/generated/swift/` is not committed; the app also keeps hand-written `Codable` models (e.g. `EVYFlow`, `EVYPage`, `EVYRow`, `EVYWebsocket`) aligned with `types/schema/`.
 
+### Synced service data
+
+At startup, the app calls `syncServiceData` for supported backend services and stores each returned resource under a service-qualified key: `<service>:<resource>` (for example, `marketplace:items` or `marketplace:conditions`). Exact keys are preferred when app code needs a specific backend resource.
+
+SDUI bindings may still use resource-only names such as `{conditions}` or `{timeslots}`. Those bindings resolve exact local keys first, then explicitly fall back to synced service resources. This keeps local draft/entity data separate from backend catalog data while preserving simple SDUI source strings.
+
 ### Architecture
 
 ```mermaid

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -420,6 +420,7 @@ final class WebSocketE2ETests: E2ETestBase {
                         [
                             "id": "e0fc5df1-b4bf-4996-87f4-f2b0f3c2a0be",
                             "type": "Input",
+                            "source": "{item}",
                             "view": [
                                 "content": [
                                     "title": "Title",
@@ -433,6 +434,7 @@ final class WebSocketE2ETests: E2ETestBase {
                         [
                             "id": "668aeb79-d8ba-43b7-9619-07f91d0a1908",
                             "type": "Input",
+                            "source": "{item}",
                             "view": [
                                 "content": [
                                     "title": "Price",
@@ -446,6 +448,7 @@ final class WebSocketE2ETests: E2ETestBase {
                         [
                             "id": "2a9b22a0-b0eb-4648-83ca-77b2b8748816",
                             "type": "Input",
+                            "source": "{item}",
                             "view": [
                                 "content": [
                                     "title": "Width",
@@ -460,6 +463,8 @@ final class WebSocketE2ETests: E2ETestBase {
                     "footer": [
                         "id": "1cb41189-6fa5-4562-996a-7cefb88a08ca",
                         "type": "Button",
+                        "source": "{item}",
+                        "destination": "",
                         "view": [
                             "content": [
                                 "title": "",
@@ -518,6 +523,8 @@ final class WebSocketE2ETests: E2ETestBase {
                         [
                             "id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
                             "type": "ColumnContainer",
+                            "source": "",
+                            "destination": "",
                             "actions": [],
                             "view": [
                                 "content": [
@@ -526,6 +533,8 @@ final class WebSocketE2ETests: E2ETestBase {
                                         [
                                             "id": "441c1433-446b-4682-854d-5d795ef52709",
                                             "type": "Button",
+                                            "source": "",
+                                            "destination": "",
                                             "view": [
                                                 "content": [
                                                     "title": "",
@@ -541,6 +550,8 @@ final class WebSocketE2ETests: E2ETestBase {
                                         [
                                             "id": "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
                                             "type": "Button",
+                                            "source": "",
+                                            "destination": "",
                                             "view": [
                                                 "content": [
                                                     "title": "",
@@ -624,4 +635,3 @@ final class E2EErrorStateTests: XCTestCase {
         )
     }
 }
-

--- a/ios/evy/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/evy/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,11 +1,11 @@
 {
-  "colors" : [
-    {
-      "idiom" : "universal"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"colors": [
+		{
+			"idiom": "universal"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/evy/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,14 +1,14 @@
 {
-  "images" : [
-    {
-      "filename" : "AppIcon.png",
-      "idiom" : "universal",
-      "platform" : "ios",
-      "size" : "1024x1024"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "AppIcon.png",
+			"idiom": "universal",
+			"platform": "ios",
+			"size": "1024x1024"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/Contents.json
+++ b/ios/evy/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/condition.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/condition.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "conditions.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "conditions.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/delivery.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/delivery.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "delivery.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "delivery.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/dimensions.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/dimensions.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "dimensions.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "dimensions.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/lock.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/lock.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "lock.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "lock.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/logo.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/logo.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "logo.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "logo.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/pickup.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/pickup.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "pickup.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "pickup.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/printer.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/printer.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "printer.jpg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "printer.jpg",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/printer_logo.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/printer_logo.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "printer_logo.jpg",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "printer_logo.jpg",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/Assets.xcassets/reason.imageset/Contents.json
+++ b/ios/evy/Assets.xcassets/reason.imageset/Contents.json
@@ -1,21 +1,21 @@
 {
-  "images" : [
-    {
-      "filename" : "reason.png",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
-    }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"images": [
+		{
+			"filename": "reason.png",
+			"idiom": "universal",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"scale": "3x"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/ContentView.swift
+++ b/ios/evy/ContentView.swift
@@ -41,13 +41,13 @@ struct ContentView: View {
 	@State private var loading = true
     @State private var itemData: Data?
     @State private var activeDraftKeys: Set<String> = []
-    
+
     private func showError(_ error: Error) {
 		alertTitle = "Error"
         alertMessage = error.localizedDescription
         showingAlert = true
     }
-    
+
     private func handleNavigationData(_ navOperation: NavOperation, _ currentFlowId: String) {
         switch navOperation {
         case .navigate(let route):
@@ -56,11 +56,11 @@ struct ContentView: View {
 			} else {
 				routes.append(route)
 			}
-            
+
             if currentFlowId == route.flowId {
                 break
             }
-            
+
             guard let newFlow = flows.first(where: { $0.id == route.flowId }) else {
 				alertTitle = "Unable to load flow"
                 alertMessage = "Please check your internet connection"
@@ -68,7 +68,7 @@ struct ContentView: View {
                 routes.removeLast()
                 break
             }
-            
+
             let createKeys = Self.extractCreateKeys(from: newFlow)
             for key in createKeys {
                 guard let itemData = itemData else {
@@ -87,7 +87,7 @@ struct ContentView: View {
                     showError(error)
                 }
             }
-            
+
         case .create(let key):
             createFlow(currentFlowId: currentFlowId, key: key)
 
@@ -95,7 +95,7 @@ struct ContentView: View {
 			alertTitle = "Missing information"
             alertMessage = "\(fieldName) is required"
             showingAlert = true
-            
+
         case .close:
 			if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
                 routes.removeSubrange(existing...)
@@ -104,7 +104,7 @@ struct ContentView: View {
             }
         }
     }
-    
+
     private func createFlow(currentFlowId: String, key: String) {
         do {
             let draftScope = EVYDraft.createMergeScopeId(flowId: currentFlowId, entityKey: key)
@@ -122,7 +122,7 @@ struct ContentView: View {
             routes.removeAll()
         }
     }
-    
+
     @ViewBuilder
     private var homeContent: some View {
         if loading {
@@ -156,16 +156,17 @@ struct ContentView: View {
             .accessibilityIdentifier("errorState")
         }
     }
-    
+
     var body: some View {
         NavigationStack(path: $routes) {
             homeContent
                 .task {
                     if !flows.isEmpty { return }
-                    
+
                     do {
                         try EVY.getUserData()
-                        itemData = try await EVY.getData()
+                        try await EVY.syncAllServices()
+                        itemData = try EVY.getItemData()
                         flows = try await EVY.getSDUI()
                         loading = false
                     } catch let error as EVYRPCError {
@@ -202,7 +203,7 @@ struct ContentView: View {
         .onChange(of: routes) { _, _ in
             let previousFlowId = currentFlowId
             let newFlowId = routes.last?.flowId ?? HOME_FLOW_ID
-            
+
             if newFlowId != previousFlowId {
                 let keysToDelete = Self.createKeysToDelete(
                     whenLeaving: previousFlowId,
@@ -229,7 +230,7 @@ struct ContentView: View {
                     activeDraftKeys.subtract(keysToDelete)
                 }
             }
-            
+
             currentFlowId = newFlowId
         }
         .onReceive(NotificationCenter.default.publisher(for: .evyFlowUpdated)) { notification in
@@ -250,7 +251,7 @@ struct ContentView: View {
             }
         }
     }
-    
+
     static func draftScopeId(for route: Route, flows: [UI_Flow]) -> String? {
         guard let flow = flows.first(where: { $0.id == route.flowId }) else { return nil }
         let keys = extractCreateKeys(from: flow)
@@ -270,7 +271,7 @@ struct ContentView: View {
         }
         return extractCreateKeys(from: flow).intersection(activeDraftKeys)
     }
-    
+
     private static func extractCreateKeys(from flow: UI_Flow) -> Set<String> {
         var keys = Set<String>()
         for page in flow.pages {

--- a/ios/evy/Data/EVYDataManager.swift
+++ b/ios/evy/Data/EVYDataManager.swift
@@ -117,17 +117,26 @@ final class EVYDataManager {
 
     func get(key: String) throws -> EVYData {
         let descriptor = FetchDescriptor<EVYData>(predicate: #Predicate { $0.key == key })
-        if let first = try context.fetch(descriptor).first {
-            return first
+        guard let first = try context.fetch(descriptor).first else {
+            throw EVYDataError.keyNotFound
         }
+        return first
+    }
 
-        let suffix = ":\(key)"
-        let fallbackDescriptor = FetchDescriptor<EVYData>()
-        if let first = try context.fetch(fallbackDescriptor).first(where: { $0.key.hasSuffix(suffix) }) {
-            return first
+    func getForBinding(key: String) throws -> EVYData {
+        if let exact = try? get(key: key) {
+            return exact
         }
+        return try getSyncedResource(resource: key)
+    }
 
-        throw EVYDataError.keyNotFound
+    private func getSyncedResource(resource: String) throws -> EVYData {
+        let suffix = ":\(resource)"
+        let descriptor = FetchDescriptor<EVYData>()
+        guard let first = try context.fetch(descriptor).first(where: { $0.key.hasSuffix(suffix) }) else {
+            throw EVYDataError.keyNotFound
+        }
+        return first
     }
 
     func create(key: String, data: Data) throws {

--- a/ios/evy/Data/EVYDataManager.swift
+++ b/ios/evy/Data/EVYDataManager.swift
@@ -51,9 +51,7 @@ extension Notification.Name {
     var value: T {
         get { _value }
         set {
-            if _value != newValue {
-                _value = newValue
-            }
+            if _value != newValue { _value = newValue }
         }
     }
 
@@ -92,9 +90,7 @@ extension Notification.Name {
                 let minLen = min(watchSegments.count, notifSegments.count)
                 let prefixMatch = Array(watchSegments.prefix(minLen)) == Array(notifSegments.prefix(minLen))
 
-                if prefixMatch {
-                    self?.value = setter(watch)
-                }
+                if prefixMatch { self?.value = setter(watch) }
             }
         }
     }
@@ -113,25 +109,25 @@ final class EVYDataManager {
 
     var activeDraftScopeId: String?
 
-    init() {
-        self.context = ModelContext(container)
-    }
+    init() { self.context = ModelContext(container) }
 
     func exists(key: String) -> Bool {
-        let descriptor = FetchDescriptor<EVYData>(predicate: #Predicate { $0.key == key })
-        do {
-            return try context.fetchCount(descriptor) > 0
-        } catch {
-            return false
-        }
+        (try? get(key: key)) != nil
     }
 
     func get(key: String) throws -> EVYData {
         let descriptor = FetchDescriptor<EVYData>(predicate: #Predicate { $0.key == key })
-        guard let first = try context.fetch(descriptor).first else {
-            throw EVYDataError.keyNotFound
+        if let first = try context.fetch(descriptor).first {
+            return first
         }
-        return first
+
+        let suffix = ":\(key)"
+        let fallbackDescriptor = FetchDescriptor<EVYData>()
+        if let first = try context.fetch(fallbackDescriptor).first(where: { $0.key.hasSuffix(suffix) }) {
+            return first
+        }
+
+        throw EVYDataError.keyNotFound
     }
 
     func create(key: String, data: Data) throws {
@@ -142,6 +138,27 @@ final class EVYDataManager {
 
         NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
                                         object: key)
+    }
+
+    func upsert(key: String, value: Data) throws {
+        let nowIso = Date().ISO8601Format()
+
+        if let existing = try? get(key: key) {
+            existing.data = value
+            existing.lastSyncedAt = nowIso
+        } else {
+            context.insert(EVYData(key: key, lastSyncedAt: nowIso, data: value))
+        }
+
+        NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
+                                        object: key)
+
+        if let resourceKey = key.split(separator: ":").last.map(String.init),
+           resourceKey != key
+        {
+            NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
+                                            object: resourceKey)
+        }
     }
 
     func update(props: [String], data: Data) throws {

--- a/ios/evy/Data/EVYSearchController.swift
+++ b/ios/evy/Data/EVYSearchController.swift
@@ -55,6 +55,58 @@ private final class SearchTemplateFormatPrep {
         "title", "subtitle", "text", "label", "placeholder", "value",
     ]
 
+    private static let datumReferenceRegex = try! NSRegularExpression(
+        pattern: #"\{\$datum:([A-Za-z0-9_.-]+)\}"#
+    )
+
+    private static func datumValue(path: String, datum: EVYJson) -> String {
+        let pathSegments = path.split(separator: ".").map(String.init)
+        if pathSegments.isEmpty {
+            return datum.toString()
+        }
+
+        var currentValue = datum
+        for pathSegment in pathSegments {
+            switch currentValue {
+            case let .dictionary(dictionaryValue):
+                guard let nextValue = dictionaryValue[pathSegment] else {
+                    return ""
+                }
+                currentValue = nextValue
+            case let .array(arrayValue):
+                guard let index = Int(pathSegment), arrayValue.indices.contains(index) else {
+                    return ""
+                }
+                currentValue = arrayValue[index]
+            default:
+                return ""
+            }
+        }
+
+        return currentValue.toString()
+    }
+
+    private static func formatDatumReferences(_ template: String, datum: EVYJson) -> String {
+        var formattedTemplate = template
+        let templateRange = NSRange(template.startIndex..., in: template)
+        let matches = datumReferenceRegex.matches(in: template, range: templateRange)
+
+        for match in matches.reversed() {
+            guard let fullRange = Range(match.range, in: formattedTemplate),
+                  let pathRange = Range(match.range(at: 1), in: formattedTemplate) else {
+                continue
+            }
+
+            let path = String(formattedTemplate[pathRange])
+            formattedTemplate.replaceSubrange(
+                fullRange,
+                with: datumValue(path: path, datum: datum)
+            )
+        }
+
+        return formattedTemplate
+    }
+
     init(template: UI_Row) throws {
         let data = try JSONEncoder().encode(template)
         guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -71,7 +123,7 @@ private final class SearchTemplateFormatPrep {
         }
         for key in Array(content.keys) {
             if let raw = content[key] as? String {
-                content[key] = try EVY.formatData(json: datum, format: raw)
+                content[key] = Self.formatDatumReferences(raw, datum: datum)
             }
         }
         let value = Self.displayKeys
@@ -91,8 +143,9 @@ enum EVYSearchFormattingError: Error {
 
 @MainActor
 class EVYSearchController: ObservableObject {
+    private static let apiSourcePrefix = "$api:"
+
     private let sourceType: EVYSearchSourceType
-    private let source: String
     private let resultTemplate: UI_Row?
 
     private var cachedFormatPrep: SearchTemplateFormatPrep?
@@ -101,18 +154,25 @@ class EVYSearchController: ObservableObject {
 
     init(source: String, resultTemplate: UI_Row?) {
         self.resultTemplate = resultTemplate
+        sourceType = Self.searchSourceType(for: source)
+    }
 
-        let sourceProps = EVY.parsePropsFromText(source)
-        if sourceProps.hasPrefix("api:") {
-            sourceType = .api
-            self.source = String(source.dropFirst(4))
-        } else if sourceProps.hasPrefix("local:") {
-            sourceType = .local
-            self.source = String(source.dropFirst(6))
-        } else {
-            sourceType = .local
-            self.source = source
+    private static func searchSourceType(for source: String) -> EVYSearchSourceType {
+        guard let binding = bracedBinding(from: source),
+              binding.hasPrefix(apiSourcePrefix) else {
+            return .local
         }
+        return .api
+    }
+
+    private static func bracedBinding(from source: String) -> String? {
+        let normalizedSource = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sourceProps = EVY.parsePropsFromText(normalizedSource)
+        guard normalizedSource == "{\(sourceProps)}" else {
+            return nil
+        }
+
+        return sourceProps
     }
 
     private func loadFormatPrep() throws -> SearchTemplateFormatPrep {
@@ -198,8 +258,8 @@ class EVYSearchController: ObservableObject {
             "actions": [],
             "view": {
                 "content": {
-                    "title": "{datum.unit} {datum.street}",
-                    "subtitle": "{datum.city} {datum.state} {datum.postcode}",
+                    "title": "{$datum:unit} {$datum:street}",
+                    "subtitle": "{$datum:city} {$datum:state} {$datum:postcode}",
                     "icon": ""
                 }
             }
@@ -210,7 +270,7 @@ class EVYSearchController: ObservableObject {
             from: Data(templateJson.utf8),
         )
         return EVYSearch(
-            source: "local:address",
+            source: "{$local:address}",
             destination: "{tags}",
             placeholder: "Search",
             resultTemplate: template

--- a/ios/evy/Data/EVYSearchController.swift
+++ b/ios/evy/Data/EVYSearchController.swift
@@ -221,9 +221,6 @@ class EVYSearchController: ObservableObject {
                 let json = try EVY.getDataFromProps(id.uuidString)
                 results = [try makeSearchResult(datum: json)]
             } catch {
-                #if DEBUG
-                print("[EVYSearchController] Error in local search: \(error)")
-                #endif
                 results = []
             }
         default:
@@ -232,9 +229,6 @@ class EVYSearchController: ObservableObject {
                 let response = try JSONDecoder().decode([EVYJson].self, from: data)
                 results = try response.map { try makeSearchResult(datum: $0) }
             } catch {
-                #if DEBUG
-                print("[EVYSearchController] Error in API search: \(error)")
-                #endif
                 results = []
             }
         }

--- a/ios/evy/Data/Models/EVYData.swift
+++ b/ios/evy/Data/Models/EVYData.swift
@@ -18,13 +18,13 @@ struct EVYValue: Equatable {
     var value: String
     var prefix: String?
     var suffix: String?
-    
+
     init(_ value: String, _ prefix: String?, _ suffix: String?) {
         self.value = value
         self.prefix = prefix
         self.suffix = suffix
     }
-    
+
     func toString() -> String {
         return "\(prefix ?? "")\(value)\(suffix ?? "")"
     }
@@ -33,34 +33,36 @@ struct EVYValue: Equatable {
 @Model
 class EVYData {
     var key: String
+    var lastSyncedAt: String
     var data: Data
-    
-    init(key: String, data: Data) {
+
+    init(key: String, lastSyncedAt: String = "", data: Data) {
         self.key = key
+        self.lastSyncedAt = lastSyncedAt
         self.data = data
     }
-    
+
     func decoded() throws -> EVYJson {
         try JSONDecoder().decode(EVYJson.self, from: data)
     }
-    
+
     func updateDataWithData(_ data: Data, props: [String]) throws {
         if props.count < 1 {
             return
         }
-        
+
         let currentDataAsJson = try decoded()
         let newDataAsJson = try JSONDecoder().decode(EVYJson.self, from: data)
-        
+
         let updatedJson = try getUpdatedJson(props: props, data: currentDataAsJson, value: newDataAsJson)
         self.data = try JSONEncoder().encode(updatedJson)
     }
-    
+
     private func getUpdatedJson(props: [String], data: EVYJson, value: EVYJson) throws -> EVYJson {
         if props.count < 1 {
             return data
         }
-        
+
         switch data {
         case var .dictionary(dictValue):
             guard let firstProp = props.first else {
@@ -117,22 +119,22 @@ public enum EVYJson: Codable, Hashable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        
+
         if let stringValue = try? container.decode(String.self) {
             self = .string(stringValue)
             return
         }
-        
+
         if let intValue = try? container.decode(Int.self) {
             self = .int(intValue)
             return
         }
-		
+
 		if let decimalValue = try? container.decode(Decimal.self) {
 			self = .decimal(decimalValue)
 			return
 		}
-        
+
         if let boolValue = try? container.decode(Bool.self) {
             self = .bool(boolValue)
             return
@@ -150,7 +152,7 @@ public enum EVYJson: Codable, Hashable {
 
         throw EVYDataParseError.unprocessableValue
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -168,10 +170,10 @@ public enum EVYJson: Codable, Hashable {
             try container.encode(jsonData)
         }
     }
-    
+
     public func toString() -> String {
         let encoder = JSONEncoder()
-        
+
         switch self {
         case let .string(stringValue):
             return stringValue
@@ -199,7 +201,7 @@ public enum EVYJson: Codable, Hashable {
             return string
         }
     }
-    
+
     @MainActor
     public func identifierValue() -> String {
         switch self {
@@ -209,13 +211,13 @@ public enum EVYJson: Codable, Hashable {
             return toString()
         }
     }
-    
+
     @MainActor
     public func parseProp(props: [String]) -> EVYJson {
         if props.count < 1 {
             return self
         }
-        
+
         switch self {
         case let .dictionary(dictValue):
             guard let firstVariable = props.first else {
@@ -227,7 +229,7 @@ public enum EVYJson: Codable, Hashable {
             if props.count == 1 {
                 return parseIdOrIds(props: props, value: subData)
             }
-            
+
             return subData.parseProp(props: Array(props[1...]))
         case let .array(arrayValue):
             guard let firstVariable = props.first else {
@@ -236,7 +238,7 @@ public enum EVYJson: Codable, Hashable {
             guard let index = Int(firstVariable) else {
                 return self
             }
-            
+
             let subData = arrayValue[index]
             if props.count == 1 {
                 return parseIdOrIds(props: props, value: subData)
@@ -246,26 +248,26 @@ public enum EVYJson: Codable, Hashable {
             return parseIdOrIds(props: props, value: self)
         }
     }
-    
+
     @MainActor
     private func parseIdOrIds(props: [String], value: EVYJson) -> EVYJson {
         let key = props.first!
-        
+
         if !key.hasSuffix("_id") && !key.hasSuffix("_ids") {
             return value
         }
-        
+
         var inputValues: [String] = []
         if case let .array(arrayValue) = value {
             inputValues.append(contentsOf: arrayValue.map { $0.toString() })
         } else if case .string(_) = value {
             inputValues.append(value.toString())
         }
-        
+
         if inputValues.isEmpty {
             return value
         }
-        
+
         do {
             if key.hasSuffix("_ids") {
                 let data = try EVY.getDataFromProps(String(key.dropLast(4) + "s"))
@@ -307,7 +309,7 @@ public enum EVYJson: Codable, Hashable {
                 object: error
             )
         }
-        
+
         return value
     }
 }

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -22,10 +22,25 @@ struct Filter: Encodable {
 	let id: String?
 }
 
+struct SyncServiceDataParams: Encodable {
+	let service: String
+	let lastSyncTime: String
+}
+
+struct SyncedServiceDataRow: Codable {
+	let service: String
+	let resource: String
+	let value: EVYJson
+}
+
+struct SyncServiceDataResponse: Codable {
+	let data: [SyncedServiceDataRow]
+}
+
 @MainActor
 struct EVY {
     static let data = EVYDataManager()
-	
+
 	static func getUserData() throws {
 		let userData = try EVYJson.from(localJSON: "user_data")
 		let encodedUserData = try JSONEncoder().encode(userData)
@@ -34,59 +49,65 @@ struct EVY {
 		} catch EVYDataError.keyAlreadyExists {
 		}
 	}
-	
-	private static func fetchResource(_ resource: String, service: String) async throws -> [EVYJson] {
-		try await EVYAPIManager.shared.fetch(
-			method: "get",
-			params: GetParams(service: service, resource: resource, filter: nil),
-			expecting: [EVYJson].self
-		)
+
+	private static func upsertSyncedData(key: String, data encodedData: Data) throws {
+		try EVY.data.upsert(key: key, value: encodedData)
 	}
 
-	private static func storeIfNew(key: String, from serviceData: EVYJson) throws {
-		do {
-			let encoded = try JSONEncoder().encode(serviceData.parseProp(props: [key]))
-			try data.create(key: key, data: encoded)
-		} catch EVYDataError.keyAlreadyExists {
-		} catch {
-			throw error
+	static func syncServiceData(service: String) async throws {
+		let params = SyncServiceDataParams(
+			service: service,
+			lastSyncTime: "1970-01-01T00:00:00.000Z"
+		)
+		let response = try await EVYAPIManager.shared.fetch(
+			method: "syncServiceData",
+			params: params,
+			expecting: SyncServiceDataResponse.self
+		)
+
+		for row in response.data {
+			let key = "\(row.service):\(row.resource)"
+			let encoded = try JSONEncoder().encode(row.value)
+			try upsertSyncedData(key: key, data: encoded)
 		}
+	}
+
+	static func syncAllServices() async throws {
+		let services = ["marketplace"]
+		for service in services {
+			try await syncServiceData(service: service)
+		}
+	}
+
+	static func getItemData() throws -> Data {
+		let itemsData = try EVY.data.get(key: "marketplace:items")
+		let items = try itemsData.decoded()
+		if case .array(let arr) = items, let first = arr.first {
+			return try JSONEncoder().encode(first)
+		}
+		return try JSONEncoder().encode(EVYJson.dictionary([:]))
 	}
 
 	static func getData() async throws -> Data {
-		let resources = ["selling_reasons", "conditions", "durations", "areas", "timeslots"]
-		var serviceDict: [String: EVYJson] = [:]
-		for resource in resources {
-			serviceDict[resource] = .array(try await fetchResource(resource, service: "marketplace"))
-		}
-
-		let itemsJson = try await fetchResource("items", service: "marketplace")
-		serviceDict["item"] = itemsJson.first ?? .dictionary([:])
-
-		let serviceData: EVYJson = .dictionary(serviceDict)
-
-		for resource in resources {
-			try storeIfNew(key: resource, from: serviceData)
-		}
-
-		return try JSONEncoder().encode(serviceData.parseProp(props: ["item"]))
+		try await syncAllServices()
+		return try getItemData()
 	}
-	
+
 	static func getSDUI() async throws -> [UI_Flow] {
 		try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(service: "evy", resource: "sdui", filter: nil), expecting: [UI_Flow].self)
 	}
-	
+
 	static func createItem() async throws {
 		try EVY.data.create(key: "item", data: try await getData())
 	}
-	
+
 	static func getRow(_ props: [String]) async throws -> UI_Row {
 		try await createItem()
 		let flowData = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(service: "evy", resource: "sdui", filter: nil), expecting: EVYJson.self)
 		let rowData = try JSONEncoder().encode(flowData.parseProp(props: props))
 		return try JSONDecoder().decode(UI_Row.self, from: rowData)
 	}
-    
+
     static func getDataFromText(_ input: String) throws -> EVYJson {
         try _getDataFromText(input)
     }
@@ -121,7 +142,7 @@ struct EVY {
         }
         return try formatData(json: json, format: format)
     }
-    
+
     static func ensureDraftExists(
         variableName: String,
         initialData: Data? = nil,
@@ -204,7 +225,7 @@ struct EVY {
             }
         }
     }
-    
+
     static func updateValue(_ value: String, at: String, scopeId: String? = nil) throws {
         let destinationProps = _parsePropsFromText(at)
         if let (functionName, functionArgs) = parseFunctionCall(destinationProps) {
@@ -221,7 +242,7 @@ struct EVY {
         }
         try updateData("\"\(value)\"".data(using: .utf8)!, at: at, scopeId: scopeId)
     }
-    
+
     static func updateData(_ newData: Data, at: String, scopeId: String? = nil) throws {
         let variableName = _parsePropsFromText(at)
         let splitProps = try splitPropsFromText(variableName)
@@ -270,10 +291,10 @@ struct EVY {
 struct AsyncPreview<VisualContent: View, ViewData>: View {
 	var viewBuilder: (ViewData) -> VisualContent
 	var view: () async throws -> ViewData?
-	
+
 	@State private var viewData: ViewData?
 	@State private var error: Error?
-	
+
 	var body: some View {
 		safeView.task {
 			do {
@@ -283,7 +304,7 @@ struct AsyncPreview<VisualContent: View, ViewData>: View {
 			}
 		}
 	}
-	
+
 	@ViewBuilder
 	private var safeView: some View {
 		if let viewData {

--- a/ios/evy/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios/evy/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -76,7 +76,7 @@ private struct EVYPageBody: View {
             if row.type == .inlinePicker {
                 initialData = "[]".data(using: .utf8)
             } else if row.type == .calendar {
-                initialData = try? EVY.data.get(key: "timeslots").data
+                initialData = try? EVY.data.getForBinding(key: "timeslots").data
             } else {
                 initialData = nil
             }

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -66,8 +66,6 @@ private struct EVYPageBody: View {
     }
 
     /// Ensures a draft exists for each row `destination` binding in the active scope.
-    /// `row.source` describes where the row reads option/list data from (e.g. `{item}`, `{conditions}`, `local:address`);
-    /// it does not introduce a separate draft key — only `destination` does.
     @MainActor
     private func bootstrapDrafts(in page: UI_Page, scopeId: String?) {
         forEachRow(in: page) { row in
@@ -90,4 +88,3 @@ private struct EVYPageBody: View {
         }
     }
 }
-

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -33,11 +33,38 @@ struct EVYTextSelectRow: View, EVYRowProtocol {
 		})
 		let temporaryId = UUID().uuidString
 		let temporaryScopeId = EVYDraft.createMergeScopeId(flowId: "temporary", entityKey: temporaryId)
-		guard (try? EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)) != nil,
-		      let binding = try? EVY.data.draftBinding(fromParsedProps: temporaryId, scopeId: temporaryScopeId),
-		      let draft = EVY.data.draftIfPresent(binding: binding),
-		      let decoded = try? draft.decoded() else { return nil }
-		self.value = decoded
+
+		do {
+			try EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)
+		} catch {
+			#if DEBUG
+			print("[EVYTextSelectRow] Failed to store temporary value: \(error)")
+			#endif
+			return nil
+		}
+
+		guard let binding = try? EVY.data.draftBinding(fromParsedProps: temporaryId, scopeId: temporaryScopeId) else {
+			#if DEBUG
+			print("[EVYTextSelectRow] No draft binding found for '\(temporaryId)'")
+			#endif
+			return nil
+		}
+
+		guard let draft = EVY.data.draftIfPresent(binding: binding) else {
+			#if DEBUG
+			print("[EVYTextSelectRow] No draft present for binding '\(binding)'")
+			#endif
+			return nil
+		}
+
+		do {
+			self.value = try draft.decoded()
+		} catch {
+			#if DEBUG
+			print("[EVYTextSelectRow] Failed to decode draft: \(error)")
+			#endif
+			return nil
+		}
 	}
 
 	var body: some View {

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -25,9 +25,6 @@ struct EVYTextSelectRow: View, EVYRowProtocol {
 			do {
 				return try EVY.evaluateFromText($0)
 			} catch {
-				#if DEBUG
-				print("[EVYTextSelectRow] Error evaluating selection: \(error)")
-				#endif
 				return false
 			}
 		})

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -34,37 +34,11 @@ struct EVYTextSelectRow: View, EVYRowProtocol {
 		let temporaryId = UUID().uuidString
 		let temporaryScopeId = EVYDraft.createMergeScopeId(flowId: "temporary", entityKey: temporaryId)
 
-		do {
-			try EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)
-		} catch {
-			#if DEBUG
-			print("[EVYTextSelectRow] Failed to store temporary value: \(error)")
-			#endif
-			return nil
-		}
-
-		guard let binding = try? EVY.data.draftBinding(fromParsedProps: temporaryId, scopeId: temporaryScopeId) else {
-			#if DEBUG
-			print("[EVYTextSelectRow] No draft binding found for '\(temporaryId)'")
-			#endif
-			return nil
-		}
-
-		guard let draft = EVY.data.draftIfPresent(binding: binding) else {
-			#if DEBUG
-			print("[EVYTextSelectRow] No draft present for binding '\(binding)'")
-			#endif
-			return nil
-		}
-
-		do {
-			self.value = try draft.decoded()
-		} catch {
-			#if DEBUG
-			print("[EVYTextSelectRow] Failed to decode draft: \(error)")
-			#endif
-			return nil
-		}
+		guard (try? EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)) != nil,
+		      let binding = try? EVY.data.draftBinding(fromParsedProps: temporaryId, scopeId: temporaryScopeId),
+		      let draft = EVY.data.draftIfPresent(binding: binding),
+		      let decoded = try? draft.decoded() else { return nil }
+		self.value = decoded
 	}
 
 	var body: some View {

--- a/ios/evy/UI/Views/EVYCalendar.swift
+++ b/ios/evy/UI/Views/EVYCalendar.swift
@@ -358,7 +358,7 @@ private func getTimeslotsData(_ source: String) -> [EVYCalendarTimeslotData] {
 	} view: {
 		try! await EVY.createItem()
 
-		let timeslotsData = (try? EVY.data.get(key: "timeslots"))?.data
+		let timeslotsData = (try? EVY.data.getForBinding(key: "timeslots"))?.data
         let previewScopeId = EVYDraft.createMergeScopeId(flowId: "preview", entityKey: "timeslots")
         EVY.data.activeDraftScopeId = previewScopeId
 		EVY.ensureDraftExists(

--- a/ios/evy/UI/Views/EVYDropdown.swift
+++ b/ios/evy/UI/Views/EVYDropdown.swift
@@ -36,9 +36,6 @@ struct EVYDropdown: View {
                 loadedOptions = arrayValue
             }
         } catch {
-            #if DEBUG
-            print("[EVYDropdown] Error loading options: \(error)")
-            #endif
         }
         options = loadedOptions
 
@@ -53,9 +50,6 @@ struct EVYDropdown: View {
                 }
                 return try EVY.formatDataOrToString(json: value, format: format)
             } catch {
-                #if DEBUG
-                print("[EVYDropdown] Error formatting selection: \(error) for input \($0)")
-                #endif
                 return ""
             }
         })

--- a/ios/evy/UI/Views/EVYDropdown.swift
+++ b/ios/evy/UI/Views/EVYDropdown.swift
@@ -6,17 +6,17 @@
 //
 
 import SwiftUI
-    
+
 struct EVYDropdown: View {
     let title: String
     let destination: String
     let format: String
     let placeholder: String
-    
+
     private var options: [EVYJson] = []
     private var selection: EVYState<String>
     @State private var showSheet = false
-    
+
     init(title: String = "",
          placeholder: String = "",
          data: String,
@@ -27,9 +27,9 @@ struct EVYDropdown: View {
         self.destination = destination
         self.format = format
         self.placeholder = placeholder
-        
+
         var loadedOptions: [EVYJson] = []
-        
+
         do {
             let data = try EVY.getDataFromText(data)
             if case let .array(arrayValue) = data {
@@ -41,7 +41,7 @@ struct EVYDropdown: View {
             #endif
         }
         options = loadedOptions
-        
+
         selection = EVYState(watch: destination, setter: {
             do {
                 let value = try EVY.getDataFromText($0)
@@ -60,7 +60,7 @@ struct EVYDropdown: View {
             }
         })
     }
-    
+
     var body: some View {
         HStack {
             Button(action: { showSheet.toggle() }) {
@@ -109,12 +109,11 @@ struct EVYDropdown: View {
 	} view: {
 		try! EVY.getUserData()
 		try! await EVY.createItem()
-		
+
 		return EVYDropdown(title: "Dropdown",
 						   placeholder: "A placeholder",
 						   data: "{conditions}",
-						   format: "{$0.value}",
+						   format: "{$datum:value}",
 						   destination: "{condition}")
 	}
 }
-

--- a/ios/evy/UI/Views/EVYInlinePicker.swift
+++ b/ios/evy/UI/Views/EVYInlinePicker.swift
@@ -6,15 +6,15 @@
 //
 
 import SwiftUI
-    
+
 struct EVYInlinePicker: View {
     let title: String
     let format: String
     let destination: String
-    
+
     private var options: [EVYJson] = []
     private var selectedIdentifiers: EVYState<[String]>
-    
+
     init(title: String,
          data: String,
          format: String,
@@ -23,7 +23,7 @@ struct EVYInlinePicker: View {
         self.title = title
         self.format = format
         self.destination = destination
-        
+
         var loadedOptions: [EVYJson] = []
         do {
             let data = try EVY.getDataFromText(data)
@@ -36,7 +36,7 @@ struct EVYInlinePicker: View {
             #endif
         }
         options = loadedOptions
-        
+
         selectedIdentifiers = EVYState(watch: destination, setter: {
             do {
                 let selected = try EVY.getDataFromText($0)
@@ -53,7 +53,7 @@ struct EVYInlinePicker: View {
             return []
         })
     }
-    
+
     private func performAction(option: EVYJson) {
         let optionIdentifier = option.identifierValue()
         do {
@@ -71,7 +71,7 @@ struct EVYInlinePicker: View {
             #endif
         }
     }
-    
+
     var body: some View {
         HStack {
             ForEach(Array(options.enumerated()), id: \.offset) { _, option in
@@ -96,10 +96,10 @@ struct EVYInlinePicker: View {
 	} view: {
 		try! EVY.getUserData()
 		try! await EVY.createItem()
-		
+
 		return EVYInlinePicker(title: "Dropdown",
 							   data: "{durations}",
-							   format: "{$0.value}",
+							   format: "{$datum:value}",
 							   destination: "{duration}")
 	}
 }

--- a/ios/evy/UI/Views/EVYInputList.swift
+++ b/ios/evy/UI/Views/EVYInputList.swift
@@ -31,9 +31,6 @@ struct EVYInputList: View {
                     ]
                 }
             } catch {
-                #if DEBUG
-                print("[EVYInputList] Error formatting data: \(error) for input \($0)")
-                #endif
             }
 
             return []

--- a/ios/evy/UI/Views/EVYInputList.swift
+++ b/ios/evy/UI/Views/EVYInputList.swift
@@ -12,12 +12,12 @@ struct EVYInputList: View {
     let format: String
     var placeholder: String
     private var values: EVYState<[String]>
-    
+
     init(data: String, format: String, placeholder: String) {
         self.data = data
         self.format = format
         self.placeholder = placeholder
-        
+
         values = EVYState(watch: data, setter: {
             do {
                 let data = try EVY.getDataFromText($0)
@@ -35,11 +35,11 @@ struct EVYInputList: View {
                 print("[EVYInputList] Error formatting data: \(error) for input \($0)")
                 #endif
             }
-            
+
             return []
         })
     }
-    
+
     var body: some View {
         EVYTextField(input: "",
                      destination: "",
@@ -65,9 +65,9 @@ struct EVYInputList: View {
 		asyncView
 	} view: {
 		try! await EVY.createItem()
-		
+
 		return EVYInputList(data: "{tags}",
-							format: "{$0.value}",
+							format: "{$datum:value}",
 							placeholder: "Add tags to improve search")
 	}
 }

--- a/ios/evy/UI/Views/EVYSearchMultiple.swift
+++ b/ios/evy/UI/Views/EVYSearchMultiple.swift
@@ -152,7 +152,7 @@ struct EVYSearchMultiple: View {
         try! await EVY.createItem()
 
         return EVYSearch(
-            source: "{api:tags}",
+            source: "{$api:tags}",
             destination: "{tags}",
             placeholder: "Search",
             resultTemplate: nil,

--- a/ios/evy/UI/Views/EVYSearchSingle.swift
+++ b/ios/evy/UI/Views/EVYSearchSingle.swift
@@ -121,7 +121,7 @@ struct EVYSearchSingle: View {
     } view: {
         try! await EVY.createItem()
 
-        return EVYSearch(source: "{local:address}",
+        return EVYSearch(source: "{$local:address}",
 						 destination: "{address}",
 						 placeholder: "Search",
 						 resultTemplate: nil)

--- a/ios/evy/UI/Views/EVYSelectItem.swift
+++ b/ios/evy/UI/Views/EVYSelectItem.swift
@@ -82,9 +82,7 @@ struct EVYSelectItem: View {
                     return arrayValue.contains { $0.identifierValue() == valueId }
                 }
             } catch {
-                #if DEBUG
-                print("[EVYSelectItem] Error checking selection state: \(error)")
-                #endif
+                return false
             }
 
             return false

--- a/ios/evy/UI/Views/EVYSelectItem.swift
+++ b/ios/evy/UI/Views/EVYSelectItem.swift
@@ -25,9 +25,9 @@ struct EVYSelectItem: View {
     let target: EVYSelectItemTarget
     let textStyle: EVYTextStyle
     let onSelect: (() -> Void)?
-    
+
     private var selected: EVYState<Bool>
-    
+
     init(destination: String,
          value: EVYJson,
          format: String,
@@ -43,7 +43,7 @@ struct EVYSelectItem: View {
         self.target = target
         self.textStyle = textStyle
         self.onSelect = onSelect
-        
+
         selected = EVYState(watch: destination, setter: {
             do {
                 if target == .single_identifier {
@@ -86,11 +86,11 @@ struct EVYSelectItem: View {
                 print("[EVYSelectItem] Error checking selection state: \(error)")
                 #endif
             }
-            
+
             return false
         })
     }
-    
+
     var body: some View {
         HStack {
             let text = (try? EVY.formatDataOrToString(json: value, format: format))
@@ -126,7 +126,7 @@ struct EVYSelectItem: View {
                     guard case let .array(arrayValue) = existingData else {
                         return
                     }
-                    
+
                     if target == .multi_identifier {
                         let valueId = value.identifierValue()
                         var updatedData = arrayValue.filter {
@@ -161,7 +161,7 @@ struct EVYSelectItem: View {
                         try EVY.updateData(encoded, at: destination)
                     }
                 }
-                
+
                 onSelect?()
             } catch {
                 #if DEBUG
@@ -178,13 +178,13 @@ struct EVYSelectItem: View {
 	} view: {
 		try! EVY.getUserData()
 		try! await EVY.createItem()
-		
+
 		return Group {
 			let options = try! EVY.getDataFromText("{selling_reasons}")
 			switch options {
 			case let .array(arrayValue):
 				EVYSelectList(options: arrayValue,
-									 format: "{$0.value}",
+									 format: "{$datum:value}",
 									 destination: "{selling_reason}")
 			default:
 				Text("error")

--- a/ios/evy/UI/Views/EVYSelectList.swift
+++ b/ios/evy/UI/Views/EVYSelectList.swift
@@ -12,7 +12,7 @@ struct EVYSelectList: View {
     let format: String
     let destination: String
     @Environment(\.dismiss) private var dismiss
-    
+
     var body: some View {
         List {
             ForEach(Array(options.enumerated()), id: \.offset) { _, value in
@@ -38,13 +38,13 @@ struct EVYSelectList: View {
 	} view: {
 		try! EVY.getUserData()
 		try! await EVY.createItem()
-		
+
 		return Group {
 			let options = try! EVY.getDataFromText("{selling_reasons}")
 			switch options {
 			case let .array(arrayValue):
 				EVYSelectList(options: arrayValue,
-							  format: "{$0.value}",
+							  format: "{$datum:value}",
 							  destination: "{selling_reason}")
 			default:
 				Text("error")

--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -180,7 +180,7 @@ func _getDataFromProps(_ props: String) throws -> EVYJson {
     }
 
     let remainingProps = splitProps.count > 1 ? Array(splitProps[1...]) : []
-    let dataObj = try EVY.data.get(key: firstProp)
+    let dataObj = try EVY.data.getForBinding(key: firstProp)
     return try dataObj.decoded().parseProp(props: remainingProps)
 }
 

--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -221,9 +221,7 @@ func _formatData(json: EVYJson, format: String) throws -> String {
 
     let temporaryId = UUID().uuidString
     let formatWithNewData = format
-        .replacingOccurrences(of: "datum.", with: "\(temporaryId).")
-        .replacingOccurrences(of: ".datum", with: ".\(temporaryId)")
-        .replacingOccurrences(of: "(datum)", with: "(\(temporaryId))")
+        .replacingOccurrences(of: "$datum:", with: "\(temporaryId).")
 
     if formatWithNewData.isEmpty { return "" }
 

--- a/services/marketplace/src/data.ts
+++ b/services/marketplace/src/data.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, gt } from "drizzle-orm";
 import pluralize from "pluralize";
 
 import type {
@@ -52,6 +52,9 @@ async function marketplaceGetBody(params: GetRequest): Promise<GetResponse> {
 	const whereClauses = [eq(data.resource, singularResource)];
 	if (filter?.id) {
 		whereClauses.push(eq(data.id, filter.id));
+	}
+	if (filter?.updatedAfter) {
+		whereClauses.push(gt(data.updatedAt, filter.updatedAfter));
 	}
 
 	const rows = await db

--- a/services/marketplace/src/grpc.ts
+++ b/services/marketplace/src/grpc.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import * as grpc from "@grpc/grpc-js";
 import type { Client } from "@grpc/grpc-js";
 import * as protoLoader from "@grpc/proto-loader";
-import type { GetRequest, UpsertRequest } from "evy-types";
+import type { UpsertRequest } from "evy-types";
 
 import {
 	getForValidatedMarketplaceRequest,
@@ -103,7 +103,7 @@ function buildMarketplaceServiceHandlers(
 					{
 						service: string;
 						resource: string;
-						filter?: { id: string };
+						filter?: { id?: string; updated_after?: string };
 					},
 					{ result_json: string }
 				>,
@@ -112,10 +112,16 @@ function buildMarketplaceServiceHandlers(
 				void (async () => {
 					try {
 						const req = call.request;
-						const params: GetRequest = {
-							service: req.service as GetRequest["service"],
-							resource: req.resource as GetRequest["resource"],
-							filter: req.filter?.id ? { id: req.filter.id } : undefined,
+						const filter = {
+							...(req.filter?.id ? { id: req.filter.id } : {}),
+							...(req.filter?.updated_after
+								? { updatedAfter: req.filter.updated_after }
+								: {}),
+						};
+						const params = {
+							service: req.service,
+							resource: req.resource,
+							filter: Object.keys(filter).length > 0 ? filter : undefined,
 						};
 						validateStrictGetRequest(params);
 						const result = await getForValidatedMarketplaceRequest(params);
@@ -156,9 +162,9 @@ function buildMarketplaceServiceHandlers(
 							});
 							return;
 						}
-						const params: UpsertRequest = {
-							service: req.service as GetRequest["service"],
-							resource: req.resource as GetRequest["resource"],
+						const params = {
+							service: req.service,
+							resource: req.resource,
 							filter: req.filter?.id ? { id: req.filter.id } : undefined,
 							data,
 						};

--- a/services/marketplace/src/grpc.ts
+++ b/services/marketplace/src/grpc.ts
@@ -112,12 +112,10 @@ function buildMarketplaceServiceHandlers(
 				void (async () => {
 					try {
 						const req = call.request;
-						const filter = {
-							...(req.filter?.id ? { id: req.filter.id } : {}),
-							...(req.filter?.updated_after
-								? { updatedAfter: req.filter.updated_after }
-								: {}),
-						};
+						const filter: Record<string, string> = {};
+						if (req.filter?.id) filter.id = req.filter.id;
+						if (req.filter?.updated_after)
+							filter.updatedAfter = req.filter.updated_after;
 						const params = {
 							service: req.service,
 							resource: req.resource,

--- a/services/marketplace/src/tests/data.test.ts
+++ b/services/marketplace/src/tests/data.test.ts
@@ -63,6 +63,34 @@ describe("marketplace get/upsert", () => {
 		expect(result).toEqual([row]);
 	});
 
+	it("filters rows by updatedAfter", async () => {
+		const oldRow = { id: crypto.randomUUID(), value: "old" };
+		const newRow = { id: crypto.randomUUID(), value: "new" };
+
+		await testDb.insert(schema.data).values([
+			{
+				resource: "condition",
+				data: oldRow,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-01T00:00:00.000Z",
+			},
+			{
+				resource: "condition",
+				data: newRow,
+				createdAt: "2024-01-03T00:00:00.000Z",
+				updatedAt: "2024-01-03T00:00:00.000Z",
+			},
+		]);
+
+		const result = await get({
+			service: "marketplace",
+			resource: "conditions",
+			filter: { updatedAfter: "2024-01-02T00:00:00.000Z" },
+		});
+
+		expect(result).toEqual([newRow]);
+	});
+
 	it("uses filter.id as primary key when inserting a new row (client id)", async () => {
 		const clientId = crypto.randomUUID();
 		const payload = { id: clientId, title: "client-keyed" };

--- a/types/rpcRequestHelpers.ts
+++ b/types/rpcRequestHelpers.ts
@@ -1,11 +1,16 @@
 import type { GetRequest } from "./generated/ts/rpc/get.request";
+import type { SyncServiceDataRequest } from "./generated/ts/rpc/syncServiceData.request";
 import {
 	RESOURCES_BY_SERVICE,
 	RESOURCE_VALUES,
 	SERVICE_VALUES,
 } from "./generated/ts/rpc/get.request";
 import type { UpsertRequest } from "./generated/ts/rpc/upsert.request";
-import { validateGetRequest, validateUpsertRequest } from "./validators";
+import {
+	validateGetRequest,
+	validateSyncServiceDataRequest,
+	validateUpsertRequest,
+} from "./validators";
 
 type Service = GetRequest["service"];
 type Resource = GetRequest["resource"];
@@ -18,9 +23,18 @@ function isResource(v: unknown): v is Resource {
 	return typeof v === "string" && RESOURCE_VALUES.includes(v as Resource);
 }
 
-function isValidServiceResourcePair(service: Service, resource: Resource): boolean {
+function isValidServiceResourcePair(
+	service: Service,
+	resource: Resource,
+): boolean {
 	const allowed = RESOURCES_BY_SERVICE[service] as readonly string[];
 	return allowed.includes(resource);
+}
+
+function isSyncableService(
+	service: string,
+): service is Exclude<Service, "evy"> {
+	return isService(service) && service !== "evy";
 }
 
 /**
@@ -74,4 +88,22 @@ export function validateStrictUpsertRequest(
 		throw new Error("data is required and must be a non-null object");
 	}
 	validateUpsertRequest(params);
+}
+
+export function validateStrictSyncServiceDataRequest(
+	params: unknown,
+): asserts params is SyncServiceDataRequest {
+	if (params === null || typeof params !== "object") {
+		throw new Error("Params must be an object");
+	}
+	if (!("service" in params) || typeof params.service !== "string") {
+		throw new Error("Invalid or missing service");
+	}
+	if (!isSyncableService(params.service)) {
+		throw new Error("Invalid or unsupported service");
+	}
+	if (!("lastSyncTime" in params) || typeof params.lastSyncTime !== "string") {
+		throw new Error("Invalid or missing lastSyncTime");
+	}
+	validateSyncServiceDataRequest(params);
 }

--- a/types/schema/common/rpc.schema.json
+++ b/types/schema/common/rpc.schema.json
@@ -4,13 +4,16 @@
 	"title": "CommonRPC",
 	"description": "Shared RPC request/response definitions",
 	"$defs": {
-		"IdFilter": {
+		"DataFilter": {
 			"type": "object",
 			"additionalProperties": false,
-			"required": ["id"],
 			"properties": {
-				"id": { "type": "string" }
+				"id": { "type": "string", "format": "uuid" },
+				"updatedAfter": { "type": "string", "format": "date-time" }
 			}
+		},
+		"IdFilter": {
+			"$ref": "#/$defs/DataFilter"
 		}
 	}
 }

--- a/types/schema/data/drizzle.config.json
+++ b/types/schema/data/drizzle.config.json
@@ -18,9 +18,7 @@
 			"tableName": "Service",
 			"primaryKey": "id",
 			"defaultRandom": [],
-			"uniqueIndexes": [
-				{ "name": "Service_name_key", "columns": ["name"] }
-			]
+			"uniqueIndexes": [{ "name": "Service_name_key", "columns": ["name"] }]
 		},
 		"DATA_EVY_Organization": {
 			"tableName": "Organization",

--- a/types/schema/rpc/get.request.schema.json
+++ b/types/schema/rpc/get.request.schema.json
@@ -12,15 +12,9 @@
 				"service": { "const": "evy" },
 				"resource": {
 					"type": "string",
-					"enum": [
-						"sdui",
-						"devices",
-						"organisations",
-						"services",
-						"providers"
-					]
+					"enum": ["sdui", "devices", "organisations", "services", "providers"]
 				},
-				"filter": { "$ref": "../common/rpc.schema.json#/$defs/IdFilter" }
+				"filter": { "$ref": "../common/rpc.schema.json#/$defs/DataFilter" }
 			}
 		},
 		{
@@ -40,7 +34,7 @@
 						"items"
 					]
 				},
-				"filter": { "$ref": "../common/rpc.schema.json#/$defs/IdFilter" }
+				"filter": { "$ref": "../common/rpc.schema.json#/$defs/DataFilter" }
 			}
 		}
 	]

--- a/types/schema/rpc/syncServiceData.request.schema.json
+++ b/types/schema/rpc/syncServiceData.request.schema.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "syncServiceData-request",
+	"title": "SyncServiceDataRequest",
+	"description": "JSON-RPC params for syncServiceData method",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["service", "lastSyncTime"],
+	"properties": {
+		"service": {
+			"type": "string",
+			"minLength": 1
+		},
+		"lastSyncTime": {
+			"type": "string",
+			"format": "date-time"
+		}
+	}
+}

--- a/types/schema/rpc/syncServiceData.response.schema.json
+++ b/types/schema/rpc/syncServiceData.response.schema.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "syncServiceData-response",
+	"title": "SyncServiceDataResponse",
+	"description": "JSON-RPC response for syncServiceData method",
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["data"],
+	"properties": {
+		"data": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["service", "resource", "value"],
+				"properties": {
+					"service": { "type": "string" },
+					"resource": { "type": "string" },
+					"value": {}
+				}
+			}
+		}
+	}
+}

--- a/types/schema/rpc/upsert.request.schema.json
+++ b/types/schema/rpc/upsert.request.schema.json
@@ -20,15 +20,9 @@
 				"service": { "const": "evy" },
 				"resource": {
 					"type": "string",
-					"enum": [
-						"sdui",
-						"devices",
-						"organisations",
-						"services",
-						"providers"
-					]
+					"enum": ["sdui", "devices", "organisations", "services", "providers"]
 				},
-				"filter": { "$ref": "../common/rpc.schema.json#/$defs/IdFilter" },
+				"filter": { "$ref": "../common/rpc.schema.json#/$defs/DataFilter" },
 				"data": { "$ref": "#/$defs/UpsertDataPayload" }
 			}
 		},
@@ -49,7 +43,7 @@
 						"items"
 					]
 				},
-				"filter": { "$ref": "../common/rpc.schema.json#/$defs/IdFilter" },
+				"filter": { "$ref": "../common/rpc.schema.json#/$defs/DataFilter" },
 				"data": { "$ref": "#/$defs/UpsertDataPayload" }
 			}
 		}

--- a/types/schema/service.proto
+++ b/types/schema/service.proto
@@ -24,6 +24,7 @@ message UpsertRequest {
 
 message Filter {
   string id = 1;
+  string updated_after = 2;
 }
 
 message GetResponse {

--- a/types/validators.ts
+++ b/types/validators.ts
@@ -18,6 +18,8 @@ import type {
 import type { DATA_PRIMITIVE } from "./generated/ts/data/primitive";
 import type { GetRequest } from "./generated/ts/rpc/get.request";
 import type { GetResponse } from "./generated/ts/rpc/get.response";
+import type { SyncServiceDataRequest } from "./generated/ts/rpc/syncServiceData.request";
+import type { SyncServiceDataResponse } from "./generated/ts/rpc/syncServiceData.response";
 import type { UpsertRequest } from "./generated/ts/rpc/upsert.request";
 import type { UpsertResponse } from "./generated/ts/rpc/upsert.response";
 import type { UI_Flow } from "./generated/ts/sdui/evy";
@@ -41,10 +43,16 @@ import getRequestRaw from "./schema/rpc/get.request.schema.json" with {
 import upsertRequestRaw from "./schema/rpc/upsert.request.schema.json" with {
 	type: "json",
 };
+import syncServiceDataRequestRaw from "./schema/rpc/syncServiceData.request.schema.json" with {
+	type: "json",
+};
 import getResponseRaw from "./schema/rpc/get.response.schema.json" with {
 	type: "json",
 };
 import upsertResponseRaw from "./schema/rpc/upsert.response.schema.json" with {
+	type: "json",
+};
+import syncServiceDataResponseRaw from "./schema/rpc/syncServiceData.response.schema.json" with {
 	type: "json",
 };
 
@@ -59,11 +67,15 @@ const RAW_SCHEMAS: Record<string, Record<string, unknown>> = {
 	"sdui/evy.schema.json": evySduiRaw as Record<string, unknown>,
 	"rpc/get.request.schema.json": getRequestRaw as Record<string, unknown>,
 	"rpc/upsert.request.schema.json": upsertRequestRaw as Record<string, unknown>,
+	"rpc/syncServiceData.request.schema.json":
+		syncServiceDataRequestRaw as Record<string, unknown>,
 	"rpc/get.response.schema.json": getResponseRaw as Record<string, unknown>,
 	"rpc/upsert.response.schema.json": upsertResponseRaw as Record<
 		string,
 		unknown
 	>,
+	"rpc/syncServiceData.response.schema.json":
+		syncServiceDataResponseRaw as Record<string, unknown>,
 };
 
 const preparedCache = new Map<string, Record<string, unknown>>();
@@ -160,6 +172,7 @@ const REQUEST_SCHEMA_FILES = [
 	"common/rpc.schema.json",
 	"rpc/get.request.schema.json",
 	"rpc/upsert.request.schema.json",
+	"rpc/syncServiceData.request.schema.json",
 ] as const;
 
 /** data.schema references SDUI for DATA_EVY_Flow; register both in one instance */
@@ -170,6 +183,7 @@ const ENTITY_SCHEMA_FILES = [
 	"sdui/evy.schema.json",
 	"rpc/get.response.schema.json",
 	"rpc/upsert.response.schema.json",
+	"rpc/syncServiceData.response.schema.json",
 ] as const;
 
 let requestAjv: InstanceType<typeof Ajv2020> | null = null;
@@ -207,6 +221,8 @@ function getEntityAjv(): InstanceType<typeof Ajv2020> {
 
 let validateGetRequestFn: ValidateFunction<GetRequest> | null = null;
 let validateUpsertRequestFn: ValidateFunction<UpsertRequest> | null = null;
+let validateSyncServiceDataRequestFn: ValidateFunction<SyncServiceDataRequest> | null =
+	null;
 let validateUpsertDataPayloadFn: ValidateFunction<
 	DATA_PRIMITIVE["data"]
 > | null = null;
@@ -218,6 +234,8 @@ let validateDataEvyServiceProviderFn: ValidateFunction<DATA_EVY_ServiceProvider>
 	null;
 let validateGetResponseFn: ValidateFunction<GetResponse> | null = null;
 let validateUpsertResponseFn: ValidateFunction<UpsertResponse> | null = null;
+let validateSyncServiceDataResponseFn: ValidateFunction<SyncServiceDataResponse> | null =
+	null;
 
 function getValidateGetRequest(): ValidateFunction<GetRequest> {
 	if (!validateGetRequestFn) {
@@ -237,6 +255,16 @@ function getValidateUpsertRequest(): ValidateFunction<UpsertRequest> {
 		);
 	}
 	return validateUpsertRequestFn;
+}
+
+function getValidateSyncServiceDataRequest(): ValidateFunction<SyncServiceDataRequest> {
+	if (!validateSyncServiceDataRequestFn) {
+		validateSyncServiceDataRequestFn = compileRoot<SyncServiceDataRequest>(
+			getRequestAjv(),
+			fileId("rpc/syncServiceData.request.schema.json"),
+		);
+	}
+	return validateSyncServiceDataRequestFn;
 }
 
 function getValidateUpsertDataPayload(): ValidateFunction<
@@ -311,6 +339,16 @@ function getValidateUpsertResponse(): ValidateFunction<UpsertResponse> {
 	return validateUpsertResponseFn;
 }
 
+function getValidateSyncServiceDataResponse(): ValidateFunction<SyncServiceDataResponse> {
+	if (!validateSyncServiceDataResponseFn) {
+		validateSyncServiceDataResponseFn = compileRoot<SyncServiceDataResponse>(
+			getEntityAjv(),
+			fileId("rpc/syncServiceData.response.schema.json"),
+		);
+	}
+	return validateSyncServiceDataResponseFn;
+}
+
 export function validateGetRequest(data: unknown): GetRequest {
 	assertValid("GetRequest", getValidateGetRequest(), data);
 	return data;
@@ -318,6 +356,17 @@ export function validateGetRequest(data: unknown): GetRequest {
 
 export function validateUpsertRequest(data: unknown): UpsertRequest {
 	assertValid("UpsertRequest", getValidateUpsertRequest(), data);
+	return data;
+}
+
+export function validateSyncServiceDataRequest(
+	data: unknown,
+): SyncServiceDataRequest {
+	assertValid(
+		"SyncServiceDataRequest",
+		getValidateSyncServiceDataRequest(),
+		data,
+	);
 	return data;
 }
 
@@ -360,6 +409,17 @@ export function validateGetResponse(data: unknown): GetResponse {
 
 export function validateUpsertResponse(data: unknown): UpsertResponse {
 	assertValid("UpsertResponse", getValidateUpsertResponse(), data);
+	return data;
+}
+
+export function validateSyncServiceDataResponse(
+	data: unknown,
+): SyncServiceDataResponse {
+	assertValid(
+		"SyncServiceDataResponse",
+		getValidateSyncServiceDataResponse(),
+		data,
+	);
 	return data;
 }
 

--- a/web/app/rows/edit/DropdownRow.tsx
+++ b/web/app/rows/edit/DropdownRow.tsx
@@ -12,7 +12,7 @@ export default defineRow("DropdownRow", {
 			content: {
 				title: "Dropdown row title",
 				placeholder: "placeholder",
-				format: "{datum.value}",
+				format: "{$datum:value}",
 			},
 		},
 		destination: "{condition}",
@@ -21,7 +21,7 @@ export default defineRow("DropdownRow", {
 		<RowLayout title={row.config.view.content.title}>
 			<Dropdown
 				value={row.config.source}
-				placeholder={row.config.view.content.placeholder}
+				placeholder={row.config.view.content.placeholder ?? ""}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/InlinePickerRow.tsx
+++ b/web/app/rows/edit/InlinePickerRow.tsx
@@ -11,7 +11,7 @@ export default defineRow("InlinePickerRow", {
 		view: {
 			content: {
 				title: "Inline picker row title",
-				format: "{datum.value}",
+				format: "{$datum:value}",
 			},
 		},
 		destination: "{distance}",

--- a/web/app/rows/edit/searchPreview.test.ts
+++ b/web/app/rows/edit/searchPreview.test.ts
@@ -22,8 +22,8 @@ function buildInfoTemplateRow(): Row {
 			actions: [],
 			view: {
 				content: {
-					title: "{datum.value}",
-					subtitle: "{datum.city}",
+					title: "{$datum:value}",
+					subtitle: "{$datum:city}",
 					icon: "",
 				},
 			},
@@ -33,8 +33,8 @@ function buildInfoTemplateRow(): Row {
 
 describe("formatSearchPreviewString", () => {
 	it("replaces datum bindings with dummy preview values", () => {
-		expect(formatSearchPreviewString("{datum.value}")).toBe("Example tag");
-		expect(formatSearchPreviewString("{datum.city}, {datum.postcode}")).toBe(
+		expect(formatSearchPreviewString("{$datum:value}")).toBe("Example tag");
+		expect(formatSearchPreviewString("{$datum:city}, {$datum:postcode}")).toBe(
 			"Sydney, 2000",
 		);
 	});

--- a/web/app/rows/edit/searchPreview.tsx
+++ b/web/app/rows/edit/searchPreview.tsx
@@ -40,6 +40,8 @@ const previewRowComponents: Record<string, RowComponent> = {
 
 type SearchPreviewDatum = Record<string, string>;
 
+const BRACED_DATUM_BINDING_REGEX = /\{\$datum:([A-Za-z0-9_.-]+)\}/g;
+
 function SearchPreviewFallback({ rowType }: { rowType: string }) {
 	return (
 		<RowLayout title="">
@@ -50,21 +52,13 @@ function SearchPreviewFallback({ rowType }: { rowType: string }) {
 	);
 }
 
-function resolveDatumValue(path: string, datum: SearchPreviewDatum): string {
-	const normalizedPath = path.trim();
-	if (!normalizedPath) {
-		return datum.value ?? "";
-	}
-
-	return datum[normalizedPath] ?? "";
-}
-
 export function formatSearchPreviewString(
 	template: string,
 	datum: SearchPreviewDatum = SEARCH_PREVIEW_DATUM,
 ): string {
-	return template.replace(/\{datum(?:\.([^}]+))?\}/g, (_match, path?: string) =>
-		resolveDatumValue(path ?? "", datum),
+	return template.replace(
+		BRACED_DATUM_BINDING_REGEX,
+		(_match, path: string) => datum[path] ?? "",
 	);
 }
 

--- a/web/app/rows/view/InputListRow.tsx
+++ b/web/app/rows/view/InputListRow.tsx
@@ -12,7 +12,7 @@ export default defineRow("InputListRow", {
 			content: {
 				title: "Input list row title",
 				placeholder: "Search for tags",
-				format: "{datum.value}",
+				format: "{$datum:value}",
 			},
 		},
 	} satisfies RowConfig,
@@ -20,7 +20,7 @@ export default defineRow("InputListRow", {
 		<RowLayout title={row.config.view.content.title}>
 			<Input
 				value={row.config.source}
-				placeholder={row.config.view.content.placeholder}
+				placeholder={row.config.view.content.placeholder ?? ""}
 			/>
 		</RowLayout>
 	),

--- a/web/app/utils/decodeFlow.test.ts
+++ b/web/app/utils/decodeFlow.test.ts
@@ -135,7 +135,7 @@ describe("normalizeServerRow", () => {
 		const n = normalizeServerRow({
 			id: ROW_A,
 			type: "Search",
-			source: "{api:tags}",
+			source: "{$api:tags}",
 			destination: "{tags}",
 			actions: [],
 			view: {
@@ -148,7 +148,7 @@ describe("normalizeServerRow", () => {
 
 		expect(n.view.content.child?.type).toBe("Info");
 		expect(n.view.content.child?.view.content).toMatchObject({
-			title: "{datum.value}",
+			title: "{$datum:value}",
 			subtitle: "",
 			icon: "",
 		});

--- a/web/app/utils/searchRowDefaults.ts
+++ b/web/app/utils/searchRowDefaults.ts
@@ -1,5 +1,5 @@
 export const SEARCH_DEFAULT_RESULT_CONTENT = {
-	title: "{datum.value}",
+	title: "{$datum:value}",
 	subtitle: "",
 	icon: "",
 } as const;

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -156,7 +156,7 @@ test.describe("Row configuration", () => {
 							content: {
 								title: "Tags",
 								placeholder: "Search for tags",
-								format: "{datum.value}",
+								format: "{$datum:value}",
 							},
 						},
 						actions: [],
@@ -169,12 +169,12 @@ test.describe("Row configuration", () => {
 		const configPanel = getConfigPanel(page);
 		const formatInput = configPanel.getByLabel("format");
 		await expect(formatInput).toBeVisible();
-		await expect(formatInput).toHaveValue("{datum.value}");
+		await expect(formatInput).toHaveValue("{$datum:value}");
 
 		await formatInput.clear();
-		await formatInput.fill("{datum.label}");
+		await formatInput.fill("{$datum:label}");
 
-		await expect(formatInput).toHaveValue("{datum.label}");
+		await expect(formatInput).toHaveValue("{$datum:label}");
 	});
 
 	test("should display and edit action items via popup", async ({ page }) => {
@@ -398,6 +398,7 @@ test.describe("Row configuration", () => {
 							{
 								id: "row_btn",
 								type: "Button",
+								source: "",
 								view: { content: { title: "", label: "Go" } },
 								actions: [{ condition: "", false: "", true: "" }],
 							},
@@ -463,6 +464,7 @@ test.describe("Row configuration", () => {
 							{
 								id: "row_input_items",
 								type: "Input",
+								source: "",
 								view: {
 									content: {
 										title: "Item name",
@@ -476,6 +478,7 @@ test.describe("Row configuration", () => {
 							{
 								id: "row_btn2",
 								type: "Button",
+								source: "",
 								view: {
 									content: { title: "", label: "Create Item" },
 								},
@@ -781,6 +784,7 @@ test.describe("Row configuration", () => {
 							{
 								id: "row_input",
 								type: "Input",
+								source: "",
 								view: {
 									content: {
 										title: "Name",
@@ -794,6 +798,7 @@ test.describe("Row configuration", () => {
 							{
 								id: "row_btn",
 								type: "Button",
+								source: "",
 								view: {
 									content: { title: "", label: "Prefilled" },
 								},
@@ -1087,7 +1092,20 @@ test.describe("Row configuration", () => {
 	test("navbar breadcrumbs scroll for many nested levels and navigate on click", async ({
 		page,
 	}) => {
-		function deepNest(level: number) {
+		type DeepNestRow = {
+			type: "Input" | "ColumnContainer";
+			view: {
+				content: {
+					title: string;
+					placeholder?: string;
+					value?: string;
+					children?: DeepNestRow[];
+				};
+			};
+			actions: [];
+		};
+
+		function deepNest(level: number): DeepNestRow {
 			if (level === 0) {
 				return {
 					type: "Input" as const,

--- a/web/tests/utils.tsx
+++ b/web/tests/utils.tsx
@@ -15,7 +15,9 @@ interface ServerRowInputContent {
 	value?: string;
 	placeholder?: string;
 	text?: string;
+	subtitle?: string;
 	label?: string;
+	format?: string;
 	segments?: string[];
 }
 


### PR DESCRIPTION
## Summary

Adds service data synchronization for marketplace resources referenced from SDUI flows, expression parsing to discover bindings and API-backed sources, and client updates (iOS, web, marketplace worker) so list/search rows resolve `{$datum:...}` and related sources consistently with the API.

## Major changes

- **API:** New `expressionParser` and `serviceDataSync` modules; `syncServiceData` JSON-RPC loads marketplace resources needed by the flow; `data.ts` / `rpc.ts` wiring updates.
- **Types:** `syncServiceData` request/response schemas, proto and validator updates, `get` / `upsert` schema tweaks, `rpcRequestHelpers` for strict sync validation.
- **Marketplace worker:** gRPC/data adjustments for sync and tests.
- **Clients:** iOS (`EVYDataManager`, search controller, SwiftUI rows/views) and web (dropdown/inline picker/search preview, tests) aligned with datum and search behavior.
- **Docs:** SDUI readme and `service_sdui.json` updated for `{$datum:value}` and source semantics.

## Tests

- Added `api/src/tests/serviceDataSync.test.ts`; updated `data.test.ts`, marketplace `data.test.ts`, web tests (`searchPreview`, `decodeFlow`, `configuration.spec`), and iOS e2e touchpoints as in the diff.
- Per AGENTS.md: `bun run build`, `bun run lint`, `bun run test` (web/api), and `./run-e2e.sh --skip-ios` should be run for full verification before merge if not already green on CI.

## Risks / follow-ups

- `syncServiceData` currently validates marketplace-only service in implementation; extending to other services in `RESOURCES_BY_SERVICE` may need follow-up.
- Large iOS asset JSON churn in the diff is mostly formatting; confirm no accidental asset regression in review.

## JIRA

_(none — fill in if applicable)_

## Figma

_(none — fill in if applicable)_

## Stream / video

_(none — fill in if applicable)_

Made with [Cursor](https://cursor.com)