### PR TITLE
[REFACTOR] Move EVY error and format iOS code

### DIFF
--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -8,630 +8,668 @@ import XCTest
 // MARK: - Minimal WebSocket Emitter for E2E Tests
 
 actor WSEmitter {
-    private var ws: URLSessionWebSocketTask?
-    private var msgId = 0
+  private var ws: URLSessionWebSocketTask?
+  private var msgId = 0
 
-    func connect(host: String) async throws {
-        let url = URL(string: "ws://\(host)")!
-        ws = URLSession.shared.webSocketTask(with: url)
-        ws?.resume()
-        try await Task.sleep(nanoseconds: 300_000_000) // 0.3s for connection
+  func connect(host: String) async throws {
+    let url = URL(string: "ws://\(host)")!
+    ws = URLSession.shared.webSocketTask(with: url)
+    ws?.resume()
+    try await Task.sleep(nanoseconds: 300_000_000)  // 0.3s for connection
+  }
+
+  func login(token: String, os: String) async throws {
+    let response = try await send(method: "rpc.login", params: ["token": token, "os": os])
+    guard response["result"] as? Bool == true else {
+      throw NSError(
+        domain: "WSEmitter", code: 1, userInfo: [NSLocalizedDescriptionKey: "Login failed"])
     }
+  }
 
-    func login(token: String, os: String) async throws {
-        let response = try await send(method: "rpc.login", params: ["token": token, "os": os])
-        guard response["result"] as? Bool == true else {
-            throw NSError(domain: "WSEmitter", code: 1, userInfo: [NSLocalizedDescriptionKey: "Login failed"])
-        }
+  func updateSDUI(flowData: [String: Any], flowId: String) async throws {
+    let params: [String: Any] = [
+      "service": "evy",
+      "resource": "sdui",
+      "filter": ["id": flowId],
+      "data": flowData,
+    ]
+    _ = try await send(method: "upsert", params: params)
+  }
+
+  func getResource(service: String, resource: String, filter: [String: Any]? = nil) async throws
+    -> Any
+  {
+    var params: [String: Any] = ["service": service, "resource": resource]
+    if let filter = filter {
+      params["filter"] = filter
     }
-
-    func updateSDUI(flowData: [String: Any], flowId: String) async throws {
-        let params: [String: Any] = [
-            "service": "evy",
-            "resource": "sdui",
-            "filter": ["id": flowId],
-            "data": flowData
-        ]
-        _ = try await send(method: "upsert", params: params)
+    let response = try await send(method: "get", params: params)
+    guard let result = response["result"] else {
+      throw NSError(
+        domain: "WSEmitter",
+        code: 2,
+        userInfo: [NSLocalizedDescriptionKey: "get response missing result"]
+      )
     }
+    return result
+  }
 
-    func getResource(service: String, resource: String, filter: [String: Any]? = nil) async throws -> Any {
-        var params: [String: Any] = ["service": service, "resource": resource]
-        if let filter = filter {
-            params["filter"] = filter
-        }
-        let response = try await send(method: "get", params: params)
-        guard let result = response["result"] else {
-            throw NSError(
-                domain: "WSEmitter",
-                code: 2,
-                userInfo: [NSLocalizedDescriptionKey: "get response missing result"]
-            )
-        }
-        return result
+  func disconnect() { ws?.cancel(with: .normalClosure, reason: nil) }
+
+  private func send(method: String, params: Any) async throws -> [String: Any] {
+    msgId += 1
+    let msg: [String: Any] = ["jsonrpc": "2.0", "id": msgId, "method": method, "params": params]
+    let json = String(data: try JSONSerialization.data(withJSONObject: msg), encoding: .utf8)!
+    try await ws?.send(.string(json))
+
+    while true {
+      let result = try await ws?.receive()
+      guard case .string(let text) = result,
+        let data = text.data(using: .utf8),
+        let response = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+      else {
+        return [:]
+      }
+      if response["id"] == nil { continue }
+      if let error = response["error"] as? [String: Any] {
+        let message = (error["message"] as? String) ?? "JSON-RPC error"
+        throw NSError(
+          domain: "WSEmitter",
+          code: (error["code"] as? Int) ?? -1,
+          userInfo: [NSLocalizedDescriptionKey: "\(method) failed: \(message)"]
+        )
+      }
+      return response
     }
-
-    func disconnect() { ws?.cancel(with: .normalClosure, reason: nil) }
-
-    private func send(method: String, params: Any) async throws -> [String: Any] {
-        msgId += 1
-        let msg: [String: Any] = ["jsonrpc": "2.0", "id": msgId, "method": method, "params": params]
-        let json = String(data: try JSONSerialization.data(withJSONObject: msg), encoding: .utf8)!
-        try await ws?.send(.string(json))
-
-        while true {
-            let result = try await ws?.receive()
-            guard case .string(let text) = result,
-                  let data = text.data(using: .utf8),
-                  let response = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else {
-                return [:]
-            }
-            if response["id"] == nil { continue }
-            if let error = response["error"] as? [String: Any] {
-                let message = (error["message"] as? String) ?? "JSON-RPC error"
-                throw NSError(
-                    domain: "WSEmitter",
-                    code: (error["code"] as? Int) ?? -1,
-                    userInfo: [NSLocalizedDescriptionKey: "\(method) failed: \(message)"]
-                )
-            }
-            return response
-        }
-    }
+  }
 }
 
 // MARK: - Base class for E2E tests
 
 class E2ETestBase: XCTestCase {
 
-    var app: XCUIApplication!
+  var app: XCUIApplication!
 
-    func clearAndType(field: XCUIElement, text: String, placeholder: String? = nil) {
-        if let existingText = field.value as? String, !existingText.isEmpty {
-            let shouldClearExistingText = placeholder == nil || existingText != placeholder
-            if shouldClearExistingText {
-                field.tap()
-                field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: existingText.count))
-            }
-        }
-        field.typeText(text)
+  func clearAndType(field: XCUIElement, text: String, placeholder: String? = nil) {
+    if let existingText = field.value as? String, !existingText.isEmpty {
+      let shouldClearExistingText = placeholder == nil || existingText != placeholder
+      if shouldClearExistingText {
+        field.tap()
+        field.typeText(
+          String(repeating: XCUIKeyboardKey.delete.rawValue, count: existingText.count))
+      }
     }
+    field.typeText(text)
+  }
 
-    func findElement(identifier: String) -> XCUIElement? {
-        let otherElement = app.otherElements[identifier].firstMatch
-        if otherElement.waitForExistence(timeout: 2) {
-            return otherElement
-        }
-        let descendant = app.descendants(matching: .any)[identifier].firstMatch
-        if descendant.waitForExistence(timeout: 2) {
-            return descendant
-        }
-        return nil
+  func findElement(identifier: String) -> XCUIElement? {
+    let otherElement = app.otherElements[identifier].firstMatch
+    if otherElement.waitForExistence(timeout: 2) {
+      return otherElement
     }
-
-    func findElement(identifiers: [String], containsAny tokens: [String]) -> XCUIElement? {
-        for identifier in identifiers {
-            if let element = findElement(identifier: identifier) {
-                return element
-            }
-        }
-        for token in tokens {
-            let predicate = NSPredicate(format: "identifier CONTAINS %@", token)
-            let matches = app.descendants(matching: .any).matching(predicate)
-            let count = matches.count
-            if count > 0 {
-                for index in 0..<count {
-                    let element = matches.element(boundBy: index)
-                    if element.exists {
-                        return element
-                    }
-                }
-            }
-            let firstMatch = matches.firstMatch
-            if firstMatch.waitForExistence(timeout: 2) {
-                return firstMatch
-            }
-        }
-        return nil
+    let descendant = app.descendants(matching: .any)[identifier].firstMatch
+    if descendant.waitForExistence(timeout: 2) {
+      return descendant
     }
+    return nil
+  }
 
-    func findElementWithScroll(identifiers: [String],
-                              containsAny tokens: [String],
-                              in scrollView: XCUIElement,
-                              maxScrollAttempts: Int = 6) -> XCUIElement? {
-        if let element = findElement(identifiers: identifiers, containsAny: tokens) {
+  func findElement(identifiers: [String], containsAny tokens: [String]) -> XCUIElement? {
+    for identifier in identifiers {
+      if let element = findElement(identifier: identifier) {
+        return element
+      }
+    }
+    for token in tokens {
+      let predicate = NSPredicate(format: "identifier CONTAINS %@", token)
+      let matches = app.descendants(matching: .any).matching(predicate)
+      let count = matches.count
+      if count > 0 {
+        for index in 0..<count {
+          let element = matches.element(boundBy: index)
+          if element.exists {
             return element
+          }
         }
-        for _ in 0..<maxScrollAttempts {
-            scrollView.swipeUp()
-            if let element = findElement(identifiers: identifiers, containsAny: tokens) {
-                return element
-            }
-        }
-        return nil
+      }
+      let firstMatch = matches.firstMatch
+      if firstMatch.waitForExistence(timeout: 2) {
+        return firstMatch
+      }
     }
+    return nil
+  }
 
-    func tapAndGetEditableField(container: XCUIElement) async -> XCUIElement? {
-        container.tap()
-        try? await Task.sleep(for: .milliseconds(500))
-        let textField = container.textFields.firstMatch
-        if textField.exists {
-            return textField
-        }
-        let anyTextField = app.textFields.firstMatch
-        if anyTextField.waitForExistence(timeout: 2) {
-            return anyTextField
-        }
-        return nil
+  func findElementWithScroll(
+    identifiers: [String],
+    containsAny tokens: [String],
+    in scrollView: XCUIElement,
+    maxScrollAttempts: Int = 6
+  ) -> XCUIElement? {
+    if let element = findElement(identifiers: identifiers, containsAny: tokens) {
+      return element
     }
+    for _ in 0..<maxScrollAttempts {
+      scrollView.swipeUp()
+      if let element = findElement(identifiers: identifiers, containsAny: tokens) {
+        return element
+      }
+    }
+    return nil
+  }
 
-    override func setUpWithError() throws {
-        continueAfterFailure = false
-        app = XCUIApplication()
-        guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
-            XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
-            return
-        }
-        app.launchEnvironment["API_HOST"] = apiHost
-        app.launch()
+  func tapAndGetEditableField(container: XCUIElement) async -> XCUIElement? {
+    container.tap()
+    try? await Task.sleep(for: .milliseconds(500))
+    let textField = container.textFields.firstMatch
+    if textField.exists {
+      return textField
     }
+    let anyTextField = app.textFields.firstMatch
+    if anyTextField.waitForExistence(timeout: 2) {
+      return anyTextField
+    }
+    return nil
+  }
 
-    override func tearDownWithError() throws {
-        app = nil
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    app = XCUIApplication()
+    guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
+      XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
+      return
     }
+    app.launchEnvironment["API_HOST"] = apiHost
+    app.launch()
+  }
+
+  override func tearDownWithError() throws {
+    app = nil
+  }
 }
 
 // MARK: - Navigation and visibility only
 
 final class E2EFlowTests: E2ETestBase {
 
-    func testNavigationAndVisibility() throws {
-        XCTAssertTrue(app.exists, "App should launch successfully")
+  func testNavigationAndVisibility() throws {
+    XCTAssertTrue(app.exists, "App should launch successfully")
 
-        let loadingIndicator = app.progressIndicators["loadingIndicator"]
-        let homePage = app.scrollViews["page_55e427ac-263c-441f-9673-f60627b1baea"]
-        let initialUIAppeared = loadingIndicator.waitForExistence(timeout: 5) || homePage.waitForExistence(timeout: 5)
-        XCTAssertTrue(initialUIAppeared || app.buttons.count > 0 || app.staticTexts.count > 0,
-                      "App should display initial UI after launch")
+    let loadingIndicator = app.progressIndicators["loadingIndicator"]
+    let homePage = app.scrollViews["page_55e427ac-263c-441f-9673-f60627b1baea"]
+    let initialUIAppeared =
+      loadingIndicator.waitForExistence(timeout: 5) || homePage.waitForExistence(timeout: 5)
+    XCTAssertTrue(
+      initialUIAppeared || app.buttons.count > 0 || app.staticTexts.count > 0,
+      "App should display initial UI after launch")
 
-        let viewItemButton = app.buttons["View"]
-        let createItemButton = app.buttons["Create"]
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 20),
-                      "Home screen not loaded - verify API is running and database is seeded")
-        XCTAssertTrue(createItemButton.exists, "Create button should be visible")
+    let viewItemButton = app.buttons["View"]
+    let createItemButton = app.buttons["Create"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+    XCTAssertTrue(createItemButton.exists, "Create button should be visible")
 
-        viewItemButton.tap()
-        let scrollView = app.scrollViews.firstMatch
-        XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "Page should appear after tapping View")
-        XCTAssertFalse(viewItemButton.exists, "Home buttons should not be visible after navigation")
+    viewItemButton.tap()
+    let scrollView = app.scrollViews.firstMatch
+    XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "Page should appear after tapping View")
+    XCTAssertFalse(viewItemButton.exists, "Home buttons should not be visible after navigation")
 
-        let goHomeButton = app.buttons["Go home"]
-        XCTAssertTrue(goHomeButton.waitForExistence(timeout: 5), "Footer 'Go home' button should be visible")
+    let goHomeButton = app.buttons["Go home"]
+    XCTAssertTrue(
+      goHomeButton.waitForExistence(timeout: 5), "Footer 'Go home' button should be visible")
 
-        let backButton = app.navigationBars.buttons.firstMatch
-        XCTAssertTrue(backButton.waitForExistence(timeout: 5), "Back button should exist")
-        backButton.tap()
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 5), "Should return to home screen")
+    let backButton = app.navigationBars.buttons.firstMatch
+    XCTAssertTrue(backButton.waitForExistence(timeout: 5), "Back button should exist")
+    backButton.tap()
+    XCTAssertTrue(viewItemButton.waitForExistence(timeout: 5), "Should return to home screen")
 
-        createItemButton.tap()
-        XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "Page should appear after navigation")
-        XCTAssertFalse(createItemButton.exists, "Home buttons should not be visible after navigation")
+    createItemButton.tap()
+    XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "Page should appear after navigation")
+    XCTAssertFalse(createItemButton.exists, "Home buttons should not be visible after navigation")
 
-        XCTAssertTrue(backButton.waitForExistence(timeout: 5), "Back button should exist")
-        backButton.tap()
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 5), "Should return to home screen after create flow")
-    }
+    XCTAssertTrue(backButton.waitForExistence(timeout: 5), "Back button should exist")
+    backButton.tap()
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 5), "Should return to home screen after create flow")
+  }
 }
 
 // MARK: - WebSocket and form data editing
 
 final class WebSocketE2ETests: E2ETestBase {
 
-    @MainActor
-    func testWebSocketNotificationUpdatesUI() async throws {
-        let viewItemButton = app.buttons["View"]
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 20),
-                      "Home screen not loaded - verify API is running and database is seeded")
+  @MainActor
+  func testWebSocketNotificationUpdatesUI() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
 
-        let originalLabel = "View"
-        let updatedLabel = "Updated View \(Int(Date().timeIntervalSince1970))"
+    let originalLabel = "View"
+    let updatedLabel = "Updated View \(Int(Date().timeIntervalSince1970))"
 
-        guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
-            XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
-            return
-        }
-        let emitter = WSEmitter()
-        do {
-            try await emitter.connect(host: apiHost)
-            try await emitter.login(token: "e2e-test", os: "ios")
-            try await emitter.updateSDUI(
-                flowData: createHomeFlowData(buttonLabel: updatedLabel),
-                flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
-            )
-        } catch {
-            XCTFail("Failed to emit update: \(error.localizedDescription)")
-            return
-        }
-
-        let updatedButton = app.buttons[updatedLabel]
-        XCTAssertTrue(updatedButton.waitForExistence(timeout: 10),
-                      "Button should update to '\(updatedLabel)' after notification")
-        XCTAssertFalse(viewItemButton.exists, "Original button should be replaced")
-
-        try? await emitter.updateSDUI(
-            flowData: createHomeFlowData(buttonLabel: originalLabel),
-            flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
-        )
-        await emitter.disconnect()
+    guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
+      XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
+      return
+    }
+    let emitter = WSEmitter()
+    do {
+      try await emitter.connect(host: apiHost)
+      try await emitter.login(token: "e2e-test", os: "ios")
+      try await emitter.updateSDUI(
+        flowData: createHomeFlowData(buttonLabel: updatedLabel),
+        flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
+      )
+    } catch {
+      XCTFail("Failed to emit update: \(error.localizedDescription)")
+      return
     }
 
-    @MainActor
-    func testConditionalActionEvaluatesLogicalExpression() async throws {
-        let viewItemButton = app.buttons["View"]
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 20),
-                      "Home screen not loaded - verify API is running and database is seeded")
+    let updatedButton = app.buttons[updatedLabel]
+    XCTAssertTrue(
+      updatedButton.waitForExistence(timeout: 10),
+      "Button should update to '\(updatedLabel)' after notification")
+    XCTAssertFalse(viewItemButton.exists, "Original button should be replaced")
 
-        guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
-            XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
-            return
-        }
+    try? await emitter.updateSDUI(
+      flowData: createHomeFlowData(buttonLabel: originalLabel),
+      flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
+    )
+    await emitter.disconnect()
+  }
 
-        let emitter = WSEmitter()
-        let conditionalLabel = "Conditional \(Int(Date().timeIntervalSince1970))"
+  @MainActor
+  func testConditionalActionEvaluatesLogicalExpression() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
 
-        do {
-            try await emitter.connect(host: apiHost)
-            try await emitter.login(token: "e2e-test", os: "ios")
-            try await emitter.updateSDUI(
-                flowData: createConditionalFlowData(buttonLabel: conditionalLabel),
-                flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
-            )
-        } catch {
-            XCTFail("Failed to publish conditional flow: \(error.localizedDescription)")
-            return
-        }
-
-        let conditionalButton = app.buttons[conditionalLabel]
-        XCTAssertTrue(conditionalButton.waitForExistence(timeout: 10),
-                      "Conditional button should exist after SDUI update")
-
-        conditionalButton.tap()
-
-        let goHomeButton = app.buttons["Go home"]
-        XCTAssertTrue(goHomeButton.waitForExistence(timeout: 10),
-                      "Tapping the conditional button should navigate when the logical expression is true")
-
-        try? await emitter.updateSDUI(
-            flowData: createHomeFlowData(buttonLabel: "View"),
-            flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
-        )
-        await emitter.disconnect()
+    guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
+      XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
+      return
     }
 
-    @MainActor
-    func testCreateItemFormEditing() async throws {
-        let viewItemButton = app.buttons["View"]
-        let createItemButton = app.buttons["Create"]
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 20),
-                      "Home screen not loaded - verify API is running and database is seeded")
+    let emitter = WSEmitter()
+    let conditionalLabel = "Conditional \(Int(Date().timeIntervalSince1970))"
 
-        guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
-            XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
-            return
-        }
-
-        let emitter = WSEmitter()
-        try await emitter.connect(host: apiHost)
-        try await emitter.login(token: "e2e-test", os: "ios")
-        try await emitter.updateSDUI(
-            flowData: Self.minimalCreateItemFlowData(),
-            flowId: "ca47e6c5-da19-4491-8422-adb40d9e8a27"
-        )
-        try await Task.sleep(for: .seconds(2))
-
-        createItemButton.tap()
-
-        let scrollView = app.scrollViews.firstMatch
-        XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "Page should appear after navigation")
-
-        // Title field
-        guard let titleTextField = findElement(identifier: "textField_{title}") else {
-            XCTFail("Title text field should exist with identifier 'textField_{title}'")
-            return
-        }
-        guard let titleField = await tapAndGetEditableField(container: titleTextField) else {
-            XCTFail("Failed to get editable title field")
-            return
-        }
-        let testTitle = "Test Item Title \(Int(Date().timeIntervalSince1970))"
-        clearAndType(field: titleField, text: testTitle, placeholder: "Item")
-        let textFieldValue = titleField.value as? String ?? ""
-        XCTAssertTrue(textFieldValue.contains("Test") || textFieldValue.contains("Item"),
-                      "Text field should contain typed text, got: '\(textFieldValue)'")
-        scrollView.tap()
-        try await Task.sleep(for: .milliseconds(500))
-
-        guard let priceTextField = findElementWithScroll(
-            identifiers: [
-                "textField_{price}",
-                "textField_{item.price}",
-                "textField_{buildCurrency(price)}",
-            ],
-            containsAny: ["price", "item.price", "buildCurrency"],
-            in: scrollView
-        ) else {
-            XCTFail("Price field should exist (textField_{price}, textField_{item.price}, textField_{buildCurrency(price)}, or accessibility containing 'price')")
-            return
-        }
-        guard let priceField = await tapAndGetEditableField(container: priceTextField) else {
-            XCTFail("Failed to get editable price field")
-            return
-        }
-        clearAndType(field: priceField, text: "99", placeholder: "0")
-        let priceValue = priceField.value as? String ?? ""
-        XCTAssertTrue(priceValue.contains("99"), "Price field should contain typed value, got: '\(priceValue)'")
-        scrollView.tap()
-        try await Task.sleep(for: .milliseconds(500))
-
-        guard let widthTextField = findElementWithScroll(
-            identifiers: ["textField_{width}", "textField_{item.dimensions.width}"],
-            containsAny: ["width", "dimensions.width"],
-            in: scrollView
-        ) else {
-            XCTFail("Width field should exist (textField_{width}, textField_{item.dimensions.width}, or accessibility containing 'width')")
-            return
-        }
-        guard let widthField = await tapAndGetEditableField(container: widthTextField) else {
-            XCTFail("Failed to get editable width field")
-            return
-        }
-        clearAndType(field: widthField, text: "50", placeholder: "0")
-        let widthValue = widthField.value as? String ?? ""
-        XCTAssertTrue(widthValue.contains("50"), "Width field should contain typed value, got: '\(widthValue)'")
-        scrollView.tap()
-        try await Task.sleep(for: .milliseconds(500))
-
-        let submitButton = app.buttons["Submit"]
-        XCTAssertTrue(submitButton.waitForExistence(timeout: 5), "Submit should exist on minimal create flow")
-        submitButton.tap()
-
-        XCTAssertTrue(viewItemButton.waitForExistence(timeout: 15),
-                      "Should return to home after create(item)")
-
-        let itemsPayload = try await emitter.getResource(service: "marketplace", resource: "items")
-        XCTAssertTrue(
-            Self.marketplaceItemsContainListing(title: testTitle, priceValue: 99, widthText: "50", items: itemsPayload),
-            "Marketplace items should include listing with title, price.value 99, and width 50"
-        )
-
-        await emitter.disconnect()
+    do {
+      try await emitter.connect(host: apiHost)
+      try await emitter.login(token: "e2e-test", os: "ios")
+      try await emitter.updateSDUI(
+        flowData: createConditionalFlowData(buttonLabel: conditionalLabel),
+        flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
+      )
+    } catch {
+      XCTFail("Failed to publish conditional flow: \(error.localizedDescription)")
+      return
     }
 
-    private static func minimalCreateItemFlowData() -> [String: Any] {
+    let conditionalButton = app.buttons[conditionalLabel]
+    XCTAssertTrue(
+      conditionalButton.waitForExistence(timeout: 10),
+      "Conditional button should exist after SDUI update")
+
+    conditionalButton.tap()
+
+    let goHomeButton = app.buttons["Go home"]
+    XCTAssertTrue(
+      goHomeButton.waitForExistence(timeout: 10),
+      "Tapping the conditional button should navigate when the logical expression is true")
+
+    try? await emitter.updateSDUI(
+      flowData: createHomeFlowData(buttonLabel: "View"),
+      flowId: "f267c629-2594-4770-8cec-d5324ebb4058"
+    )
+    await emitter.disconnect()
+  }
+
+  @MainActor
+  func testCreateItemFormEditing() async throws {
+    let viewItemButton = app.buttons["View"]
+    let createItemButton = app.buttons["Create"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    guard let apiHost = ProcessInfo.processInfo.environment["API_HOST"], !apiHost.isEmpty else {
+      XCTFail("API_HOST is required (set by run-e2e.sh when running iOS e2e)")
+      return
+    }
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    try await emitter.updateSDUI(
+      flowData: Self.minimalCreateItemFlowData(),
+      flowId: "ca47e6c5-da19-4491-8422-adb40d9e8a27"
+    )
+    try await Task.sleep(for: .seconds(2))
+
+    createItemButton.tap()
+
+    let scrollView = app.scrollViews.firstMatch
+    XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "Page should appear after navigation")
+
+    // Title field
+    guard let titleTextField = findElement(identifier: "textField_{title}") else {
+      XCTFail("Title text field should exist with identifier 'textField_{title}'")
+      return
+    }
+    guard let titleField = await tapAndGetEditableField(container: titleTextField) else {
+      XCTFail("Failed to get editable title field")
+      return
+    }
+    let testTitle = "Test Item Title \(Int(Date().timeIntervalSince1970))"
+    clearAndType(field: titleField, text: testTitle, placeholder: "Item")
+    let textFieldValue = titleField.value as? String ?? ""
+    XCTAssertTrue(
+      textFieldValue.contains("Test") || textFieldValue.contains("Item"),
+      "Text field should contain typed text, got: '\(textFieldValue)'")
+    scrollView.tap()
+    try await Task.sleep(for: .milliseconds(500))
+
+    guard
+      let priceTextField = findElementWithScroll(
+        identifiers: [
+          "textField_{price}",
+          "textField_{item.price}",
+          "textField_{buildCurrency(price)}",
+        ],
+        containsAny: ["price", "item.price", "buildCurrency"],
+        in: scrollView
+      )
+    else {
+      XCTFail(
+        "Price field should exist (textField_{price}, textField_{item.price}, textField_{buildCurrency(price)}, or accessibility containing 'price')"
+      )
+      return
+    }
+    guard let priceField = await tapAndGetEditableField(container: priceTextField) else {
+      XCTFail("Failed to get editable price field")
+      return
+    }
+    clearAndType(field: priceField, text: "99", placeholder: "0")
+    let priceValue = priceField.value as? String ?? ""
+    XCTAssertTrue(
+      priceValue.contains("99"), "Price field should contain typed value, got: '\(priceValue)'")
+    scrollView.tap()
+    try await Task.sleep(for: .milliseconds(500))
+
+    guard
+      let widthTextField = findElementWithScroll(
+        identifiers: ["textField_{width}", "textField_{item.dimensions.width}"],
+        containsAny: ["width", "dimensions.width"],
+        in: scrollView
+      )
+    else {
+      XCTFail(
+        "Width field should exist (textField_{width}, textField_{item.dimensions.width}, or accessibility containing 'width')"
+      )
+      return
+    }
+    guard let widthField = await tapAndGetEditableField(container: widthTextField) else {
+      XCTFail("Failed to get editable width field")
+      return
+    }
+    clearAndType(field: widthField, text: "50", placeholder: "0")
+    let widthValue = widthField.value as? String ?? ""
+    XCTAssertTrue(
+      widthValue.contains("50"), "Width field should contain typed value, got: '\(widthValue)'")
+    scrollView.tap()
+    try await Task.sleep(for: .milliseconds(500))
+
+    let submitButton = app.buttons["Submit"]
+    XCTAssertTrue(
+      submitButton.waitForExistence(timeout: 5), "Submit should exist on minimal create flow")
+    submitButton.tap()
+
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 15),
+      "Should return to home after create(item)")
+
+    let itemsPayload = try await emitter.getResource(service: "marketplace", resource: "items")
+    XCTAssertTrue(
+      Self.marketplaceItemsContainListing(
+        title: testTitle, priceValue: 99, widthText: "50", items: itemsPayload),
+      "Marketplace items should include listing with title, price.value 99, and width 50"
+    )
+
+    await emitter.disconnect()
+  }
+
+  private static func minimalCreateItemFlowData() -> [String: Any] {
+    [
+      "id": "ca47e6c5-da19-4491-8422-adb40d9e8a27",
+      "name": "Create item",
+      "pages": [
         [
-            "id": "ca47e6c5-da19-4491-8422-adb40d9e8a27",
-            "name": "Create item",
-            "pages": [
-                [
-                    "id": "306ed62c-c2af-4652-a873-26c7a388972d",
-                    "title": "Create listing",
-                    "rows": [
-                        [
-                            "id": "e0fc5df1-b4bf-4996-87f4-f2b0f3c2a0be",
-                            "type": "Input",
-                            "source": "{item}",
-                            "view": [
-                                "content": [
-                                    "title": "Title",
-                                    "value": "{title}",
-                                    "placeholder": "Item",
-                                ],
-                            ],
-                            "destination": "{title}",
-                            "actions": [],
-                        ],
-                        [
-                            "id": "668aeb79-d8ba-43b7-9619-07f91d0a1908",
-                            "type": "Input",
-                            "source": "{item}",
-                            "view": [
-                                "content": [
-                                    "title": "Price",
-                                    "value": "{formatCurrency(price)}",
-                                    "placeholder": "0",
-                                ],
-                            ],
-                            "destination": "{buildCurrency(price)}",
-                            "actions": [],
-                        ],
-                        [
-                            "id": "2a9b22a0-b0eb-4648-83ca-77b2b8748816",
-                            "type": "Input",
-                            "source": "{item}",
-                            "view": [
-                                "content": [
-                                    "title": "Width",
-                                    "value": "{formatDimension(width)}",
-                                    "placeholder": "0",
-                                ],
-                            ],
-                            "destination": "{width}",
-                            "actions": [],
-                        ],
-                    ],
-                    "footer": [
-                        "id": "1cb41189-6fa5-4562-996a-7cefb88a08ca",
-                        "type": "Button",
-                        "source": "{item}",
-                        "destination": "",
-                        "view": [
-                            "content": [
-                                "title": "",
-                                "label": "Submit",
-                            ],
-                        ],
-                        "actions": [
-                            [
-                                "condition": "",
-                                "false": "",
-                                "true": "{create(item)}",
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]
-    }
-
-    private static func marketplaceItemsContainListing(
-        title: String,
-        priceValue: Double,
-        widthText: String,
-        items: Any
-    ) -> Bool {
-        guard let arr = items as? [Any] else { return false }
-        let normalizedExpectedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        for case let item as [String: Any] in arr {
-            guard let t = item["title"] as? String else { continue }
-            let normalizedActualTitle = t.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard normalizedActualTitle == normalizedExpectedTitle else { continue }
-            var priceOk = false
-            if let price = item["price"] as? [String: Any], let pv = price["value"] {
-                if let d = pv as? Double, abs(d - priceValue) < 0.01 { priceOk = true }
-                if let i = pv as? Int, Double(i) == priceValue { priceOk = true }
-                if let n = pv as? NSNumber, abs(n.doubleValue - priceValue) < 0.01 { priceOk = true }
-            }
-            guard priceOk else { continue }
-            let widthValue = item["width"] ?? (item["dimensions"] as? [String: Any])?["width"]
-            if let w = widthValue as? String, w == widthText { return true }
-            if let w = widthValue as? Int, String(w) == widthText { return true }
-            if let n = widthValue as? NSNumber, n.stringValue == widthText { return true }
-        }
-        return false
-    }
-
-    private func createHomeFlowData(buttonLabel: String) -> [String: Any] {
-        return [
-            "id": "f267c629-2594-4770-8cec-d5324ebb4058",
-            "name": "Home",
-            "pages": [
-                [
-                    "id": "55e427ac-263c-441f-9673-f60627b1baea",
-                    "title": "Home",
-                    "rows": [
-                        [
-                            "id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
-                            "type": "ColumnContainer",
-                            "source": "",
-                            "destination": "",
-                            "actions": [],
-                            "view": [
-                                "content": [
-                                    "title": "",
-                                    "children": [
-                                        [
-                                            "id": "441c1433-446b-4682-854d-5d795ef52709",
-                                            "type": "Button",
-                                            "source": "",
-                                            "destination": "",
-                                            "view": [
-                                                "content": [
-                                                    "title": "",
-                                                    "label": buttonLabel
-                                                ]
-                                            ],
-                                            "actions": [[
-                                                "condition": "",
-                                                "false": "",
-                                                "true": "navigate:74a49d4b-2176-4925-857a-e29e2991f1bd:82cae120-c7b1-4c29-bd42-e1521320b109"
-                                            ]]
-                                        ],
-                                        [
-                                            "id": "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
-                                            "type": "Button",
-                                            "source": "",
-                                            "destination": "",
-                                            "view": [
-                                                "content": [
-                                                    "title": "",
-                                                    "label": "Create"
-                                                ]
-                                            ],
-                                            "actions": [[
-                                                "condition": "",
-                                                "false": "",
-                                                "true": "navigate:ca47e6c5-da19-4491-8422-adb40d9e8a27:306ed62c-c2af-4652-a873-26c7a388972d"
-                                            ]]
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
+          "id": "306ed62c-c2af-4652-a873-26c7a388972d",
+          "title": "Create listing",
+          "rows": [
+            [
+              "id": "e0fc5df1-b4bf-4996-87f4-f2b0f3c2a0be",
+              "type": "Input",
+              "source": "{item}",
+              "view": [
+                "content": [
+                  "title": "Title",
+                  "value": "{title}",
+                  "placeholder": "Item",
                 ]
-            ]
+              ],
+              "destination": "{title}",
+              "actions": [],
+            ],
+            [
+              "id": "668aeb79-d8ba-43b7-9619-07f91d0a1908",
+              "type": "Input",
+              "source": "{item}",
+              "view": [
+                "content": [
+                  "title": "Price",
+                  "value": "{formatCurrency(price)}",
+                  "placeholder": "0",
+                ]
+              ],
+              "destination": "{buildCurrency(price)}",
+              "actions": [],
+            ],
+            [
+              "id": "2a9b22a0-b0eb-4648-83ca-77b2b8748816",
+              "type": "Input",
+              "source": "{item}",
+              "view": [
+                "content": [
+                  "title": "Width",
+                  "value": "{formatDimension(width)}",
+                  "placeholder": "0",
+                ]
+              ],
+              "destination": "{width}",
+              "actions": [],
+            ],
+          ],
+          "footer": [
+            "id": "1cb41189-6fa5-4562-996a-7cefb88a08ca",
+            "type": "Button",
+            "source": "{item}",
+            "destination": "",
+            "view": [
+              "content": [
+                "title": "",
+                "label": "Submit",
+              ]
+            ],
+            "actions": [
+              [
+                "condition": "",
+                "false": "",
+                "true": "{create(item)}",
+              ]
+            ],
+          ],
         ]
+      ],
+    ]
+  }
+
+  private static func marketplaceItemsContainListing(
+    title: String,
+    priceValue: Double,
+    widthText: String,
+    items: Any
+  ) -> Bool {
+    guard let arr = items as? [Any] else { return false }
+    let normalizedExpectedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    for case let item as [String: Any] in arr {
+      guard let t = item["title"] as? String else { continue }
+      let normalizedActualTitle = t.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard normalizedActualTitle == normalizedExpectedTitle else { continue }
+      var priceOk = false
+      if let price = item["price"] as? [String: Any], let pv = price["value"] {
+        if let d = pv as? Double, abs(d - priceValue) < 0.01 { priceOk = true }
+        if let i = pv as? Int, Double(i) == priceValue { priceOk = true }
+        if let n = pv as? NSNumber, abs(n.doubleValue - priceValue) < 0.01 { priceOk = true }
+      }
+      guard priceOk else { continue }
+      let widthValue = item["width"] ?? (item["dimensions"] as? [String: Any])?["width"]
+      if let w = widthValue as? String, w == widthText { return true }
+      if let w = widthValue as? Int, String(w) == widthText { return true }
+      if let n = widthValue as? NSNumber, n.stringValue == widthText { return true }
+    }
+    return false
+  }
+
+  private func createHomeFlowData(buttonLabel: String) -> [String: Any] {
+    return [
+      "id": "f267c629-2594-4770-8cec-d5324ebb4058",
+      "name": "Home",
+      "pages": [
+        [
+          "id": "55e427ac-263c-441f-9673-f60627b1baea",
+          "title": "Home",
+          "rows": [
+            [
+              "id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
+              "type": "ColumnContainer",
+              "source": "",
+              "destination": "",
+              "actions": [],
+              "view": [
+                "content": [
+                  "title": "",
+                  "children": [
+                    [
+                      "id": "441c1433-446b-4682-854d-5d795ef52709",
+                      "type": "Button",
+                      "source": "",
+                      "destination": "",
+                      "view": [
+                        "content": [
+                          "title": "",
+                          "label": buttonLabel,
+                        ]
+                      ],
+                      "actions": [
+                        [
+                          "condition": "",
+                          "false": "",
+                          "true":
+                            "navigate:74a49d4b-2176-4925-857a-e29e2991f1bd:82cae120-c7b1-4c29-bd42-e1521320b109",
+                        ]
+                      ],
+                    ],
+                    [
+                      "id": "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
+                      "type": "Button",
+                      "source": "",
+                      "destination": "",
+                      "view": [
+                        "content": [
+                          "title": "",
+                          "label": "Create",
+                        ]
+                      ],
+                      "actions": [
+                        [
+                          "condition": "",
+                          "false": "",
+                          "true":
+                            "navigate:ca47e6c5-da19-4491-8422-adb40d9e8a27:306ed62c-c2af-4652-a873-26c7a388972d",
+                        ]
+                      ],
+                    ],
+                  ],
+                ]
+              ],
+            ]
+          ],
+        ]
+      ],
+    ]
+  }
+
+  private func createConditionalFlowData(buttonLabel: String) -> [String: Any] {
+    var flowData = createHomeFlowData(buttonLabel: buttonLabel)
+    guard var pages = flowData["pages"] as? [[String: Any]],
+      var homePage = pages.first,
+      var rows = homePage["rows"] as? [[String: Any]],
+      var firstRow = rows.first,
+      var rowView = firstRow["view"] as? [String: Any],
+      var rowContent = rowView["content"] as? [String: Any],
+      var children = rowContent["children"] as? [[String: Any]],
+      var firstButton = children.first,
+      var actions = firstButton["actions"] as? [[String: Any]],
+      var firstAction = actions.first
+    else {
+      return flowData
     }
 
-    private func createConditionalFlowData(buttonLabel: String) -> [String: Any] {
-        var flowData = createHomeFlowData(buttonLabel: buttonLabel)
-        guard var pages = flowData["pages"] as? [[String: Any]],
-              var homePage = pages.first,
-              var rows = homePage["rows"] as? [[String: Any]],
-              var firstRow = rows.first,
-              var rowView = firstRow["view"] as? [String: Any],
-              var rowContent = rowView["content"] as? [String: Any],
-              var children = rowContent["children"] as? [[String: Any]],
-              var firstButton = children.first,
-              var actions = firstButton["actions"] as? [[String: Any]],
-              var firstAction = actions.first else {
-            return flowData
-        }
-
-        firstAction["condition"] = "{1 > 0 || (0 > 1 && 2 > 3)}"
-        actions[0] = firstAction
-        firstButton["actions"] = actions
-        children[0] = firstButton
-        rowContent["children"] = children
-        rowView["content"] = rowContent
-        firstRow["view"] = rowView
-        rows[0] = firstRow
-        homePage["rows"] = rows
-        pages[0] = homePage
-        flowData["pages"] = pages
-        return flowData
-    }
+    firstAction["condition"] = "{1 > 0 || (0 > 1 && 2 > 3)}"
+    actions[0] = firstAction
+    firstButton["actions"] = actions
+    children[0] = firstButton
+    rowContent["children"] = children
+    rowView["content"] = rowContent
+    firstRow["view"] = rowView
+    rows[0] = firstRow
+    homePage["rows"] = rows
+    pages[0] = homePage
+    flowData["pages"] = pages
+    return flowData
+  }
 }
 
 // MARK: - Error / unreachable API
 
 final class E2EErrorStateTests: XCTestCase {
-    private var app: XCUIApplication!
+  private var app: XCUIApplication!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchEnvironment["API_HOST"] = "127.0.0.1:59998"
-        app.launch()
-    }
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    continueAfterFailure = false
+    app = XCUIApplication()
+    app.launchEnvironment["API_HOST"] = "127.0.0.1:59998"
+    app.launch()
+  }
 
-    override func tearDownWithError() throws {
-        app = nil
-        try super.tearDownWithError()
-    }
+  override func tearDownWithError() throws {
+    app = nil
+    try super.tearDownWithError()
+  }
 
-    func testUnreachableAPIShowsErrorState() throws {
-        let failedMessage = app.staticTexts["Failed to load flows"]
-        XCTAssertTrue(
-            failedMessage.waitForExistence(timeout: 5),
-            "User-visible copy should mention failed flow load"
-        )
-        let retryMessage = app.staticTexts["Please check your connection and try again"]
-        XCTAssertTrue(
-            retryMessage.exists,
-            "User-visible copy should explain how to recover from a failed flow load"
-        )
-    }
+  func testUnreachableAPIShowsErrorState() throws {
+    let failedMessage = app.staticTexts["Failed to load flows"]
+    XCTAssertTrue(
+      failedMessage.waitForExistence(timeout: 5),
+      "User-visible copy should mention failed flow load"
+    )
+    let retryMessage = app.staticTexts["Please check your connection and try again"]
+    XCTAssertTrue(
+      retryMessage.exists,
+      "User-visible copy should explain how to recover from a failed flow load"
+    )
+  }
 }

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		734FD96D2C343C0100ACE8B7 /* EVYCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734FD96C2C343C0100ACE8B7 /* EVYCalendar.swift */; };
 		735795D32C21AF6100ADB49D /* interpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735795D22C21AF6100ADB49D /* interpreter.swift */; };
 		736495BF2B972E1800729129 /* EVYDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736495BE2B972E1800729129 /* EVYDataManager.swift */; };
+		73F7E0022F70000100000001 /* EVYError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7E0012F70000100000001 /* EVYError.swift */; };
 		736D10572B78C4C500503C4D /* EVYPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736D10562B78C4C500503C4D /* EVYPage.swift */; };
 		736D105F2B78CDDB00503C4D /* EVYTextRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736D105E2B78CDDB00503C4D /* EVYTextRow.swift */; };
 		737334F92B7B5F1800D2E1CF /* EVYInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737334F82B7B5F1800D2E1CF /* EVYInputRow.swift */; };
@@ -128,6 +129,7 @@
 		734FD96C2C343C0100ACE8B7 /* EVYCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYCalendar.swift; sourceTree = "<group>"; };
 		735795D22C21AF6100ADB49D /* interpreter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = interpreter.swift; sourceTree = "<group>"; };
 		736495BE2B972E1800729129 /* EVYDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYDataManager.swift; sourceTree = "<group>"; };
+		73F7E0012F70000100000001 /* EVYError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYError.swift; sourceTree = "<group>"; };
 		736D10562B78C4C500503C4D /* EVYPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYPage.swift; sourceTree = "<group>"; };
 		736D105E2B78CDDB00503C4D /* EVYTextRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYTextRow.swift; sourceTree = "<group>"; };
 		737334F82B7B5F1800D2E1CF /* EVYInputRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYInputRow.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 				737C6ABF2B270AAE0093D00C /* Models */,
 				737C6ACA2B270AD90093D00C /* EVYAPIManager.swift */,
 				736495BE2B972E1800729129 /* EVYDataManager.swift */,
+				73F7E0012F70000100000001 /* EVYError.swift */,
 				73DAEC0B2C7729F8003A0A29 /* EVYSearchController.swift */,
 			);
 			path = Data;
@@ -656,6 +659,7 @@
 				73F3A0012F30B00300000001 /* EVYActionRunner.swift in Sources */,
 				73CDCAC22B272E0C00D4E82A /* EVYRow.swift in Sources */,
 				736495BF2B972E1800729129 /* EVYDataManager.swift in Sources */,
+				73F7E0022F70000100000001 /* EVYError.swift in Sources */,
 				736D105F2B78CDDB00503C4D /* EVYTextRow.swift in Sources */,
 				73B3CF812C68ABD100FD333A /* EVYSelectSegmentContainerRow.swift in Sources */,
 				2E8EEC3A2B2730B0003DF2DC /* Constants.swift in Sources */,

--- a/ios/evy/Constants.swift
+++ b/ios/evy/Constants.swift
@@ -8,33 +8,38 @@
 import SwiftUI
 
 extension Font {
-    static let evy = Font.custom("SFProText-Regular", size: 15)
-    static let evyTitle = Font.custom("SFProText-Bold", size: 20)
-    static let evyButton = Font.custom("SFProText-Regular", size: 24)
+  static let evy = Font.custom("SFProText-Regular", size: 15)
+  static let evyTitle = Font.custom("SFProText-Bold", size: 20)
+  static let evyButton = Font.custom("SFProText-Regular", size: 24)
 }
 
 struct Constants {
-    static let base = 4.0
-    
-    static let padding = base
-    static let fieldPadding: CGFloat = base*6
-    static let majorPadding: CGFloat = base*4
-    static let minorPadding: CGFloat = base*2
-    
-    static let mainCornerRadius: CGFloat = base*2
-    static let smallCornerRadius: CGFloat = base
+  static let base = 4.0
 
-    static let textGreyColor = Color(#colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1))
-    static let buttonColor: Color = Color(#colorLiteral(red: 0.2352934182, green: 0.2352946103, blue: 0.2610042691, alpha: 1))
-    static let buttonDisabledColor: Color = Color(#colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1))
-    static let tappableClearColor: Color = Color.black.opacity(0.0001)
-    static let actionColor: Color = .blue
-    static let inactiveBackground: Color = Color(#colorLiteral(red: 0.9621850848, green: 0.9621850848, blue: 0.9621850848, alpha: 1))
-    
-    static let borderWidth: CGFloat = 1.0
-    static let thinBorderWidth: CGFloat = 0.5
-    static let borderColor: Color = Color(#colorLiteral(red: 0.7267977595, green: 0.7267977595, blue: 0.7267977595, alpha: 1))
-    static let borderOpacity: CGFloat = 0.5
-	
-	static let listRowHeight: CGFloat = base*12
+  static let padding = base
+  static let fieldPadding: CGFloat = base * 6
+  static let majorPadding: CGFloat = base * 4
+  static let minorPadding: CGFloat = base * 2
+
+  static let mainCornerRadius: CGFloat = base * 2
+  static let smallCornerRadius: CGFloat = base
+
+  static let textGreyColor = Color(
+    #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1))
+  static let buttonColor: Color = Color(
+    #colorLiteral(red: 0.2352934182, green: 0.2352946103, blue: 0.2610042691, alpha: 1))
+  static let buttonDisabledColor: Color = Color(
+    #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1))
+  static let tappableClearColor: Color = Color.black.opacity(0.0001)
+  static let actionColor: Color = .blue
+  static let inactiveBackground: Color = Color(
+    #colorLiteral(red: 0.9621850848, green: 0.9621850848, blue: 0.9621850848, alpha: 1))
+
+  static let borderWidth: CGFloat = 1.0
+  static let thinBorderWidth: CGFloat = 0.5
+  static let borderColor: Color = Color(
+    #colorLiteral(red: 0.7267977595, green: 0.7267977595, blue: 0.7267977595, alpha: 1))
+  static let borderOpacity: CGFloat = 0.5
+
+  static let listRowHeight: CGFloat = base * 12
 }

--- a/ios/evy/ContentView.swift
+++ b/ios/evy/ContentView.swift
@@ -8,294 +8,296 @@
 import SwiftUI
 
 public struct Route: Hashable, Codable {
-    let flowId: String
-    let pageId: String
+  let flowId: String
+  let pageId: String
 }
 public enum NavOperation: Hashable {
-    case navigate(Route)
-    case create(String)
-    case highlightRequired(String)
-    case close
+  case navigate(Route)
+  case create(String)
+  case highlightRequired(String)
+  case close
 }
 
 struct NavigateEnvironmentKey: EnvironmentKey {
-    static let defaultValue: (NavOperation) -> Void = { _ in }
+  static let defaultValue: (NavOperation) -> Void = { _ in }
 }
 
 extension EnvironmentValues {
-    var navigate: (NavOperation) -> Void {
-        get { self[NavigateEnvironmentKey.self] }
-        set { self[NavigateEnvironmentKey.self] = newValue }
-    }
+  var navigate: (NavOperation) -> Void {
+    get { self[NavigateEnvironmentKey.self] }
+    set { self[NavigateEnvironmentKey.self] = newValue }
+  }
 }
 
 private let HOME_FLOW_ID = "f267c629-2594-4770-8cec-d5324ebb4058"
 
 struct ContentView: View {
-    @State private var flows: [UI_Flow] = []
-    @State private var routes: [Route] = []
-    @State private var currentFlowId: String = HOME_FLOW_ID
-	@State private var showingAlert = false
-	@State private var alertTitle = ""
-	@State private var alertMessage = ""
-	@State private var loading = true
-    @State private var itemData: Data?
-    @State private var activeDraftKeys: Set<String> = []
+  @State private var flows: [UI_Flow] = []
+  @State private var routes: [Route] = []
+  @State private var currentFlowId: String = HOME_FLOW_ID
+  @State private var showingAlert = false
+  @State private var alertTitle = ""
+  @State private var alertMessage = ""
+  @State private var loading = true
+  @State private var itemData: Data?
+  @State private var activeDraftKeys: Set<String> = []
 
-    private func showError(_ error: Error) {
-		alertTitle = "Error"
-        alertMessage = error.localizedDescription
+  private func showError(_ error: Error) {
+    alertTitle = "Error"
+    alertMessage = error.localizedDescription
+    showingAlert = true
+  }
+
+  private func handleNavigationData(_ navOperation: NavOperation, _ currentFlowId: String) {
+    switch navOperation {
+    case .navigate(let route):
+      if let existing = routes.lastIndex(of: route) {
+        routes.removeSubrange(existing...)
+      } else {
+        routes.append(route)
+      }
+
+      if currentFlowId == route.flowId {
+        break
+      }
+
+      guard let newFlow = flows.first(where: { $0.id == route.flowId }) else {
+        alertTitle = "Unable to load flow"
+        alertMessage = "Please check your internet connection"
         showingAlert = true
-    }
+        routes.removeLast()
+        break
+      }
 
-    private func handleNavigationData(_ navOperation: NavOperation, _ currentFlowId: String) {
-        switch navOperation {
-        case .navigate(let route):
-            if let existing = routes.lastIndex(of: route) {
-                routes.removeSubrange(existing...)
-			} else {
-				routes.append(route)
-			}
-
-            if currentFlowId == route.flowId {
-                break
-            }
-
-            guard let newFlow = flows.first(where: { $0.id == route.flowId }) else {
-				alertTitle = "Unable to load flow"
-                alertMessage = "Please check your internet connection"
-                showingAlert = true
-                routes.removeLast()
-                break
-            }
-
-            let createKeys = Self.extractCreateKeys(from: newFlow)
-            for key in createKeys {
-                guard let itemData = itemData else {
-					alertTitle = "Unable to load item"
-                    alertMessage = "Please check your internet connection"
-                    showingAlert = true
-                    routes.removeLast()
-                    break
-                }
-                do {
-                    try EVY.data.create(key: key, data: itemData)
-                    activeDraftKeys.insert(key)
-                } catch EVYDataError.keyAlreadyExists {
-                    activeDraftKeys.insert(key)
-                } catch {
-                    showError(error)
-                }
-            }
-
-        case .create(let key):
-            createFlow(currentFlowId: currentFlowId, key: key)
-
-        case .highlightRequired(let fieldName):
-			alertTitle = "Missing information"
-            alertMessage = "\(fieldName) is required"
-            showingAlert = true
-
-        case .close:
-			if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
-                routes.removeSubrange(existing...)
-            } else {
-                routes.removeAll()
-            }
+      let createKeys = Self.extractCreateKeys(from: newFlow)
+      for key in createKeys {
+        guard let itemData = itemData else {
+          alertTitle = "Unable to load item"
+          alertMessage = "Please check your internet connection"
+          showingAlert = true
+          routes.removeLast()
+          break
         }
-    }
-
-    private func createFlow(currentFlowId: String, key: String) {
         do {
-            let draftScope = EVYDraft.createMergeScopeId(flowId: currentFlowId, entityKey: key)
-            try EVY.create(key: key, draftScopeId: draftScope)
+          try EVY.data.create(key: key, data: itemData)
+          activeDraftKeys.insert(key)
+        } catch EVYDataError.keyAlreadyExists {
+          activeDraftKeys.insert(key)
         } catch {
-            showError(error)
-            return
+          showError(error)
         }
+      }
 
-        activeDraftKeys.remove(key)
+    case .create(let key):
+      createFlow(currentFlowId: currentFlowId, key: key)
 
-        if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
-            routes.removeSubrange(existing...)
-        } else {
-            routes.removeAll()
-        }
+    case .highlightRequired(let fieldName):
+      alertTitle = "Missing information"
+      alertMessage = "\(fieldName) is required"
+      showingAlert = true
+
+    case .close:
+      if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
+        routes.removeSubrange(existing...)
+      } else {
+        routes.removeAll()
+      }
+    }
+  }
+
+  private func createFlow(currentFlowId: String, key: String) {
+    do {
+      let draftScope = EVYDraft.createMergeScopeId(flowId: currentFlowId, entityKey: key)
+      try EVY.create(key: key, draftScopeId: draftScope)
+    } catch {
+      showError(error)
+      return
     }
 
-    @ViewBuilder
-    private var homeContent: some View {
-        if loading {
-            ProgressView()
-                .controlSize(.large)
-                .accessibilityIdentifier("loadingIndicator")
-        } else if let homeFlow = flows.first(where: { $0.id == HOME_FLOW_ID }) {
-            if homeFlow.pages.isEmpty {
-                VStack(spacing: 20) {
-                    Text("This flow has no pages")
-                        .font(.evyTitle)
-                        .foregroundColor(.gray)
-                        .accessibilityIdentifier("emptyFlowMessage")
-                }
-            } else if let homePage = homeFlow.pages.first {
-                homePage
-                    .environment(\.navigate) { navOperation in
-                        handleNavigationData(navOperation, currentFlowId)
-                    }
-            }
-        } else {
-            VStack(spacing: 20) {
-                Text("Failed to load flows")
-                    .font(.evyTitle)
-                    .foregroundColor(.red)
-                    .accessibilityIdentifier("errorMessage")
-                Text("Please check your connection and try again")
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
-            }
-            .accessibilityIdentifier("errorState")
+    activeDraftKeys.remove(key)
+
+    if let existing = routes.firstIndex(where: { $0.flowId == currentFlowId }) {
+      routes.removeSubrange(existing...)
+    } else {
+      routes.removeAll()
+    }
+  }
+
+  @ViewBuilder
+  private var homeContent: some View {
+    if loading {
+      ProgressView()
+        .controlSize(.large)
+        .accessibilityIdentifier("loadingIndicator")
+    } else if let homeFlow = flows.first(where: { $0.id == HOME_FLOW_ID }) {
+      if homeFlow.pages.isEmpty {
+        VStack(spacing: 20) {
+          Text("This flow has no pages")
+            .font(.evyTitle)
+            .foregroundColor(.gray)
+            .accessibilityIdentifier("emptyFlowMessage")
+        }
+      } else if let homePage = homeFlow.pages.first {
+        homePage
+          .environment(\.navigate) { navOperation in
+            handleNavigationData(navOperation, currentFlowId)
+          }
+      }
+    } else {
+      VStack(spacing: 20) {
+        Text("Failed to load flows")
+          .font(.evyTitle)
+          .foregroundColor(.red)
+          .accessibilityIdentifier("errorMessage")
+        Text("Please check your connection and try again")
+          .font(.subheadline)
+          .foregroundColor(.gray)
+      }
+      .accessibilityIdentifier("errorState")
+    }
+  }
+
+  var body: some View {
+    NavigationStack(path: $routes) {
+      homeContent
+        .task {
+          if !flows.isEmpty { return }
+
+          do {
+            try EVY.getUserData()
+            try await EVY.syncAllServices()
+            itemData = try EVY.getItemData()
+            flows = try await EVY.getSDUI()
+            loading = false
+          } catch let error as EVYRPCError {
+            alertTitle = "Error"
+            alertMessage = error.localizedDescription
+            showingAlert = true
+            loading = false
+          } catch {
+            alertTitle = "Error"
+            alertMessage = error.localizedDescription
+            showingAlert = true
+            loading = false
+          }
+        }
+        .navigationDestination(for: Route.self) { route in
+          if let flow = flows.first(where: { $0.id == route.flowId }),
+            let page = flow.getPageById(route.pageId)
+          {
+            page
+              .environment(\.evyDraftScopeId, Self.draftScopeId(for: route, flows: flows))
+              .environment(\.navigate) { navOperation in
+                handleNavigationData(navOperation, currentFlowId)
+              }
+          } else {
+            Text("Flow not found")
+              .foregroundColor(.red)
+          }
         }
     }
-
-    var body: some View {
-        NavigationStack(path: $routes) {
-            homeContent
-                .task {
-                    if !flows.isEmpty { return }
-
-                    do {
-                        try EVY.getUserData()
-                        try await EVY.syncAllServices()
-                        itemData = try EVY.getItemData()
-                        flows = try await EVY.getSDUI()
-                        loading = false
-                    } catch let error as EVYRPCError {
-						alertTitle = "Error"
-                        alertMessage = error.localizedDescription
-                        showingAlert = true
-                        loading = false
-                    } catch {
-						alertTitle = "Error"
-                        alertMessage = error.localizedDescription
-                        showingAlert = true
-                        loading = false
-                    }
-                }
-                .navigationDestination(for: Route.self) { route in
-                    if let flow = flows.first(where: { $0.id == route.flowId }),
-                       let page = flow.getPageById(route.pageId) {
-                        page
-                            .environment(\.evyDraftScopeId, Self.draftScopeId(for: route, flows: flows))
-                            .environment(\.navigate) { navOperation in
-                                handleNavigationData(navOperation, currentFlowId)
-                            }
-                    } else {
-                        Text("Flow not found")
-                            .foregroundColor(.red)
-                    }
-                }
-        }
-		.alert(isPresented: $showingAlert) {
-			Alert(title: Text(alertTitle),
-				  message: Text(alertMessage),
-				  dismissButton: .default(Text("Ok")))
-		}
-        .onChange(of: routes) { _, _ in
-            let previousFlowId = currentFlowId
-            let newFlowId = routes.last?.flowId ?? HOME_FLOW_ID
-
-            if newFlowId != previousFlowId {
-                let keysToDelete = Self.createKeysToDelete(
-                    whenLeaving: previousFlowId,
-                    flows: flows,
-                    activeDraftKeys: activeDraftKeys
-                )
-                if !keysToDelete.isEmpty {
-                    for key in keysToDelete {
-                        EVY.data.deleteDrafts(
-                            scopeId: EVYDraft.createMergeScopeId(
-                                flowId: previousFlowId,
-                                entityKey: key
-                            )
-                        )
-                    }
-                    for key in keysToDelete {
-                        do {
-                            try EVY.data.delete(key: key)
-                        } catch EVYDataError.keyNotFound {
-                        } catch {
-                            showError(error)
-                        }
-                    }
-                    activeDraftKeys.subtract(keysToDelete)
-                }
-            }
-
-            currentFlowId = newFlowId
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .evyFlowUpdated)) { notification in
-            guard let updatedFlow = notification.object as? UI_Flow else { return }
-
-            var nextFlows = flows
-            if let index = nextFlows.firstIndex(where: { $0.id == updatedFlow.id }) {
-                nextFlows[index] = updatedFlow
-            } else {
-                nextFlows.append(updatedFlow)
-            }
-            flows = nextFlows
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .evyErrorOccurred)) { notification in
-            if let error = notification.object as? Error {
-                if loading { loading = false }
-                showError(error)
-            }
-        }
+    .alert(isPresented: $showingAlert) {
+      Alert(
+        title: Text(alertTitle),
+        message: Text(alertMessage),
+        dismissButton: .default(Text("Ok")))
     }
+    .onChange(of: routes) { _, _ in
+      let previousFlowId = currentFlowId
+      let newFlowId = routes.last?.flowId ?? HOME_FLOW_ID
 
-    static func draftScopeId(for route: Route, flows: [UI_Flow]) -> String? {
-        guard let flow = flows.first(where: { $0.id == route.flowId }) else { return nil }
-        let keys = extractCreateKeys(from: flow)
-        if let k = keys.sorted().first {
-            return EVYDraft.createMergeScopeId(flowId: route.flowId, entityKey: k)
-        }
-        return "\(route.flowId)#browse"
-    }
-
-    static func createKeysToDelete(
-        whenLeaving flowId: String,
-        flows: [UI_Flow],
-        activeDraftKeys: Set<String>
-    ) -> Set<String> {
-        guard let flow = flows.first(where: { $0.id == flowId }) else {
-            return []
-        }
-        return extractCreateKeys(from: flow).intersection(activeDraftKeys)
-    }
-
-    private static func extractCreateKeys(from flow: UI_Flow) -> Set<String> {
-        var keys = Set<String>()
-        for page in flow.pages {
-            forEachRow(in: page) { row in
-                for action in row.actions {
-                    for branch in [action.`true`, action.`false`] {
-                        var unwrapped = branch.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if unwrapped.hasPrefix("{"), unwrapped.hasSuffix("}") {
-                            unwrapped = String(unwrapped.dropFirst().dropLast())
-                        }
-                        if let (name, args) = parseFunctionCall(unwrapped),
-                           name == "create"
-                        {
-                            let key = args.trimmingCharacters(in: .whitespacesAndNewlines)
-                            if !key.isEmpty { keys.insert(key) }
-                        }
-                    }
-                }
+      if newFlowId != previousFlowId {
+        let keysToDelete = Self.createKeysToDelete(
+          whenLeaving: previousFlowId,
+          flows: flows,
+          activeDraftKeys: activeDraftKeys
+        )
+        if !keysToDelete.isEmpty {
+          for key in keysToDelete {
+            EVY.data.deleteDrafts(
+              scopeId: EVYDraft.createMergeScopeId(
+                flowId: previousFlowId,
+                entityKey: key
+              )
+            )
+          }
+          for key in keysToDelete {
+            do {
+              try EVY.data.delete(key: key)
+            } catch EVYDataError.keyNotFound {
+            } catch {
+              showError(error)
             }
+          }
+          activeDraftKeys.subtract(keysToDelete)
         }
-        return keys
+      }
+
+      currentFlowId = newFlowId
     }
+    .onReceive(NotificationCenter.default.publisher(for: .evyFlowUpdated)) { notification in
+      guard let updatedFlow = notification.object as? UI_Flow else { return }
+
+      var nextFlows = flows
+      if let index = nextFlows.firstIndex(where: { $0.id == updatedFlow.id }) {
+        nextFlows[index] = updatedFlow
+      } else {
+        nextFlows.append(updatedFlow)
+      }
+      flows = nextFlows
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .evyErrorOccurred)) { notification in
+      if let error = notification.object as? Error {
+        if loading { loading = false }
+        showError(error)
+      }
+    }
+  }
+
+  static func draftScopeId(for route: Route, flows: [UI_Flow]) -> String? {
+    guard let flow = flows.first(where: { $0.id == route.flowId }) else { return nil }
+    let keys = extractCreateKeys(from: flow)
+    if let k = keys.sorted().first {
+      return EVYDraft.createMergeScopeId(flowId: route.flowId, entityKey: k)
+    }
+    return "\(route.flowId)#browse"
+  }
+
+  static func createKeysToDelete(
+    whenLeaving flowId: String,
+    flows: [UI_Flow],
+    activeDraftKeys: Set<String>
+  ) -> Set<String> {
+    guard let flow = flows.first(where: { $0.id == flowId }) else {
+      return []
+    }
+    return extractCreateKeys(from: flow).intersection(activeDraftKeys)
+  }
+
+  private static func extractCreateKeys(from flow: UI_Flow) -> Set<String> {
+    var keys = Set<String>()
+    for page in flow.pages {
+      forEachRow(in: page) { row in
+        for action in row.actions {
+          for branch in [action.`true`, action.`false`] {
+            var unwrapped = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+            if unwrapped.hasPrefix("{"), unwrapped.hasSuffix("}") {
+              unwrapped = String(unwrapped.dropFirst().dropLast())
+            }
+            if let (name, args) = parseFunctionCall(unwrapped),
+              name == "create"
+            {
+              let key = args.trimmingCharacters(in: .whitespacesAndNewlines)
+              if !key.isEmpty { keys.insert(key) }
+            }
+          }
+        }
+      }
+    }
+    return keys
+  }
 }
 
 #Preview {
-    ContentView()
+  ContentView()
 }

--- a/ios/evy/Data/API/EVYAPI.swift
+++ b/ios/evy/Data/API/EVYAPI.swift
@@ -8,77 +8,77 @@
 import Foundation
 
 struct APIResponse: Decodable {
-    let results: [Result]
-    
-    private enum CodingKeys: String, CodingKey {
-        case results = "Search"
-    }
+  let results: [Result]
+
+  private enum CodingKeys: String, CodingKey {
+    case results = "Search"
+  }
 }
 
 struct Result: Decodable, Encodable {
-    let id: String
-    let value: String
-    
-    private enum DecodingKeys: String, CodingKey {
-        case id = "imdbID"
-        case value = "Title"
-    }
-    
-    private enum EncodingKeys: String, CodingKey {
-        case id
-        case value
-    }
-    
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: DecodingKeys.self)
-        id = try container.decode(String.self, forKey: .id)
-        
-        let decodedValue = try container.decode(String.self, forKey: .value)
-        let components = decodedValue.components(separatedBy: " ")
-        value = components.randomElement()!
-    }
-    
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: EncodingKeys.self)
-        try container.encode(id, forKey: .id)
-        try container.encode(value, forKey: .value)
-    }
+  let id: String
+  let value: String
+
+  private enum DecodingKeys: String, CodingKey {
+    case id = "imdbID"
+    case value = "Title"
+  }
+
+  private enum EncodingKeys: String, CodingKey {
+    case id
+    case value
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: DecodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+
+    let decodedValue = try container.decode(String.self, forKey: .value)
+    let components = decodedValue.components(separatedBy: " ")
+    value = components.randomElement()!
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: EncodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(value, forKey: .value)
+  }
 }
 
 enum NetworkError: Error {
-    case badURL
-    case badID
+  case badURL
+  case badID
 }
 
 class EVYMovieAPI {
-    func search(term: String) async throws -> Data {
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = "omdbapi.com"
-        components.queryItems = [
-            URLQueryItem(name: "s", value: term.trimmingCharacters(in: .whitespacesAndNewlines)),
-            URLQueryItem(name: "apikey", value: "306232b0")
-        ]
-        
-        guard let url = components.url else {
-            throw NetworkError.badURL
-        }
-        
-        let (data, response) = try await URLSession.shared.data(from: url)
-        
-        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
-            throw NetworkError.badID
-        }
-        
-        let decodedResponse: APIResponse?
-        do {
-            decodedResponse = try JSONDecoder().decode(APIResponse.self, from: data)
-        } catch {
-            #if DEBUG
-            print("[EVYAPI] Error decoding API response: \(error)")
-            #endif
-            decodedResponse = nil
-        }
-        return try JSONEncoder().encode(decodedResponse?.results ?? [])
+  func search(term: String) async throws -> Data {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "omdbapi.com"
+    components.queryItems = [
+      URLQueryItem(name: "s", value: term.trimmingCharacters(in: .whitespacesAndNewlines)),
+      URLQueryItem(name: "apikey", value: "306232b0"),
+    ]
+
+    guard let url = components.url else {
+      throw NetworkError.badURL
     }
+
+    let (data, response) = try await URLSession.shared.data(from: url)
+
+    guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+      throw NetworkError.badID
+    }
+
+    let decodedResponse: APIResponse?
+    do {
+      decodedResponse = try JSONDecoder().decode(APIResponse.self, from: data)
+    } catch {
+      #if DEBUG
+        print("[EVYAPI] Error decoding API response: \(error)")
+      #endif
+      decodedResponse = nil
+    }
+    return try JSONEncoder().encode(decodedResponse?.results ?? [])
+  }
 }

--- a/ios/evy/Data/API/EVYWebsocket.swift
+++ b/ios/evy/Data/API/EVYWebsocket.swift
@@ -10,255 +10,259 @@ import JsonRPC
 import Serializable
 
 public enum EVYRPCError: LocalizedError {
-    case loginError
-    case connectionError(String)
-    case rpcError(code: Int, message: String)
-    case unknownError(String)
-    case subscriptionError(String)
-    
-    public var errorDescription: String? {
-        switch self {
-        case .loginError:
-            return "Authentication failed"
-        case .connectionError(let message):
-            return "Connection error: \(message)"
-        case .rpcError(_, let message):
-            return message
-        case .unknownError(let message):
-            return message
-        case .subscriptionError(let message):
-            return "Subscription error: \(message)"
-        }
+  case loginError
+  case connectionError(String)
+  case rpcError(code: Int, message: String)
+  case unknownError(String)
+  case subscriptionError(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .loginError:
+      return "Authentication failed"
+    case .connectionError(let message):
+      return "Connection error: \(message)"
+    case .rpcError(_, let message):
+      return message
+    case .unknownError(let message):
+      return message
+    case .subscriptionError(let message):
+      return "Subscription error: \(message)"
     }
+  }
 }
 
 struct EVYLoginParams: Encodable {
-    let token: String
-    let os: DataOS
+  let token: String
+  let os: DataOS
 }
 
 struct DataUpdatedNotification: Decodable {
-    let dataId: String
-    let data: EVYJson
-    let createdAt: String
-    let updatedAt: String
-    
-    enum CodingKeys: String, CodingKey {
-        case dataId = "id"
-        case data
-        case createdAt
-        case updatedAt
-    }
+  let dataId: String
+  let data: EVYJson
+  let createdAt: String
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case dataId = "id"
+    case data
+    case createdAt
+    case updatedAt
+  }
 }
 
 struct FlowUpdatedNotification: Decodable {
-    let flow: UI_Flow
+  let flow: UI_Flow
 
-    enum CodingKeys: String, CodingKey {
-        case flow = "data"
-    }
+  enum CodingKeys: String, CodingKey {
+    case flow = "data"
+  }
 }
 
 protocol EVYWebsocketProtocol {
-	func connect(token: String, os: DataOS) async throws -> Bool
-	func fetch<T: Codable>(
-		method: String,
-		params: Encodable,
-		expecting _: T.Type
-	) async throws -> T
-	func subscribe(event: String) async throws -> [String: String]
+  func connect(token: String, os: DataOS) async throws -> Bool
+  func fetch<T: Codable>(
+    method: String,
+    params: Encodable,
+    expecting _: T.Type
+  ) async throws -> T
+  func subscribe(event: String) async throws -> [String: String]
 }
 
 final class EVYWebsocket: EVYWebsocketProtocol {
-    let rpc: Client & Persistent & Connectable
-    
-    init(host: String) {
-        rpc = JsonRpc(.ws(url: URL(string: "ws://\(host)")!, autoconnect: false), queue: .main)
-        rpc.delegate = self
+  let rpc: Client & Persistent & Connectable
+
+  init(host: String) {
+    rpc = JsonRpc(.ws(url: URL(string: "ws://\(host)")!, autoconnect: false), queue: .main)
+    rpc.delegate = self
+  }
+
+  public func connect(token: String, os: DataOS) async throws -> Bool {
+    if rpc.connected == .disconnected {
+      rpc.connect()
     }
-    
-    public func connect(token: String, os: DataOS) async throws -> Bool {
-        if rpc.connected == .disconnected {
-            rpc.connect()
-        }
-		return try await fetch(method: "rpc.login",
-							   params: EVYLoginParams(token: token, os: os),
-							   expecting: Bool.self)
+    return try await fetch(
+      method: "rpc.login",
+      params: EVYLoginParams(token: token, os: os),
+      expecting: Bool.self)
+  }
+
+  public func subscribe(event: String) async throws -> [String: String] {
+    try await fetch(
+      method: "rpc.on",
+      params: [event],
+      expecting: [String: String].self
+    )
+  }
+
+  public func fetch<T: Codable>(
+    method: String,
+    params: Encodable,
+    expecting _: T.Type
+  ) async throws -> T {
+    do {
+      return try await rpc.call(method: method, params: params, T.self, String.self)
+    } catch let error as AsAnyRequestError {
+      #if DEBUG
+        print("[EVYWebsocket] RPC error for method '\(method)': \(error)")
+      #endif
+      throw mapRequestError(error.anyRequestError)
+    } catch {
+      #if DEBUG
+        print("[EVYWebsocket] Unknown error for method '\(method)': \(error)")
+      #endif
+      throw EVYRPCError.unknownError(error.localizedDescription)
     }
-    
-    public func subscribe(event: String) async throws -> [String: String] {
-        try await fetch(
-            method: "rpc.on",
-            params: [event],
-            expecting: [String: String].self
-        )
+  }
+
+  private func mapRequestError(_ error: RequestError<Any, Any>) -> EVYRPCError {
+    switch error {
+    case .reply(_, _, let responseError):
+      return .rpcError(code: responseError.code, message: responseError.message)
+    case .service(.connection(let cause)):
+      return .connectionError(cause.localizedDescription)
+    case .service(.codec(let cause)):
+      return .unknownError("Encoding/decoding error: \(cause.localizedDescription)")
+    case .service(.envelope(_, let description)):
+      return .unknownError("Protocol error: \(description)")
+    case .service(.unregisteredResponse(let id, _)):
+      return .unknownError("Unregistered response with id: \(id)")
+    case .empty:
+      return .unknownError("Empty response from server")
+    case .custom(let description, _):
+      return .unknownError(description)
     }
-    
-    public func fetch<T: Codable>(
-        method: String,
-        params: Encodable,
-        expecting _: T.Type
-    ) async throws -> T {
-        do {
-            return try await rpc.call(method: method, params: params, T.self, String.self)
-        } catch let error as AsAnyRequestError {
-            #if DEBUG
-            print("[EVYWebsocket] RPC error for method '\(method)': \(error)")
-            #endif
-            throw mapRequestError(error.anyRequestError)
-        } catch {
-            #if DEBUG
-            print("[EVYWebsocket] Unknown error for method '\(method)': \(error)")
-            #endif
-            throw EVYRPCError.unknownError(error.localizedDescription)
-        }
-    }
-    
-    private func mapRequestError(_ error: RequestError<Any, Any>) -> EVYRPCError {
-        switch error {
-        case .reply(_, _, let responseError):
-            return .rpcError(code: responseError.code, message: responseError.message)
-        case .service(.connection(let cause)):
-            return .connectionError(cause.localizedDescription)
-        case .service(.codec(let cause)):
-            return .unknownError("Encoding/decoding error: \(cause.localizedDescription)")
-        case .service(.envelope(_, let description)):
-            return .unknownError("Protocol error: \(description)")
-        case .service(.unregisteredResponse(let id, _)):
-            return .unknownError("Unregistered response with id: \(id)")
-        case .empty:
-            return .unknownError("Empty response from server")
-        case .custom(let description, _):
-            return .unknownError(description)
-        }
-    }
+  }
 }
 
 extension EVYWebsocket: ConnectableDelegate, NotificationDelegate, ErrorDelegate {
-    
-    private func postError(_ error: Error) {
-        #if DEBUG
-        print("[EVYWebsocket] Error: \(error.localizedDescription)")
-        #endif
-        NotificationCenter.default.post(
-            name: Notification.Name.evyErrorOccurred,
-            object: error
-        )
-    }
-    
-    #if DEBUG
-    public func state(_ state: ConnectableState) {
-        print("[EVYWebsocket] Connection state changed: \(state)")
-    }
-    #endif
-    
-    public func error(_ error: ServiceError) {
-        #if DEBUG
-        print("[EVYWebsocket] Service error: \(error)")
-        #endif
-        postError(EVYError.websocketError(context: error.localizedDescription))
-    }
-    
-    public func notification(method: String, params: Parsable) {
-        switch method {
-        case "dataUpdated":
-            handleDataUpdated(params: params)
-        case "flowUpdated":
-            handleFlowUpdated(params: params)
-        default:
-            #if DEBUG
-            print("[EVYWebsocket] Received unknown notification: \(method)")
-            #endif
-        }
-    }
-    
-    private func handleDataUpdated(params: Parsable) {
-        let notification: DataUpdatedNotification
-        let encodedData: Data
-        
-        do {
-            guard let parsed = try params.parse(to: DataUpdatedNotification.self).get() else {
-                throw EVYError.parsingFailed(context: "dataUpdated notification returned nil")
-            }
-            notification = parsed
-            encodedData = try JSONEncoder().encode(notification.data)
-        } catch {
-            #if DEBUG
-            print("[EVYWebsocket] Failed to parse dataUpdated notification: \(error)")
-            #endif
-            postError(EVYError.parsingFailed(context: "dataUpdated: \(error.localizedDescription)"))
-            return
-        }
-        
-        // Dispatch to MainActor for thread-safe data access
-        Task { @MainActor in
-            do {
-                if EVY.data.exists(key: notification.dataId) {
-                    try EVY.data.update(props: [notification.dataId], data: encodedData)
-                } else {
-                    try EVY.data.create(key: notification.dataId, data: encodedData)
-                }
-                NotificationCenter.default.post(
-                    name: Notification.Name.evyDataUpdated,
-                    object: notification.dataId
-                )
-            } catch {
-                #if DEBUG
-                print("[EVYWebsocket] Failed to update data: \(error)")
-                #endif
-                self.postError(EVYError.invalidData(context: "failed to update data: \(error.localizedDescription)"))
-            }
-        }
-    }
-    
-    private func handleFlowUpdated(params: Parsable) {
-        do {
-            guard let notification = try params.parse(to: FlowUpdatedNotification.self).get() else {
-                throw EVYError.parsingFailed(context: "flowUpdated notification returned nil")
-            }
 
-            Task { @MainActor in
-                NotificationCenter.default.post(
-                    name: Notification.Name.evyFlowUpdated,
-                    object: notification.flow
-                )
-            }
-        } catch {
-            #if DEBUG
-            print("[EVYWebsocket] Failed to parse flowUpdated notification: \(error)")
-            #endif
-            postError(EVYError.parsingFailed(context: "flowUpdated: \(error.localizedDescription)"))
-        }
+  private func postError(_ error: Error) {
+    #if DEBUG
+      print("[EVYWebsocket] Error: \(error.localizedDescription)")
+    #endif
+    NotificationCenter.default.post(
+      name: Notification.Name.evyErrorOccurred,
+      object: error
+    )
+  }
+
+  #if DEBUG
+    public func state(_ state: ConnectableState) {
+      print("[EVYWebsocket] Connection state changed: \(state)")
     }
+  #endif
+
+  public func error(_ error: ServiceError) {
+    #if DEBUG
+      print("[EVYWebsocket] Service error: \(error)")
+    #endif
+    postError(EVYError.websocketError(context: error.localizedDescription))
+  }
+
+  public func notification(method: String, params: Parsable) {
+    switch method {
+    case "dataUpdated":
+      handleDataUpdated(params: params)
+    case "flowUpdated":
+      handleFlowUpdated(params: params)
+    default:
+      #if DEBUG
+        print("[EVYWebsocket] Received unknown notification: \(method)")
+      #endif
+    }
+  }
+
+  private func handleDataUpdated(params: Parsable) {
+    let notification: DataUpdatedNotification
+    let encodedData: Data
+
+    do {
+      guard let parsed = try params.parse(to: DataUpdatedNotification.self).get() else {
+        throw EVYError.parsingFailed(context: "dataUpdated notification returned nil")
+      }
+      notification = parsed
+      encodedData = try JSONEncoder().encode(notification.data)
+    } catch {
+      #if DEBUG
+        print("[EVYWebsocket] Failed to parse dataUpdated notification: \(error)")
+      #endif
+      postError(EVYError.parsingFailed(context: "dataUpdated: \(error.localizedDescription)"))
+      return
+    }
+
+    // Dispatch to MainActor for thread-safe data access
+    Task { @MainActor in
+      do {
+        if EVY.data.exists(key: notification.dataId) {
+          try EVY.data.update(props: [notification.dataId], data: encodedData)
+        } else {
+          try EVY.data.create(key: notification.dataId, data: encodedData)
+        }
+        NotificationCenter.default.post(
+          name: Notification.Name.evyDataUpdated,
+          object: notification.dataId
+        )
+      } catch {
+        #if DEBUG
+          print("[EVYWebsocket] Failed to update data: \(error)")
+        #endif
+        self.postError(
+          EVYError.invalidData(context: "failed to update data: \(error.localizedDescription)"))
+      }
+    }
+  }
+
+  private func handleFlowUpdated(params: Parsable) {
+    do {
+      guard let notification = try params.parse(to: FlowUpdatedNotification.self).get() else {
+        throw EVYError.parsingFailed(context: "flowUpdated notification returned nil")
+      }
+
+      Task { @MainActor in
+        NotificationCenter.default.post(
+          name: Notification.Name.evyFlowUpdated,
+          object: notification.flow
+        )
+      }
+    } catch {
+      #if DEBUG
+        print("[EVYWebsocket] Failed to parse flowUpdated notification: \(error)")
+      #endif
+      postError(EVYError.parsingFailed(context: "flowUpdated: \(error.localizedDescription)"))
+    }
+  }
 }
 
 enum JSONParseError: Error {
-	case fileNotFound
-	case dataInitialisation(error: Error)
-	case decoding(error: Error)
+  case fileNotFound
+  case dataInitialisation(error: Error)
+  case decoding(error: Error)
 }
 
 extension Decodable {
-	static func from(localJSON filename: String,
-					 bundle: Bundle = .main) throws -> Self {
-		guard let url = bundle.url(forResource: filename, withExtension: "json") else {
-			throw JSONParseError.fileNotFound
-		}
-		let data: Data
-		do {
-			data = try Data(contentsOf: url)
-		} catch let error {
-			throw JSONParseError.dataInitialisation(error: error)
-		}
-		
-		if self == Data.self {
-			return data as! Self
-		}
+  static func from(
+    localJSON filename: String,
+    bundle: Bundle = .main
+  ) throws -> Self {
+    guard let url = bundle.url(forResource: filename, withExtension: "json") else {
+      throw JSONParseError.fileNotFound
+    }
+    let data: Data
+    do {
+      data = try Data(contentsOf: url)
+    } catch let error {
+      throw JSONParseError.dataInitialisation(error: error)
+    }
 
-		do {
-			return try JSONDecoder().decode(self, from: data)
-		} catch let error {
-			throw JSONParseError.decoding(error: error)
-		}
-	}
+    if self == Data.self {
+      return data as! Self
+    }
+
+    do {
+      return try JSONDecoder().decode(self, from: data)
+    } catch let error {
+      throw JSONParseError.decoding(error: error)
+    }
+  }
 }

--- a/ios/evy/Data/EVYAPIManager.swift
+++ b/ios/evy/Data/EVYAPIManager.swift
@@ -8,42 +8,42 @@
 import Foundation
 
 private func requireAPIHost() -> String {
-	guard let host = ProcessInfo.processInfo.environment["API_HOST"], !host.isEmpty else {
-		fatalError("API_HOST is required (set by run-e2e.sh or Xcode scheme for iOS e2e)")
-	}
-	return host
+  guard let host = ProcessInfo.processInfo.environment["API_HOST"], !host.isEmpty else {
+    fatalError("API_HOST is required (set by run-e2e.sh or Xcode scheme for iOS e2e)")
+  }
+  return host
 }
 
 let API_HOST = requireAPIHost()
 let userDefault = UserDefaults.standard
 
 final class EVYAPIManager {
-	private let rpcWS: EVYWebsocketProtocol
-	private var authed: Bool = false
+  private let rpcWS: EVYWebsocketProtocol
+  private var authed: Bool = false
 
-	static let shared = EVYAPIManager()
+  static let shared = EVYAPIManager()
 
-	public func fetch<T: Codable>(
-		method: String,
-		params: Encodable,
-		expecting _: T.Type
-	) async throws -> T {
-		try await validateAuth()
-		return try await rpcWS.fetch(method: method, params: params, expecting: T.self)
-	}
+  public func fetch<T: Codable>(
+    method: String,
+    params: Encodable,
+    expecting _: T.Type
+  ) async throws -> T {
+    try await validateAuth()
+    return try await rpcWS.fetch(method: method, params: params, expecting: T.self)
+  }
 
-	private init() {
-		self.rpcWS = EVYWebsocket(host: API_HOST)
-	}
+  private init() {
+    self.rpcWS = EVYWebsocket(host: API_HOST)
+  }
 
-	private func validateAuth() async throws {
-		if (authed) { return }
+  private func validateAuth() async throws {
+    if authed { return }
 
-		authed = try await rpcWS.connect(token: "Geo", os: DataOS.ios)
+    authed = try await rpcWS.connect(token: "Geo", os: DataOS.ios)
 
-		let result = try await rpcWS.subscribe(event: "flowUpdated")
-		if result["flowUpdated"] != "ok" {
-			throw EVYRPCError.subscriptionError("Failed to subscribe to flowUpdated events")
-		}
-	}
+    let result = try await rpcWS.subscribe(event: "flowUpdated")
+    if result["flowUpdated"] != "ok" {
+      throw EVYRPCError.subscriptionError("Failed to subscribe to flowUpdated events")
+    }
+  }
 }

--- a/ios/evy/Data/EVYDataManager.swift
+++ b/ios/evy/Data/EVYDataManager.swift
@@ -9,69 +9,69 @@ import Foundation
 import SwiftData
 
 public enum EVYDataError: Error {
-    case keyAlreadyExists
-    case keyNotFound
+  case keyAlreadyExists
+  case keyNotFound
 }
 
 extension Notification.Name {
-    static let evyDataUpdated = Notification.Name("EVYDataUpdated")
-    static let evyFlowUpdated = Notification.Name("EVYFlowUpdated")
-    static let evyErrorOccurred = Notification.Name("EVYErrorOccurred")
+  static let evyDataUpdated = Notification.Name("EVYDataUpdated")
+  static let evyFlowUpdated = Notification.Name("EVYFlowUpdated")
+  static let evyErrorOccurred = Notification.Name("EVYErrorOccurred")
 }
 
 @MainActor
 @Observable class EVYState<T: Equatable> {
-    private var _value: T
-    var value: T {
-        get { _value }
-        set {
-            if _value != newValue { _value = newValue }
+  private var _value: T
+  var value: T {
+    get { _value }
+    set {
+      if _value != newValue { _value = newValue }
+    }
+  }
+
+  init(setter: @escaping () -> T) {
+    _value = setter()
+
+    NotificationCenter.default.addObserver(
+      forName: .evyDataUpdated,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        self?.value = setter()
+      }
+    }
+  }
+
+  init(watch: String, setter: @escaping (_ input: String) -> T) {
+    _value = setter(watch)
+
+    let watchProps = EVY.parsePropsFromText(watch)
+    let watchSegments = watchProps.components(separatedBy: PROP_SEPARATOR)
+
+    NotificationCenter.default.addObserver(
+      forName: .evyDataUpdated,
+      object: nil,
+      queue: .main
+    ) { [weak self] notif in
+      Task { @MainActor in
+        guard let notifProp = notif.object as? String else {
+          self?.value = setter(watch)
+          return
         }
+
+        let notifSegments = notifProp.components(separatedBy: PROP_SEPARATOR)
+        let minLen = min(watchSegments.count, notifSegments.count)
+        let prefixMatch = Array(watchSegments.prefix(minLen)) == Array(notifSegments.prefix(minLen))
+
+        if prefixMatch { self?.value = setter(watch) }
+      }
     }
+  }
 
-    init(setter: @escaping () -> T) {
-        _value = setter()
-
-        NotificationCenter.default.addObserver(
-            forName: .evyDataUpdated,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.value = setter()
-            }
-        }
-    }
-
-    init(watch: String, setter: @escaping (_ input: String) -> T) {
-        _value = setter(watch)
-
-        let watchProps = EVY.parsePropsFromText(watch)
-        let watchSegments = watchProps.components(separatedBy: PROP_SEPARATOR)
-
-        NotificationCenter.default.addObserver(
-            forName: .evyDataUpdated,
-            object: nil,
-            queue: .main
-        ) { [weak self] notif in
-            Task { @MainActor in
-                guard let notifProp = notif.object as? String else {
-                    self?.value = setter(watch)
-                    return
-                }
-
-                let notifSegments = notifProp.components(separatedBy: PROP_SEPARATOR)
-                let minLen = min(watchSegments.count, notifSegments.count)
-                let prefixMatch = Array(watchSegments.prefix(minLen)) == Array(notifSegments.prefix(minLen))
-
-                if prefixMatch { self?.value = setter(watch) }
-            }
-        }
-    }
-
-    init(staticString: T) {
-        _value = staticString
-    }
+  init(staticString: T) {
+    _value = staticString
+  }
 }
 
 let config = ModelConfiguration(isStoredInMemoryOnly: true)
@@ -79,185 +79,193 @@ let container = try! ModelContainer(for: EVYData.self, EVYDraft.self, configurat
 
 @MainActor
 final class EVYDataManager {
-    private let context: ModelContext
+  private let context: ModelContext
 
-    var activeDraftScopeId: String?
+  var activeDraftScopeId: String?
 
-    init() { self.context = ModelContext(container) }
+  init() { self.context = ModelContext(container) }
 
-    func exists(key: String) -> Bool {
-        (try? get(key: key)) != nil
+  func exists(key: String) -> Bool {
+    (try? get(key: key)) != nil
+  }
+
+  func get(key: String) throws -> EVYData {
+    let descriptor = FetchDescriptor<EVYData>(predicate: #Predicate { $0.key == key })
+    guard let first = try context.fetch(descriptor).first else {
+      throw EVYDataError.keyNotFound
+    }
+    return first
+  }
+
+  func getForBinding(key: String) throws -> EVYData {
+    if let exact = try? get(key: key) {
+      return exact
+    }
+    return try getSyncedResource(resource: key)
+  }
+
+  private func getSyncedResource(resource: String) throws -> EVYData {
+    let suffix = ":\(resource)"
+    let descriptor = FetchDescriptor<EVYData>()
+    guard let first = try context.fetch(descriptor).first(where: { $0.key.hasSuffix(suffix) })
+    else {
+      throw EVYDataError.keyNotFound
+    }
+    return first
+  }
+
+  func create(key: String, data: Data) throws {
+    if exists(key: key) {
+      throw EVYDataError.keyAlreadyExists
+    }
+    context.insert(EVYData(key: key, data: data))
+
+    NotificationCenter.default.post(
+      name: Notification.Name.evyDataUpdated,
+      object: key)
+  }
+
+  func upsert(key: String, value: Data) throws {
+    let nowIso = Date().ISO8601Format()
+
+    if let existing = try? get(key: key) {
+      existing.data = value
+      existing.lastSyncedAt = nowIso
+    } else {
+      context.insert(EVYData(key: key, lastSyncedAt: nowIso, data: value))
     }
 
-    func get(key: String) throws -> EVYData {
-        let descriptor = FetchDescriptor<EVYData>(predicate: #Predicate { $0.key == key })
-        guard let first = try context.fetch(descriptor).first else {
-            throw EVYDataError.keyNotFound
-        }
-        return first
+    NotificationCenter.default.post(
+      name: Notification.Name.evyDataUpdated,
+      object: key)
+
+    if let resourceKey = key.split(separator: ":").last.map(String.init),
+      resourceKey != key
+    {
+      NotificationCenter.default.post(
+        name: Notification.Name.evyDataUpdated,
+        object: resourceKey)
+    }
+  }
+
+  func update(props: [String], data: Data) throws {
+    let existing = try get(key: props.first!)
+    existing.data = data
+
+    var propsForNotification = props
+    if let index = props.firstIndex(where: { $0.isNumber }) {
+      propsForNotification.removeLast(props.count - index)
     }
 
-    func getForBinding(key: String) throws -> EVYData {
-        if let exact = try? get(key: key) {
-            return exact
-        }
-        return try getSyncedResource(resource: key)
+    let notifKey = propsForNotification.joined(separator: PROP_SEPARATOR)
+    NotificationCenter.default.post(
+      name: Notification.Name.evyDataUpdated,
+      object: notifKey)
+  }
+
+  func delete(key: String) throws {
+    let existing = try get(key: key)
+    context.delete(existing)
+
+    NotificationCenter.default.post(
+      name: Notification.Name.evyDataUpdated,
+      object: key)
+  }
+
+  // MARK: - Drafts
+
+  func drafts(forScopeId scopeId: String) throws -> [EVYDraft] {
+    let descriptor = FetchDescriptor<EVYDraft>(predicate: #Predicate { $0.scopeId == scopeId })
+    return try context.fetch(descriptor)
+  }
+
+  func draft(binding: EVYDraft.Binding) throws -> EVYDraft {
+    guard let row = draftFirstMatching(scopeId: binding.scopeId, pathKey: binding.pathKey) else {
+      throw EVYDataError.keyNotFound
     }
+    return row
+  }
 
-    private func getSyncedResource(resource: String) throws -> EVYData {
-        let suffix = ":\(resource)"
-        let descriptor = FetchDescriptor<EVYData>()
-        guard let first = try context.fetch(descriptor).first(where: { $0.key.hasSuffix(suffix) }) else {
-            throw EVYDataError.keyNotFound
-        }
-        return first
+  func draftIfPresent(binding: EVYDraft.Binding) -> EVYDraft? {
+    draftFirstMatching(scopeId: binding.scopeId, pathKey: binding.pathKey)
+  }
+
+  private func draftFirstMatching(scopeId: String, pathKey: String) -> EVYDraft? {
+    let sid = scopeId
+    let pk = pathKey
+    let descriptor = FetchDescriptor<EVYDraft>(
+      predicate: #Predicate { $0.scopeId == sid && $0.pathKey == pk }
+    )
+    do {
+      return try context.fetch(descriptor).first
+    } catch {
+      #if DEBUG
+        print("[EVYDataManager] draftFirstMatching error: \(error)")
+      #endif
+      return nil
     }
+  }
 
-    func create(key: String, data: Data) throws {
-        if exists(key: key) {
-            throw EVYDataError.keyAlreadyExists
-        }
-        context.insert(EVYData(key: key, data: data))
+  func hasDraft(binding: EVYDraft.Binding) -> Bool {
+    draftIfPresent(binding: binding) != nil
+  }
 
-        NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
-                                        object: key)
+  func createDraft(binding: EVYDraft.Binding, data: Data) throws {
+    if hasDraft(binding: binding) {
+      throw EVYDataError.keyAlreadyExists
     }
+    context.insert(EVYDraft(binding: binding, data: data))
+    NotificationCenter.default.post(name: .evyDataUpdated, object: binding.notificationKey)
+  }
 
-    func upsert(key: String, value: Data) throws {
-        let nowIso = Date().ISO8601Format()
-
-        if let existing = try? get(key: key) {
-            existing.data = value
-            existing.lastSyncedAt = nowIso
-        } else {
-            context.insert(EVYData(key: key, lastSyncedAt: nowIso, data: value))
-        }
-
-        NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
-                                        object: key)
-
-        if let resourceKey = key.split(separator: ":").last.map(String.init),
-           resourceKey != key
-        {
-            NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
-                                            object: resourceKey)
-        }
+  func upsertDraft(binding: EVYDraft.Binding, data: Data) throws {
+    if let existing = draftIfPresent(binding: binding) {
+      existing.data = data
+    } else {
+      context.insert(EVYDraft(binding: binding, data: data))
     }
+    NotificationCenter.default.post(name: .evyDataUpdated, object: binding.notificationKey)
+  }
 
-    func update(props: [String], data: Data) throws {
-        let existing = try get(key: props.first!)
-        existing.data = data
+  func updateDraft(binding: EVYDraft.Binding, data: Data) throws {
+    let existing = try draft(binding: binding)
+    existing.data = data
+    NotificationCenter.default.post(name: .evyDataUpdated, object: binding.notificationKey)
+  }
 
-        var propsForNotification = props
-        if let index = props.firstIndex(where: { $0.isNumber }) {
-            propsForNotification.removeLast(props.count - index)
-        }
-
-        let notifKey = propsForNotification.joined(separator: PROP_SEPARATOR)
-        NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
-                                        object: notifKey)
+  func deleteDrafts(scopeId: String) {
+    do {
+      let descriptor = FetchDescriptor<EVYDraft>(predicate: #Predicate { $0.scopeId == scopeId })
+      let rows = try context.fetch(descriptor)
+      for row in rows {
+        context.delete(row)
+      }
+    } catch {
+      #if DEBUG
+        print("[EVYDataManager] deleteDrafts error: \(error)")
+      #endif
     }
+  }
 
-    func delete(key: String) throws {
-        let existing = try get(key: key)
-        context.delete(existing)
-
-        NotificationCenter.default.post(name: Notification.Name.evyDataUpdated,
-                                        object: key)
+  func deleteAllDraftsForTestIsolation() {
+    do {
+      let descriptor = FetchDescriptor<EVYDraft>()
+      for row in try context.fetch(descriptor) {
+        context.delete(row)
+      }
+    } catch {
+      #if DEBUG
+        print("[EVYDataManager] deleteAllDraftsForTestIsolation error: \(error)")
+      #endif
     }
+  }
 
-    // MARK: - Drafts
-
-    func drafts(forScopeId scopeId: String) throws -> [EVYDraft] {
-        let descriptor = FetchDescriptor<EVYDraft>(predicate: #Predicate { $0.scopeId == scopeId })
-        return try context.fetch(descriptor)
-    }
-
-    func draft(binding: EVYDraft.Binding) throws -> EVYDraft {
-        guard let row = draftFirstMatching(scopeId: binding.scopeId, pathKey: binding.pathKey) else {
-            throw EVYDataError.keyNotFound
-        }
-        return row
-    }
-
-    func draftIfPresent(binding: EVYDraft.Binding) -> EVYDraft? {
-        draftFirstMatching(scopeId: binding.scopeId, pathKey: binding.pathKey)
-    }
-
-    private func draftFirstMatching(scopeId: String, pathKey: String) -> EVYDraft? {
-        let sid = scopeId
-        let pk = pathKey
-        let descriptor = FetchDescriptor<EVYDraft>(
-            predicate: #Predicate { $0.scopeId == sid && $0.pathKey == pk }
-        )
-        do {
-            return try context.fetch(descriptor).first
-        } catch {
-            #if DEBUG
-            print("[EVYDataManager] draftFirstMatching error: \(error)")
-            #endif
-            return nil
-        }
-    }
-
-    func hasDraft(binding: EVYDraft.Binding) -> Bool {
-        draftIfPresent(binding: binding) != nil
-    }
-
-    func createDraft(binding: EVYDraft.Binding, data: Data) throws {
-        if hasDraft(binding: binding) {
-            throw EVYDataError.keyAlreadyExists
-        }
-        context.insert(EVYDraft(binding: binding, data: data))
-        NotificationCenter.default.post(name: .evyDataUpdated, object: binding.notificationKey)
-    }
-
-    func upsertDraft(binding: EVYDraft.Binding, data: Data) throws {
-        if let existing = draftIfPresent(binding: binding) {
-            existing.data = data
-        } else {
-            context.insert(EVYDraft(binding: binding, data: data))
-        }
-        NotificationCenter.default.post(name: .evyDataUpdated, object: binding.notificationKey)
-    }
-
-    func updateDraft(binding: EVYDraft.Binding, data: Data) throws {
-        let existing = try draft(binding: binding)
-        existing.data = data
-        NotificationCenter.default.post(name: .evyDataUpdated, object: binding.notificationKey)
-    }
-
-    func deleteDrafts(scopeId: String) {
-        do {
-            let descriptor = FetchDescriptor<EVYDraft>(predicate: #Predicate { $0.scopeId == scopeId })
-            let rows = try context.fetch(descriptor)
-            for row in rows {
-                context.delete(row)
-            }
-        } catch {
-            #if DEBUG
-            print("[EVYDataManager] deleteDrafts error: \(error)")
-            #endif
-        }
-    }
-
-    func deleteAllDraftsForTestIsolation() {
-        do {
-            let descriptor = FetchDescriptor<EVYDraft>()
-            for row in try context.fetch(descriptor) {
-                context.delete(row)
-            }
-        } catch {
-            #if DEBUG
-            print("[EVYDataManager] deleteAllDraftsForTestIsolation error: \(error)")
-            #endif
-        }
-    }
-
-    func draftBinding(fromParsedProps parsed: String, scopeId: String? = nil) throws -> EVYDraft.Binding {
-        try EVYDraft.binding(
-            parsedProps: parsed,
-            scopeId: scopeId ?? activeDraftScopeId
-        )
-    }
+  func draftBinding(fromParsedProps parsed: String, scopeId: String? = nil) throws
+    -> EVYDraft.Binding
+  {
+    try EVYDraft.binding(
+      parsedProps: parsed,
+      scopeId: scopeId ?? activeDraftScopeId
+    )
+  }
 }

--- a/ios/evy/Data/EVYDataManager.swift
+++ b/ios/evy/Data/EVYDataManager.swift
@@ -13,32 +13,6 @@ public enum EVYDataError: Error {
     case keyNotFound
 }
 
-public enum EVYError: LocalizedError {
-    case parsingFailed(context: String)
-    case invalidData(context: String)
-    case regexCompilationFailed(pattern: String)
-    case imageLoadFailed(name: String)
-    case formatFailed(type: String, reason: String)
-    case websocketError(context: String)
-
-    public var errorDescription: String? {
-        switch self {
-        case .parsingFailed(let context):
-            return "Parsing failed: \(context)"
-        case .invalidData(let context):
-            return "Invalid data: \(context)"
-        case .regexCompilationFailed(let pattern):
-            return "Invalid regex pattern: \(pattern)"
-        case .imageLoadFailed(let name):
-            return "Failed to load image: \(name)"
-        case .formatFailed(let type, let reason):
-            return "Failed to format \(type): \(reason)"
-        case .websocketError(let context):
-            return "WebSocket error: \(context)"
-        }
-    }
-}
-
 extension Notification.Name {
     static let evyDataUpdated = Notification.Name("EVYDataUpdated")
     static let evyFlowUpdated = Notification.Name("EVYFlowUpdated")

--- a/ios/evy/Data/EVYError.swift
+++ b/ios/evy/Data/EVYError.swift
@@ -8,27 +8,27 @@
 import Foundation
 
 public enum EVYError: LocalizedError {
-    case parsingFailed(context: String)
-    case invalidData(context: String)
-    case regexCompilationFailed(pattern: String)
-    case imageLoadFailed(name: String)
-    case formatFailed(type: String, reason: String)
-    case websocketError(context: String)
+  case parsingFailed(context: String)
+  case invalidData(context: String)
+  case regexCompilationFailed(pattern: String)
+  case imageLoadFailed(name: String)
+  case formatFailed(type: String, reason: String)
+  case websocketError(context: String)
 
-    public var errorDescription: String? {
-        switch self {
-        case .parsingFailed(let context):
-            return "Parsing failed: \(context)"
-        case .invalidData(let context):
-            return "Invalid data: \(context)"
-        case .regexCompilationFailed(let pattern):
-            return "Invalid regex pattern: \(pattern)"
-        case .imageLoadFailed(let name):
-            return "Failed to load image: \(name)"
-        case .formatFailed(let type, let reason):
-            return "Failed to format \(type): \(reason)"
-        case .websocketError(let context):
-            return "WebSocket error: \(context)"
-        }
+  public var errorDescription: String? {
+    switch self {
+    case .parsingFailed(let context):
+      return "Parsing failed: \(context)"
+    case .invalidData(let context):
+      return "Invalid data: \(context)"
+    case .regexCompilationFailed(let pattern):
+      return "Invalid regex pattern: \(pattern)"
+    case .imageLoadFailed(let name):
+      return "Failed to load image: \(name)"
+    case .formatFailed(let type, let reason):
+      return "Failed to format \(type): \(reason)"
+    case .websocketError(let context):
+      return "WebSocket error: \(context)"
     }
+  }
 }

--- a/ios/evy/Data/EVYError.swift
+++ b/ios/evy/Data/EVYError.swift
@@ -1,0 +1,34 @@
+//
+//  EVYError.swift
+//  evy
+//
+//  Created by Geoffroy Lesage on 4/3/2024.
+//
+
+import Foundation
+
+public enum EVYError: LocalizedError {
+    case parsingFailed(context: String)
+    case invalidData(context: String)
+    case regexCompilationFailed(pattern: String)
+    case imageLoadFailed(name: String)
+    case formatFailed(type: String, reason: String)
+    case websocketError(context: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .parsingFailed(let context):
+            return "Parsing failed: \(context)"
+        case .invalidData(let context):
+            return "Invalid data: \(context)"
+        case .regexCompilationFailed(let pattern):
+            return "Invalid regex pattern: \(pattern)"
+        case .imageLoadFailed(let name):
+            return "Failed to load image: \(name)"
+        case .formatFailed(let type, let reason):
+            return "Failed to format \(type): \(reason)"
+        case .websocketError(let context):
+            return "WebSocket error: \(context)"
+        }
+    }
+}

--- a/ios/evy/Data/EVYSearchController.swift
+++ b/ios/evy/Data/EVYSearchController.swift
@@ -9,265 +9,269 @@ import Foundation
 import SwiftUI
 
 private enum EVYSearchSourceType {
-    case api
-    case local
+  case api
+  case local
 }
 
 public struct EVYSearchResult: Equatable {
-    let data: EVYJson
-    let value: String
-    let displayRow: UI_Row
+  let data: EVYJson
+  let value: String
+  let displayRow: UI_Row
 
-    public static func == (lhs: EVYSearchResult, rhs: EVYSearchResult) -> Bool {
-        lhs.value == rhs.value && lhs.data == rhs.data
-    }
+  public static func == (lhs: EVYSearchResult, rhs: EVYSearchResult) -> Bool {
+    lhs.value == rhs.value && lhs.data == rhs.data
+  }
 }
 
 // MARK: - Search Result Template
 private func deepCopyJSONValue(_ value: Any) -> Any {
-    switch value {
-    case let d as [String: Any]:
-        var out: [String: Any] = [:]
-        out.reserveCapacity(d.count)
-        for (k, v) in d {
-            out[k] = deepCopyJSONValue(v)
-        }
-        return out
-    case let d as NSDictionary:
-        var out: [String: Any] = [:]
-        for case let (k as String, v) in d {
-            out[k] = deepCopyJSONValue(v)
-        }
-        return out
-    case let a as [Any]:
-        return a.map { deepCopyJSONValue($0) }
-    case let a as NSArray:
-        return a.map { deepCopyJSONValue($0) }
-    default:
-        return value
+  switch value {
+  case let d as [String: Any]:
+    var out: [String: Any] = [:]
+    out.reserveCapacity(d.count)
+    for (k, v) in d {
+      out[k] = deepCopyJSONValue(v)
     }
+    return out
+  case let d as NSDictionary:
+    var out: [String: Any] = [:]
+    for case (let k as String, let v) in d {
+      out[k] = deepCopyJSONValue(v)
+    }
+    return out
+  case let a as [Any]:
+    return a.map { deepCopyJSONValue($0) }
+  case let a as NSArray:
+    return a.map { deepCopyJSONValue($0) }
+  default:
+    return value
+  }
 }
 
 @MainActor
 private final class SearchTemplateFormatPrep {
-    private let rootPrototype: [String: Any]
-    private static let displayKeys = [
-        "title", "subtitle", "text", "label", "placeholder", "value",
-    ]
+  private let rootPrototype: [String: Any]
+  private static let displayKeys = [
+    "title", "subtitle", "text", "label", "placeholder", "value",
+  ]
 
-    private static let datumReferenceRegex = try! NSRegularExpression(
-        pattern: #"\{\$datum:([A-Za-z0-9_.-]+)\}"#
-    )
+  private static let datumReferenceRegex = try! NSRegularExpression(
+    pattern: #"\{\$datum:([A-Za-z0-9_.-]+)\}"#
+  )
 
-    private static func datumValue(path: String, datum: EVYJson) -> String {
-        let pathSegments = path.split(separator: ".").map(String.init)
-        if pathSegments.isEmpty {
-            return datum.toString()
-        }
-
-        var currentValue = datum
-        for pathSegment in pathSegments {
-            switch currentValue {
-            case let .dictionary(dictionaryValue):
-                guard let nextValue = dictionaryValue[pathSegment] else {
-                    return ""
-                }
-                currentValue = nextValue
-            case let .array(arrayValue):
-                guard let index = Int(pathSegment), arrayValue.indices.contains(index) else {
-                    return ""
-                }
-                currentValue = arrayValue[index]
-            default:
-                return ""
-            }
-        }
-
-        return currentValue.toString()
+  private static func datumValue(path: String, datum: EVYJson) -> String {
+    let pathSegments = path.split(separator: ".").map(String.init)
+    if pathSegments.isEmpty {
+      return datum.toString()
     }
 
-    private static func formatDatumReferences(_ template: String, datum: EVYJson) -> String {
-        var formattedTemplate = template
-        let templateRange = NSRange(template.startIndex..., in: template)
-        let matches = datumReferenceRegex.matches(in: template, range: templateRange)
-
-        for match in matches.reversed() {
-            guard let fullRange = Range(match.range, in: formattedTemplate),
-                  let pathRange = Range(match.range(at: 1), in: formattedTemplate) else {
-                continue
-            }
-
-            let path = String(formattedTemplate[pathRange])
-            formattedTemplate.replaceSubrange(
-                fullRange,
-                with: datumValue(path: path, datum: datum)
-            )
+    var currentValue = datum
+    for pathSegment in pathSegments {
+      switch currentValue {
+      case .dictionary(let dictionaryValue):
+        guard let nextValue = dictionaryValue[pathSegment] else {
+          return ""
         }
-
-        return formattedTemplate
+        currentValue = nextValue
+      case .array(let arrayValue):
+        guard let index = Int(pathSegment), arrayValue.indices.contains(index) else {
+          return ""
+        }
+        currentValue = arrayValue[index]
+      default:
+        return ""
+      }
     }
 
-    init(template: UI_Row) throws {
-        let data = try JSONEncoder().encode(template)
-        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw EVYSearchFormattingError.invalidTemplate
-        }
-        rootPrototype = root
+    return currentValue.toString()
+  }
+
+  private static func formatDatumReferences(_ template: String, datum: EVYJson) -> String {
+    var formattedTemplate = template
+    let templateRange = NSRange(template.startIndex..., in: template)
+    let matches = datumReferenceRegex.matches(in: template, range: templateRange)
+
+    for match in matches.reversed() {
+      guard let fullRange = Range(match.range, in: formattedTemplate),
+        let pathRange = Range(match.range(at: 1), in: formattedTemplate)
+      else {
+        continue
+      }
+
+      let path = String(formattedTemplate[pathRange])
+      formattedTemplate.replaceSubrange(
+        fullRange,
+        with: datumValue(path: path, datum: datum)
+      )
     }
 
-    func formattedResult(datum: EVYJson) throws -> (row: UI_Row, value: String) {
-        guard var root = deepCopyJSONValue(rootPrototype) as? [String: Any],
-              var view = root["view"] as? [String: Any],
-              var content = view["content"] as? [String: Any] else {
-            throw EVYSearchFormattingError.invalidTemplate
-        }
-        for key in Array(content.keys) {
-            if let raw = content[key] as? String {
-                content[key] = Self.formatDatumReferences(raw, datum: datum)
-            }
-        }
-        let value = Self.displayKeys
-            .compactMap { content[$0] as? String }
-            .first(where: { !$0.isEmpty }) ?? ""
-        view["content"] = content
-        root["view"] = view
-        root["id"] = UUID().uuidString
-        let out = try JSONSerialization.data(withJSONObject: root)
-        return (try JSONDecoder().decode(UI_Row.self, from: out), value)
+    return formattedTemplate
+  }
+
+  init(template: UI_Row) throws {
+    let data = try JSONEncoder().encode(template)
+    guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw EVYSearchFormattingError.invalidTemplate
     }
+    rootPrototype = root
+  }
+
+  func formattedResult(datum: EVYJson) throws -> (row: UI_Row, value: String) {
+    guard var root = deepCopyJSONValue(rootPrototype) as? [String: Any],
+      var view = root["view"] as? [String: Any],
+      var content = view["content"] as? [String: Any]
+    else {
+      throw EVYSearchFormattingError.invalidTemplate
+    }
+    for key in Array(content.keys) {
+      if let raw = content[key] as? String {
+        content[key] = Self.formatDatumReferences(raw, datum: datum)
+      }
+    }
+    let value =
+      Self.displayKeys
+      .compactMap { content[$0] as? String }
+      .first(where: { !$0.isEmpty }) ?? ""
+    view["content"] = content
+    root["view"] = view
+    root["id"] = UUID().uuidString
+    let out = try JSONSerialization.data(withJSONObject: root)
+    return (try JSONDecoder().decode(UI_Row.self, from: out), value)
+  }
 }
 
 enum EVYSearchFormattingError: Error {
-    case invalidTemplate
+  case invalidTemplate
 }
 
 @MainActor
 class EVYSearchController: ObservableObject {
-    private static let apiSourcePrefix = "$api:"
+  private static let apiSourcePrefix = "$api:"
 
-    private let sourceType: EVYSearchSourceType
-    private let resultTemplate: UI_Row?
+  private let sourceType: EVYSearchSourceType
+  private let resultTemplate: UI_Row?
 
-    private var cachedFormatPrep: SearchTemplateFormatPrep?
+  private var cachedFormatPrep: SearchTemplateFormatPrep?
 
-    @Published var results: [EVYSearchResult] = []
+  @Published var results: [EVYSearchResult] = []
 
-    init(source: String, resultTemplate: UI_Row?) {
-        self.resultTemplate = resultTemplate
-        sourceType = Self.searchSourceType(for: source)
+  init(source: String, resultTemplate: UI_Row?) {
+    self.resultTemplate = resultTemplate
+    sourceType = Self.searchSourceType(for: source)
+  }
+
+  private static func searchSourceType(for source: String) -> EVYSearchSourceType {
+    guard let binding = bracedBinding(from: source),
+      binding.hasPrefix(apiSourcePrefix)
+    else {
+      return .local
+    }
+    return .api
+  }
+
+  private static func bracedBinding(from source: String) -> String? {
+    let normalizedSource = source.trimmingCharacters(in: .whitespacesAndNewlines)
+    let sourceProps = EVY.parsePropsFromText(normalizedSource)
+    guard normalizedSource == "{\(sourceProps)}" else {
+      return nil
     }
 
-    private static func searchSourceType(for source: String) -> EVYSearchSourceType {
-        guard let binding = bracedBinding(from: source),
-              binding.hasPrefix(apiSourcePrefix) else {
-            return .local
-        }
-        return .api
+    return sourceProps
+  }
+
+  private func loadFormatPrep() throws -> SearchTemplateFormatPrep {
+    if let prep = cachedFormatPrep {
+      return prep
+    }
+    guard let resultTemplate else {
+      throw EVYSearchFormattingError.invalidTemplate
+    }
+    let prep = try SearchTemplateFormatPrep(template: resultTemplate)
+    cachedFormatPrep = prep
+    return prep
+  }
+
+  func makeSearchResult(datum: EVYJson) throws -> EVYSearchResult {
+    let (row, value) = try loadFormatPrep().formattedResult(datum: datum)
+    return EVYSearchResult(data: datum, value: value, displayRow: row)
+  }
+
+  func search(name: String) async {
+    guard resultTemplate != nil else {
+      results = []
+      return
     }
 
-    private static func bracedBinding(from source: String) -> String? {
-        let normalizedSource = source.trimmingCharacters(in: .whitespacesAndNewlines)
-        let sourceProps = EVY.parsePropsFromText(normalizedSource)
-        guard normalizedSource == "{\(sourceProps)}" else {
-            return nil
-        }
-
-        return sourceProps
-    }
-
-    private func loadFormatPrep() throws -> SearchTemplateFormatPrep {
-        if let prep = cachedFormatPrep {
-            return prep
-        }
-        guard let resultTemplate else {
-            throw EVYSearchFormattingError.invalidTemplate
-        }
-        let prep = try SearchTemplateFormatPrep(template: resultTemplate)
-        cachedFormatPrep = prep
-        return prep
-    }
-
-    func makeSearchResult(datum: EVYJson) throws -> EVYSearchResult {
-        let (row, value) = try loadFormatPrep().formattedResult(datum: datum)
-        return EVYSearchResult(data: datum, value: value, displayRow: row)
-    }
-
-    func search(name: String) async {
-        guard resultTemplate != nil else {
-            results = []
-            return
-        }
-
-        switch sourceType {
-        case .local:
-            let address = """
-                {
-                    "unit": "100",
-                    "street": "Main Street",
-                    "city": "Rosebery",
-                    "postcode": "2018",
-                    "state": "NSW",
-                    "country": "Australia",
-                    "location": {
-                        "latitude": "45.323124",
-                        "longitude": "-3.424233"
-                    },
-                    "instructions": ""
-                }
-            """.data(using: .utf8)!
-            let id = UUID()
-            do {
-                try EVY.data.create(key: id.uuidString, data: address)
-                let json = try EVY.getDataFromProps(id.uuidString)
-                results = [try makeSearchResult(datum: json)]
-            } catch {
-                results = []
+    switch sourceType {
+    case .local:
+      let address = """
+            {
+                "unit": "100",
+                "street": "Main Street",
+                "city": "Rosebery",
+                "postcode": "2018",
+                "state": "NSW",
+                "country": "Australia",
+                "location": {
+                    "latitude": "45.323124",
+                    "longitude": "-3.424233"
+                },
+                "instructions": ""
             }
-        default:
-            do {
-                let data = try await EVYMovieAPI().search(term: name)
-                let response = try JSONDecoder().decode([EVYJson].self, from: data)
-                results = try response.map { try makeSearchResult(datum: $0) }
-            } catch {
-                results = []
-            }
-        }
+        """.data(using: .utf8)!
+      let id = UUID()
+      do {
+        try EVY.data.create(key: id.uuidString, data: address)
+        let json = try EVY.getDataFromProps(id.uuidString)
+        results = [try makeSearchResult(datum: json)]
+      } catch {
+        results = []
+      }
+    default:
+      do {
+        let data = try await EVYMovieAPI().search(term: name)
+        let response = try JSONDecoder().decode([EVYJson].self, from: data)
+        results = try response.map { try makeSearchResult(datum: $0) }
+      } catch {
+        results = []
+      }
     }
+  }
 }
 
 #Preview {
-    AsyncPreview { (asyncView: EVYSearch) in
-        asyncView
-    } view: {
-        // Local-only: no EVY.getRow / EVYAPIManager (avoids API_HOST fatalError in Xcode canvas).
-        if !EVY.data.exists(key: "tags") {
-            try EVY.data.create(key: "tags", data: Data("[]".utf8))
-        }
-        let templateJson = """
-        {
-            "id": "preview-search-row",
-            "type": "Info",
-            "source": "",
-            "destination": "",
-            "actions": [],
-            "view": {
-                "content": {
-                    "title": "{$datum:unit} {$datum:street}",
-                    "subtitle": "{$datum:city} {$datum:state} {$datum:postcode}",
-                    "icon": ""
-                }
-            }
-        }
-        """
-        let template = try JSONDecoder().decode(
-            UI_Row.self,
-            from: Data(templateJson.utf8),
-        )
-        return EVYSearch(
-            source: "{$local:address}",
-            destination: "{tags}",
-            placeholder: "Search",
-            resultTemplate: template
-        )
+  AsyncPreview { (asyncView: EVYSearch) in
+    asyncView
+  } view: {
+    // Local-only: no EVY.getRow / EVYAPIManager (avoids API_HOST fatalError in Xcode canvas).
+    if !EVY.data.exists(key: "tags") {
+      try EVY.data.create(key: "tags", data: Data("[]".utf8))
     }
+    let templateJson = """
+      {
+          "id": "preview-search-row",
+          "type": "Info",
+          "source": "",
+          "destination": "",
+          "actions": [],
+          "view": {
+              "content": {
+                  "title": "{$datum:unit} {$datum:street}",
+                  "subtitle": "{$datum:city} {$datum:state} {$datum:postcode}",
+                  "icon": ""
+              }
+          }
+      }
+      """
+    let template = try JSONDecoder().decode(
+      UI_Row.self,
+      from: Data(templateJson.utf8),
+    )
+    return EVYSearch(
+      source: "{$local:address}",
+      destination: "{tags}",
+      placeholder: "Search",
+      resultTemplate: template
+    )
+  }
 }

--- a/ios/evy/Data/Models/EVYCalendarTimeslotData.swift
+++ b/ios/evy/Data/Models/EVYCalendarTimeslotData.swift
@@ -6,10 +6,10 @@
 //
 
 public struct EVYCalendarTimeslotData: Decodable {
-    let x: Int
-    let y: Int
-    let header: String
-    let start_label: String
-    let end_label: String
-    let selected: Bool
+  let x: Int
+  let y: Int
+  let header: String
+  let start_label: String
+  let end_label: String
+  let selected: Bool
 }

--- a/ios/evy/Data/Models/EVYData.swift
+++ b/ios/evy/Data/Models/EVYData.swift
@@ -9,307 +9,308 @@ import Foundation
 import SwiftData
 
 public enum EVYDataParseError: Error {
-    case invalidProps
-    case invalidVariable
-    case unprocessableValue
+  case invalidProps
+  case invalidVariable
+  case unprocessableValue
 }
 
 struct EVYValue: Equatable {
-    var value: String
-    var prefix: String?
-    var suffix: String?
+  var value: String
+  var prefix: String?
+  var suffix: String?
 
-    init(_ value: String, _ prefix: String?, _ suffix: String?) {
-        self.value = value
-        self.prefix = prefix
-        self.suffix = suffix
-    }
+  init(_ value: String, _ prefix: String?, _ suffix: String?) {
+    self.value = value
+    self.prefix = prefix
+    self.suffix = suffix
+  }
 
-    func toString() -> String {
-        return "\(prefix ?? "")\(value)\(suffix ?? "")"
-    }
+  func toString() -> String {
+    return "\(prefix ?? "")\(value)\(suffix ?? "")"
+  }
 }
 
 @Model
 class EVYData {
-    var key: String
-    var lastSyncedAt: String
-    var data: Data
+  var key: String
+  var lastSyncedAt: String
+  var data: Data
 
-    init(key: String, lastSyncedAt: String = "", data: Data) {
-        self.key = key
-        self.lastSyncedAt = lastSyncedAt
-        self.data = data
+  init(key: String, lastSyncedAt: String = "", data: Data) {
+    self.key = key
+    self.lastSyncedAt = lastSyncedAt
+    self.data = data
+  }
+
+  func decoded() throws -> EVYJson {
+    try JSONDecoder().decode(EVYJson.self, from: data)
+  }
+
+  func updateDataWithData(_ data: Data, props: [String]) throws {
+    if props.count < 1 {
+      return
     }
 
-    func decoded() throws -> EVYJson {
-        try JSONDecoder().decode(EVYJson.self, from: data)
+    let currentDataAsJson = try decoded()
+    let newDataAsJson = try JSONDecoder().decode(EVYJson.self, from: data)
+
+    let updatedJson = try getUpdatedJson(
+      props: props, data: currentDataAsJson, value: newDataAsJson)
+    self.data = try JSONEncoder().encode(updatedJson)
+  }
+
+  private func getUpdatedJson(props: [String], data: EVYJson, value: EVYJson) throws -> EVYJson {
+    if props.count < 1 {
+      return data
     }
 
-    func updateDataWithData(_ data: Data, props: [String]) throws {
-        if props.count < 1 {
-            return
-        }
-
-        let currentDataAsJson = try decoded()
-        let newDataAsJson = try JSONDecoder().decode(EVYJson.self, from: data)
-
-        let updatedJson = try getUpdatedJson(props: props, data: currentDataAsJson, value: newDataAsJson)
-        self.data = try JSONEncoder().encode(updatedJson)
+    switch data {
+    case .dictionary(var dictValue):
+      guard let firstProp = props.first else {
+        throw EVYDataParseError.invalidProps
+      }
+      guard let subData = dictValue[firstProp] else {
+        throw EVYDataParseError.invalidProps
+      }
+      if props.count == 1 {
+        dictValue[firstProp] = value
+        let dictAsData = try JSONEncoder().encode(dictValue)
+        return try JSONDecoder().decode(EVYJson.self, from: dictAsData)
+      }
+      let updatedData = try getUpdatedJson(props: Array(props[1...]), data: subData, value: value)
+      if props.count > 1 {
+        dictValue[firstProp] = updatedData
+        let dictAsData = try JSONEncoder().encode(dictValue)
+        return try JSONDecoder().decode(EVYJson.self, from: dictAsData)
+      }
+      return updatedData
+    case .array(var arrayValue):
+      guard let firstProp = props.first else {
+        throw EVYDataParseError.invalidProps
+      }
+      guard let index = Int(firstProp) else {
+        throw EVYDataParseError.invalidProps
+      }
+      let subData = arrayValue[index]
+      if props.count == 1 {
+        arrayValue[index] = value
+        let arrayAsData = try JSONEncoder().encode(arrayValue)
+        return try JSONDecoder().decode(EVYJson.self, from: arrayAsData)
+      }
+      let updatedData = try getUpdatedJson(props: Array(props[1...]), data: subData, value: value)
+      if props.count > 1 {
+        arrayValue[index] = updatedData
+        let arrayAsData = try JSONEncoder().encode(arrayValue)
+        return try JSONDecoder().decode(EVYJson.self, from: arrayAsData)
+      }
+      return updatedData
+    default:
+      return data
     }
-
-    private func getUpdatedJson(props: [String], data: EVYJson, value: EVYJson) throws -> EVYJson {
-        if props.count < 1 {
-            return data
-        }
-
-        switch data {
-        case var .dictionary(dictValue):
-            guard let firstProp = props.first else {
-                throw EVYDataParseError.invalidProps
-            }
-            guard let subData = dictValue[firstProp] else {
-                throw EVYDataParseError.invalidProps
-            }
-            if props.count == 1 {
-                dictValue[firstProp] = value
-                let dictAsData = try JSONEncoder().encode(dictValue)
-                return try JSONDecoder().decode(EVYJson.self, from: dictAsData)
-            }
-            let updatedData = try getUpdatedJson(props: Array(props[1...]), data: subData, value: value)
-            if props.count > 1 {
-                dictValue[firstProp] = updatedData
-                let dictAsData = try JSONEncoder().encode(dictValue)
-                return try JSONDecoder().decode(EVYJson.self, from: dictAsData)
-            }
-            return updatedData
-        case var .array(arrayValue):
-            guard let firstProp = props.first else {
-                throw EVYDataParseError.invalidProps
-            }
-            guard let index = Int(firstProp) else {
-                throw EVYDataParseError.invalidProps
-            }
-            let subData = arrayValue[index]
-            if props.count == 1 {
-                arrayValue[index] = value
-                let arrayAsData = try JSONEncoder().encode(arrayValue)
-                return try JSONDecoder().decode(EVYJson.self, from: arrayAsData)
-            }
-            let updatedData = try getUpdatedJson(props: Array(props[1...]), data: subData, value: value)
-            if props.count > 1 {
-                arrayValue[index] = updatedData
-                let arrayAsData = try JSONEncoder().encode(arrayValue)
-                return try JSONDecoder().decode(EVYJson.self, from: arrayAsData)
-            }
-            return updatedData
-        default:
-            return data
-        }
-    }
+  }
 }
 
 public enum EVYJson: Codable, Hashable {
-	case string(String)
-	case int(Int)
-	case decimal(Decimal)
-	case bool(Bool)
-	case dictionary([String: EVYJson])
-	case array([EVYJson])
+  case string(String)
+  case int(Int)
+  case decimal(Decimal)
+  case bool(Bool)
+  case dictionary([String: EVYJson])
+  case array([EVYJson])
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
 
-        if let stringValue = try? container.decode(String.self) {
-            self = .string(stringValue)
-            return
-        }
-
-        if let intValue = try? container.decode(Int.self) {
-            self = .int(intValue)
-            return
-        }
-
-		if let decimalValue = try? container.decode(Decimal.self) {
-			self = .decimal(decimalValue)
-			return
-		}
-
-        if let boolValue = try? container.decode(Bool.self) {
-            self = .bool(boolValue)
-            return
-        }
-
-        if let dictionaryValue = try? container.decode([String: EVYJson].self) {
-            self = .dictionary(dictionaryValue)
-            return
-        }
-
-        if let arrayValue = try? container.decode([EVYJson].self) {
-            self = .array(arrayValue)
-            return
-        }
-
-        throw EVYDataParseError.unprocessableValue
+    if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+      return
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        switch self {
-        case let .string(jsonData):
-            try container.encode(jsonData)
-		case let .int(jsonData):
-			try container.encode(jsonData)
-		case let .decimal(jsonData):
-			try container.encode(jsonData)
-        case let .bool(jsonData):
-            try container.encode(jsonData)
-        case let .dictionary(jsonData):
-            try container.encode(jsonData)
-        case let .array(jsonData):
-            try container.encode(jsonData)
-        }
+    if let intValue = try? container.decode(Int.self) {
+      self = .int(intValue)
+      return
     }
 
-    public func toString() -> String {
-        let encoder = JSONEncoder()
-
-        switch self {
-        case let .string(stringValue):
-            return stringValue
-        case let .int(intValue):
-            return "\(intValue)"
-		case let .decimal(decimalValue):
-			return "\(decimalValue)"
-        case let .bool(boolValue):
-            return boolValue ? "true" : "false"
-        case let .array(arrayValue):
-            guard let data = try? encoder.encode(arrayValue) else {
-                return arrayValue.description
-            }
-            guard let string = String(data: data, encoding: .utf8) else {
-                return arrayValue.description
-            }
-            return string
-        case let .dictionary(dictValue):
-            guard let data = try? encoder.encode(dictValue) else {
-                return dictValue.description
-            }
-            guard let string = String(data: data, encoding: .utf8) else {
-                return dictValue.description
-            }
-            return string
-        }
+    if let decimalValue = try? container.decode(Decimal.self) {
+      self = .decimal(decimalValue)
+      return
     }
 
-    @MainActor
-    public func identifierValue() -> String {
-        switch self {
-        case .dictionary(_):
-            return parseProp(props: ["id"]).toString()
-        default:
-            return toString()
-        }
+    if let boolValue = try? container.decode(Bool.self) {
+      self = .bool(boolValue)
+      return
     }
 
-    @MainActor
-    public func parseProp(props: [String]) -> EVYJson {
-        if props.count < 1 {
-            return self
-        }
-
-        switch self {
-        case let .dictionary(dictValue):
-            guard let firstVariable = props.first else {
-                return self
-            }
-            guard let subData = dictValue[firstVariable] else {
-                return self
-            }
-            if props.count == 1 {
-                return parseIdOrIds(props: props, value: subData)
-            }
-
-            return subData.parseProp(props: Array(props[1...]))
-        case let .array(arrayValue):
-            guard let firstVariable = props.first else {
-                return self
-            }
-            guard let index = Int(firstVariable) else {
-                return self
-            }
-
-            let subData = arrayValue[index]
-            if props.count == 1 {
-                return parseIdOrIds(props: props, value: subData)
-            }
-            return subData.parseProp(props: Array(props[1...]))
-        default:
-            return parseIdOrIds(props: props, value: self)
-        }
+    if let dictionaryValue = try? container.decode([String: EVYJson].self) {
+      self = .dictionary(dictionaryValue)
+      return
     }
 
-    @MainActor
-    private func parseIdOrIds(props: [String], value: EVYJson) -> EVYJson {
-        let key = props.first!
-
-        if !key.hasSuffix("_id") && !key.hasSuffix("_ids") {
-            return value
-        }
-
-        var inputValues: [String] = []
-        if case let .array(arrayValue) = value {
-            inputValues.append(contentsOf: arrayValue.map { $0.toString() })
-        } else if case .string(_) = value {
-            inputValues.append(value.toString())
-        }
-
-        if inputValues.isEmpty {
-            return value
-        }
-
-        do {
-            if key.hasSuffix("_ids") {
-                let data = try EVY.getDataFromProps(String(key.dropLast(4) + "s"))
-                if case let .array(arrayValue) = data {
-                    let filteredValues = arrayValue.filter {
-                        inputValues.contains($0.identifierValue())
-                    }
-                    if filteredValues.count > 0 {
-                        let data = try JSONEncoder().encode(filteredValues)
-                        return try JSONDecoder().decode(EVYJson.self, from: data)
-                    }
-                }
-            }
-            if key.hasSuffix("_id") {
-                let data = try EVY.getDataFromProps(String(key.dropLast(3) + "s"))
-                if case let .array(arrayValue) = data {
-                    let matchingValue = arrayValue.first {
-                        inputValues.contains($0.identifierValue())
-                    }
-                    if matchingValue != nil {
-                        return matchingValue!
-                    }
-                }
-            }
-        } catch EVYDataError.keyNotFound {
-            #if DEBUG
-            print("[EVYData] parseIdOrIds: key not found for \(key)")
-            #endif
-        } catch EVYParamError.invalidProps {
-            #if DEBUG
-            print("[EVYData] parseIdOrIds: invalid props for \(key)")
-            #endif
-        } catch {
-            #if DEBUG
-            print("[EVYData] parseIdOrIds unexpected error: \(error)")
-            #endif
-            NotificationCenter.default.post(
-                name: Notification.Name.evyErrorOccurred,
-                object: error
-            )
-        }
-
-        return value
+    if let arrayValue = try? container.decode([EVYJson].self) {
+      self = .array(arrayValue)
+      return
     }
+
+    throw EVYDataParseError.unprocessableValue
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let jsonData):
+      try container.encode(jsonData)
+    case .int(let jsonData):
+      try container.encode(jsonData)
+    case .decimal(let jsonData):
+      try container.encode(jsonData)
+    case .bool(let jsonData):
+      try container.encode(jsonData)
+    case .dictionary(let jsonData):
+      try container.encode(jsonData)
+    case .array(let jsonData):
+      try container.encode(jsonData)
+    }
+  }
+
+  public func toString() -> String {
+    let encoder = JSONEncoder()
+
+    switch self {
+    case .string(let stringValue):
+      return stringValue
+    case .int(let intValue):
+      return "\(intValue)"
+    case .decimal(let decimalValue):
+      return "\(decimalValue)"
+    case .bool(let boolValue):
+      return boolValue ? "true" : "false"
+    case .array(let arrayValue):
+      guard let data = try? encoder.encode(arrayValue) else {
+        return arrayValue.description
+      }
+      guard let string = String(data: data, encoding: .utf8) else {
+        return arrayValue.description
+      }
+      return string
+    case .dictionary(let dictValue):
+      guard let data = try? encoder.encode(dictValue) else {
+        return dictValue.description
+      }
+      guard let string = String(data: data, encoding: .utf8) else {
+        return dictValue.description
+      }
+      return string
+    }
+  }
+
+  @MainActor
+  public func identifierValue() -> String {
+    switch self {
+    case .dictionary(_):
+      return parseProp(props: ["id"]).toString()
+    default:
+      return toString()
+    }
+  }
+
+  @MainActor
+  public func parseProp(props: [String]) -> EVYJson {
+    if props.count < 1 {
+      return self
+    }
+
+    switch self {
+    case .dictionary(let dictValue):
+      guard let firstVariable = props.first else {
+        return self
+      }
+      guard let subData = dictValue[firstVariable] else {
+        return self
+      }
+      if props.count == 1 {
+        return parseIdOrIds(props: props, value: subData)
+      }
+
+      return subData.parseProp(props: Array(props[1...]))
+    case .array(let arrayValue):
+      guard let firstVariable = props.first else {
+        return self
+      }
+      guard let index = Int(firstVariable) else {
+        return self
+      }
+
+      let subData = arrayValue[index]
+      if props.count == 1 {
+        return parseIdOrIds(props: props, value: subData)
+      }
+      return subData.parseProp(props: Array(props[1...]))
+    default:
+      return parseIdOrIds(props: props, value: self)
+    }
+  }
+
+  @MainActor
+  private func parseIdOrIds(props: [String], value: EVYJson) -> EVYJson {
+    let key = props.first!
+
+    if !key.hasSuffix("_id") && !key.hasSuffix("_ids") {
+      return value
+    }
+
+    var inputValues: [String] = []
+    if case .array(let arrayValue) = value {
+      inputValues.append(contentsOf: arrayValue.map { $0.toString() })
+    } else if case .string(_) = value {
+      inputValues.append(value.toString())
+    }
+
+    if inputValues.isEmpty {
+      return value
+    }
+
+    do {
+      if key.hasSuffix("_ids") {
+        let data = try EVY.getDataFromProps(String(key.dropLast(4) + "s"))
+        if case .array(let arrayValue) = data {
+          let filteredValues = arrayValue.filter {
+            inputValues.contains($0.identifierValue())
+          }
+          if filteredValues.count > 0 {
+            let data = try JSONEncoder().encode(filteredValues)
+            return try JSONDecoder().decode(EVYJson.self, from: data)
+          }
+        }
+      }
+      if key.hasSuffix("_id") {
+        let data = try EVY.getDataFromProps(String(key.dropLast(3) + "s"))
+        if case .array(let arrayValue) = data {
+          let matchingValue = arrayValue.first {
+            inputValues.contains($0.identifierValue())
+          }
+          if matchingValue != nil {
+            return matchingValue!
+          }
+        }
+      }
+    } catch EVYDataError.keyNotFound {
+      #if DEBUG
+        print("[EVYData] parseIdOrIds: key not found for \(key)")
+      #endif
+    } catch EVYParamError.invalidProps {
+      #if DEBUG
+        print("[EVYData] parseIdOrIds: invalid props for \(key)")
+      #endif
+    } catch {
+      #if DEBUG
+        print("[EVYData] parseIdOrIds unexpected error: \(error)")
+      #endif
+      NotificationCenter.default.post(
+        name: Notification.Name.evyErrorOccurred,
+        object: error
+      )
+    }
+
+    return value
+  }
 }

--- a/ios/evy/Data/Models/EVYDraft.swift
+++ b/ios/evy/Data/Models/EVYDraft.swift
@@ -8,257 +8,261 @@ import SwiftData
 
 @Model
 final class EVYDraft {
-    var scopeId: String
-    var pathKey: String
-    var isAliasBinding: Bool
-    var data: Data
+  var scopeId: String
+  var pathKey: String
+  var isAliasBinding: Bool
+  var data: Data
 
-    init(scopeId: String, pathKey: String, isAliasBinding: Bool, data: Data) {
-        self.scopeId = scopeId
-        self.pathKey = pathKey
-        self.isAliasBinding = isAliasBinding
-        self.data = data
-    }
+  init(scopeId: String, pathKey: String, isAliasBinding: Bool, data: Data) {
+    self.scopeId = scopeId
+    self.pathKey = pathKey
+    self.isAliasBinding = isAliasBinding
+    self.data = data
+  }
 
-    convenience init(binding: EVYDraft.Binding, data: Data) {
-        let alias: Bool
-        if case .aliasFlat = binding.mergeMode {
-            alias = true
-        } else {
-            alias = false
-        }
-        self.init(
-            scopeId: binding.scopeId,
-            pathKey: binding.pathKey,
-            isAliasBinding: alias,
-            data: data
-        )
+  convenience init(binding: EVYDraft.Binding, data: Data) {
+    let alias: Bool
+    if case .aliasFlat = binding.mergeMode {
+      alias = true
+    } else {
+      alias = false
     }
+    self.init(
+      scopeId: binding.scopeId,
+      pathKey: binding.pathKey,
+      isAliasBinding: alias,
+      data: data
+    )
+  }
 
-    func decoded() throws -> EVYJson {
-        try JSONDecoder().decode(EVYJson.self, from: data)
-    }
+  func decoded() throws -> EVYJson {
+    try JSONDecoder().decode(EVYJson.self, from: data)
+  }
 
-    func mergeModeEnum() -> EVYDraft.MergeMode {
-        let segments: [String]
-        if let raw = Data(base64Encoded: pathKey),
-           let arr = try? JSONSerialization.jsonObject(with: raw) as? [String]
-        {
-            segments = arr
-        } else {
-            segments = []
-        }
-        if isAliasBinding {
-            return .aliasFlat(pathSegments: segments)
-        }
-        return .explicitPath(pathSegments: segments)
+  func mergeModeEnum() -> EVYDraft.MergeMode {
+    let segments: [String]
+    if let raw = Data(base64Encoded: pathKey),
+      let arr = try? JSONSerialization.jsonObject(with: raw) as? [String]
+    {
+      segments = arr
+    } else {
+      segments = []
     }
+    if isAliasBinding {
+      return .aliasFlat(pathSegments: segments)
+    }
+    return .explicitPath(pathSegments: segments)
+  }
 
-    func merged(into entity: EVYJson, draftValue: EVYJson) -> EVYJson {
-        switch mergeModeEnum() {
-        case .explicitPath(let path):
-            return evyJsonUpdating(json: entity, at: path, with: draftValue) ?? entity
-        case .aliasFlat(let pathSegments):
-            let leafName = pathSegments.last ?? ""
-            return mergeDraftValue(
-                variableName: leafName,
-                draftValue: draftValue,
-                into: entity
-            )
-        }
+  func merged(into entity: EVYJson, draftValue: EVYJson) -> EVYJson {
+    switch mergeModeEnum() {
+    case .explicitPath(let path):
+      return evyJsonUpdating(json: entity, at: path, with: draftValue) ?? entity
+    case .aliasFlat(let pathSegments):
+      let leafName = pathSegments.last ?? ""
+      return mergeDraftValue(
+        variableName: leafName,
+        draftValue: draftValue,
+        into: entity
+      )
     }
+  }
 }
 
 extension EVYDraft {
-    enum MergeMode: Equatable {
-        case explicitPath(pathSegments: [String])
-        case aliasFlat(pathSegments: [String])
+  enum MergeMode: Equatable {
+    case explicitPath(pathSegments: [String])
+    case aliasFlat(pathSegments: [String])
+  }
+
+  struct Binding: Equatable {
+    let scopeId: String
+    let pathSegments: [String]
+    let mergeMode: MergeMode
+
+    var pathKey: String {
+      (try? JSONSerialization.data(withJSONObject: pathSegments))?
+        .base64EncodedString() ?? pathSegments.joined(separator: "\u{1f}")
     }
 
-    struct Binding: Equatable {
-        let scopeId: String
-        let pathSegments: [String]
-        let mergeMode: MergeMode
+    var notificationKey: String {
+      pathSegments.joined(separator: PROP_SEPARATOR)
+    }
+  }
 
-        var pathKey: String {
-            (try? JSONSerialization.data(withJSONObject: pathSegments))?
-                .base64EncodedString() ?? pathSegments.joined(separator: "\u{1f}")
-        }
+  enum Scope {
+    static let fallbackUnscoped = "app#unscoped"
 
-        var notificationKey: String {
-            pathSegments.joined(separator: PROP_SEPARATOR)
-        }
+    static func entityKey(fromScopeId scopeId: String?) -> String? {
+      guard let scopeId, let range = scopeId.range(of: "#", options: .backwards) else { return nil }
+      let key = String(scopeId[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+      if key.isEmpty || key == "browse" { return nil }
+      return key
+    }
+  }
+
+  @MainActor
+  static func binding(parsedProps: String, scopeId: String?) throws -> Binding {
+    let segments = try splitPropsFromText(parsedProps)
+
+    if let first = segments.first, UUID(uuidString: first) != nil, segments.count == 1 {
+      let ephemeralScope = "ephemeral:\(first)"
+      return Binding(
+        scopeId: ephemeralScope,
+        pathSegments: [first],
+        mergeMode: .aliasFlat(pathSegments: [first])
+      )
     }
 
-    enum Scope {
-        static let fallbackUnscoped = "app#unscoped"
+    let effectiveScope = scopeId ?? Scope.fallbackUnscoped
+    let entityKey = Scope.entityKey(fromScopeId: effectiveScope)
 
-        static func entityKey(fromScopeId scopeId: String?) -> String? {
-            guard let scopeId, let range = scopeId.range(of: "#", options: .backwards) else { return nil }
-            let key = String(scopeId[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
-            if key.isEmpty || key == "browse" { return nil }
-            return key
-        }
+    if let ek = entityKey,
+      segments.first == ek,
+      segments.count > 1
+    {
+      let rest = Array(segments.dropFirst())
+      return Binding(
+        scopeId: effectiveScope,
+        pathSegments: rest,
+        mergeMode: .explicitPath(pathSegments: rest)
+      )
     }
 
-    @MainActor
-    static func binding(parsedProps: String, scopeId: String?) throws -> Binding {
-        let segments = try splitPropsFromText(parsedProps)
-
-        if let first = segments.first, UUID(uuidString: first) != nil, segments.count == 1 {
-            let ephemeralScope = "ephemeral:\(first)"
-            return Binding(
-                scopeId: ephemeralScope,
-                pathSegments: [first],
-                mergeMode: .aliasFlat(pathSegments: [first])
-            )
-        }
-
-        let effectiveScope = scopeId ?? Scope.fallbackUnscoped
-        let entityKey = Scope.entityKey(fromScopeId: effectiveScope)
-
-        if let ek = entityKey,
-           segments.first == ek,
-           segments.count > 1
-        {
-            let rest = Array(segments.dropFirst())
-            return Binding(
-                scopeId: effectiveScope,
-                pathSegments: rest,
-                mergeMode: .explicitPath(pathSegments: rest)
-            )
-        }
-
-        if segments.count > 1 {
-            return Binding(
-                scopeId: effectiveScope,
-                pathSegments: segments,
-                mergeMode: .explicitPath(pathSegments: segments)
-            )
-        }
-
-        return Binding(
-            scopeId: effectiveScope,
-            pathSegments: segments,
-            mergeMode: .aliasFlat(pathSegments: segments)
-        )
+    if segments.count > 1 {
+      return Binding(
+        scopeId: effectiveScope,
+        pathSegments: segments,
+        mergeMode: .explicitPath(pathSegments: segments)
+      )
     }
 
-    static func createMergeScopeId(flowId: String, entityKey: String) -> String {
-        "\(flowId)#\(entityKey)"
-    }
+    return Binding(
+      scopeId: effectiveScope,
+      pathSegments: segments,
+      mergeMode: .aliasFlat(pathSegments: segments)
+    )
+  }
 
-    static func remainingPropsAfterDraftPrefix(splitProps: [String], binding: Binding) -> [String] {
-        let path = binding.pathSegments
-        if splitProps.count >= path.count, Array(splitProps.prefix(path.count)) == path {
-            return Array(splitProps.suffix(splitProps.count - path.count))
-        }
-        if let ek = Scope.entityKey(fromScopeId: binding.scopeId),
-           splitProps.first == ek,
-           splitProps.count > 1,
-           Array(splitProps.dropFirst()) == path
-        {
-            return []
-        }
-        return splitProps
+  static func createMergeScopeId(flowId: String, entityKey: String) -> String {
+    "\(flowId)#\(entityKey)"
+  }
+
+  static func remainingPropsAfterDraftPrefix(splitProps: [String], binding: Binding) -> [String] {
+    let path = binding.pathSegments
+    if splitProps.count >= path.count, Array(splitProps.prefix(path.count)) == path {
+      return Array(splitProps.suffix(splitProps.count - path.count))
     }
+    if let ek = Scope.entityKey(fromScopeId: binding.scopeId),
+      splitProps.first == ek,
+      splitProps.count > 1,
+      Array(splitProps.dropFirst()) == path
+    {
+      return []
+    }
+    return splitProps
+  }
 }
 
 private func mergeDraftValue(
-    variableName: String,
-    draftValue: EVYJson,
-    into entity: EVYJson
+  variableName: String,
+  draftValue: EVYJson,
+  into entity: EVYJson
 ) -> EVYJson {
-    guard case .dictionary(var dict) = entity else {
-        return entity
-    }
+  guard case .dictionary(var dict) = entity else {
+    return entity
+  }
 
-    if dict[variableName] != nil {
-        dict[variableName] = draftValue
-        return .dictionary(dict)
-    }
-
-    let matchingPaths = leafPaths(named: variableName, in: entity)
-    if matchingPaths.count == 1,
-       let updated = evyJsonUpdating(json: entity, at: matchingPaths[0], with: draftValue)
-    {
-        return updated
-    }
-
+  if dict[variableName] != nil {
     dict[variableName] = draftValue
     return .dictionary(dict)
+  }
+
+  let matchingPaths = leafPaths(named: variableName, in: entity)
+  if matchingPaths.count == 1,
+    let updated = evyJsonUpdating(json: entity, at: matchingPaths[0], with: draftValue)
+  {
+    return updated
+  }
+
+  dict[variableName] = draftValue
+  return .dictionary(dict)
 }
 
 private func leafPaths(
-    named variableName: String,
-    in json: EVYJson,
-    currentPath: [String] = []
+  named variableName: String,
+  in json: EVYJson,
+  currentPath: [String] = []
 ) -> [[String]] {
-    switch json {
-    case .dictionary(let dict):
-        return dict.flatMap { key, value in
-            let path = currentPath + [key]
-            let directMatch = key == variableName ? [path] : []
-            return directMatch + leafPaths(named: variableName, in: value, currentPath: path)
-        }
-    case .array(let array):
-        return array.enumerated().flatMap { index, value in
-            leafPaths(
-                named: variableName,
-                in: value,
-                currentPath: currentPath + [String(index)]
-            )
-        }
-    default:
-        return []
+  switch json {
+  case .dictionary(let dict):
+    return dict.flatMap { key, value in
+      let path = currentPath + [key]
+      let directMatch = key == variableName ? [path] : []
+      return directMatch + leafPaths(named: variableName, in: value, currentPath: path)
     }
+  case .array(let array):
+    return array.enumerated().flatMap { index, value in
+      leafPaths(
+        named: variableName,
+        in: value,
+        currentPath: currentPath + [String(index)]
+      )
+    }
+  default:
+    return []
+  }
 }
 
 private func evyJsonUpdating(
-    json: EVYJson,
-    at path: [String],
-    with value: EVYJson
+  json: EVYJson,
+  at path: [String],
+  with value: EVYJson
 ) -> EVYJson? {
-    guard let head = path.first else {
-        return value
-    }
+  guard let head = path.first else {
+    return value
+  }
 
-    switch json {
-    case .dictionary(var dict):
-        guard let child = dict[head] else {
-            return nil
-        }
-        if path.count == 1 {
-            dict[head] = value
-            return .dictionary(dict)
-        }
-        guard let updatedChild = evyJsonUpdating(
-            json: child,
-            at: Array(path.dropFirst()),
-            with: value
-        ) else {
-            return nil
-        }
-        dict[head] = updatedChild
-        return .dictionary(dict)
-    case .array(var array):
-        guard let index = Int(head), array.indices.contains(index) else {
-            return nil
-        }
-        if path.count == 1 {
-            array[index] = value
-            return .array(array)
-        }
-        guard let updatedChild = evyJsonUpdating(
-            json: array[index],
-            at: Array(path.dropFirst()),
-            with: value
-        ) else {
-            return nil
-        }
-        array[index] = updatedChild
-        return .array(array)
-    default:
-        return nil
+  switch json {
+  case .dictionary(var dict):
+    guard let child = dict[head] else {
+      return nil
     }
+    if path.count == 1 {
+      dict[head] = value
+      return .dictionary(dict)
+    }
+    guard
+      let updatedChild = evyJsonUpdating(
+        json: child,
+        at: Array(path.dropFirst()),
+        with: value
+      )
+    else {
+      return nil
+    }
+    dict[head] = updatedChild
+    return .dictionary(dict)
+  case .array(var array):
+    guard let index = Int(head), array.indices.contains(index) else {
+      return nil
+    }
+    if path.count == 1 {
+      array[index] = value
+      return .array(array)
+    }
+    guard
+      let updatedChild = evyJsonUpdating(
+        json: array[index],
+        at: Array(path.dropFirst()),
+        with: value
+      )
+    else {
+      return nil
+    }
+    array[index] = updatedChild
+    return .array(array)
+  default:
+    return nil
+  }
 }

--- a/ios/evy/EVY.swift
+++ b/ios/evy/EVY.swift
@@ -9,310 +9,317 @@ import Foundation
 import SwiftUI
 
 public enum EVYParamError: Error {
-    case invalidProps
+  case invalidProps
 }
 
 struct GetParams: Encodable {
-	let service: String
-	let resource: String
-	let filter: Filter?
+  let service: String
+  let resource: String
+  let filter: Filter?
 }
 
 struct Filter: Encodable {
-	let id: String?
+  let id: String?
 }
 
 struct SyncServiceDataParams: Encodable {
-	let service: String
-	let lastSyncTime: String
+  let service: String
+  let lastSyncTime: String
 }
 
 struct SyncedServiceDataRow: Codable {
-	let service: String
-	let resource: String
-	let value: EVYJson
+  let service: String
+  let resource: String
+  let value: EVYJson
 }
 
 struct SyncServiceDataResponse: Codable {
-	let data: [SyncedServiceDataRow]
+  let data: [SyncedServiceDataRow]
 }
 
 @MainActor
 struct EVY {
-    static let data = EVYDataManager()
+  static let data = EVYDataManager()
 
-	static func getUserData() throws {
-		let userData = try EVYJson.from(localJSON: "user_data")
-		let encodedUserData = try JSONEncoder().encode(userData)
-		do {
-			try EVY.data.create(key: "user", data: encodedUserData)
-		} catch EVYDataError.keyAlreadyExists {
-		}
-	}
+  static func getUserData() throws {
+    let userData = try EVYJson.from(localJSON: "user_data")
+    let encodedUserData = try JSONEncoder().encode(userData)
+    do {
+      try EVY.data.create(key: "user", data: encodedUserData)
+    } catch EVYDataError.keyAlreadyExists {
+    }
+  }
 
-	private static func upsertSyncedData(key: String, data encodedData: Data) throws {
-		try EVY.data.upsert(key: key, value: encodedData)
-	}
+  private static func upsertSyncedData(key: String, data encodedData: Data) throws {
+    try EVY.data.upsert(key: key, value: encodedData)
+  }
 
-	static func syncServiceData(service: String) async throws {
-		let params = SyncServiceDataParams(
-			service: service,
-			lastSyncTime: "1970-01-01T00:00:00.000Z"
-		)
-		let response = try await EVYAPIManager.shared.fetch(
-			method: "syncServiceData",
-			params: params,
-			expecting: SyncServiceDataResponse.self
-		)
+  static func syncServiceData(service: String) async throws {
+    let params = SyncServiceDataParams(
+      service: service,
+      lastSyncTime: "1970-01-01T00:00:00.000Z"
+    )
+    let response = try await EVYAPIManager.shared.fetch(
+      method: "syncServiceData",
+      params: params,
+      expecting: SyncServiceDataResponse.self
+    )
 
-		for row in response.data {
-			let key = "\(row.service):\(row.resource)"
-			let encoded = try JSONEncoder().encode(row.value)
-			try upsertSyncedData(key: key, data: encoded)
-		}
-	}
+    for row in response.data {
+      let key = "\(row.service):\(row.resource)"
+      let encoded = try JSONEncoder().encode(row.value)
+      try upsertSyncedData(key: key, data: encoded)
+    }
+  }
 
-	static func syncAllServices() async throws {
-		let services = ["marketplace"]
-		for service in services {
-			try await syncServiceData(service: service)
-		}
-	}
+  static func syncAllServices() async throws {
+    let services = ["marketplace"]
+    for service in services {
+      try await syncServiceData(service: service)
+    }
+  }
 
-	static func getItemData() throws -> Data {
-		let itemsData = try EVY.data.get(key: "marketplace:items")
-		let items = try itemsData.decoded()
-		if case .array(let arr) = items, let first = arr.first {
-			return try JSONEncoder().encode(first)
-		}
-		return try JSONEncoder().encode(EVYJson.dictionary([:]))
-	}
+  static func getItemData() throws -> Data {
+    let itemsData = try EVY.data.get(key: "marketplace:items")
+    let items = try itemsData.decoded()
+    if case .array(let arr) = items, let first = arr.first {
+      return try JSONEncoder().encode(first)
+    }
+    return try JSONEncoder().encode(EVYJson.dictionary([:]))
+  }
 
-	static func getData() async throws -> Data {
-		try await syncAllServices()
-		return try getItemData()
-	}
+  static func getData() async throws -> Data {
+    try await syncAllServices()
+    return try getItemData()
+  }
 
-	static func getSDUI() async throws -> [UI_Flow] {
-		try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(service: "evy", resource: "sdui", filter: nil), expecting: [UI_Flow].self)
-	}
+  static func getSDUI() async throws -> [UI_Flow] {
+    try await EVYAPIManager.shared.fetch(
+      method: "get", params: GetParams(service: "evy", resource: "sdui", filter: nil),
+      expecting: [UI_Flow].self)
+  }
 
-	static func createItem() async throws {
-		try EVY.data.create(key: "item", data: try await getData())
-	}
+  static func createItem() async throws {
+    try EVY.data.create(key: "item", data: try await getData())
+  }
 
-	static func getRow(_ props: [String]) async throws -> UI_Row {
-		try await createItem()
-		let flowData = try await EVYAPIManager.shared.fetch(method: "get", params: GetParams(service: "evy", resource: "sdui", filter: nil), expecting: EVYJson.self)
-		let rowData = try JSONEncoder().encode(flowData.parseProp(props: props))
-		return try JSONDecoder().decode(UI_Row.self, from: rowData)
-	}
+  static func getRow(_ props: [String]) async throws -> UI_Row {
+    try await createItem()
+    let flowData = try await EVYAPIManager.shared.fetch(
+      method: "get", params: GetParams(service: "evy", resource: "sdui", filter: nil),
+      expecting: EVYJson.self)
+    let rowData = try JSONEncoder().encode(flowData.parseProp(props: props))
+    return try JSONDecoder().decode(UI_Row.self, from: rowData)
+  }
 
-    static func getDataFromText(_ input: String) throws -> EVYJson {
-        try _getDataFromText(input)
+  static func getDataFromText(_ input: String) throws -> EVYJson {
+    try _getDataFromText(input)
+  }
+
+  static func getDataFromProps(_ props: String) throws -> EVYJson {
+    try _getDataFromProps(props)
+  }
+
+  static func getValueFromText(_ input: String, editing: Bool = false) throws -> EVYValue {
+    try _getValueFromText(input, editing: editing)
+  }
+
+  static func parsePropsFromText(_ input: String) -> String {
+    _parsePropsFromText(input)
+  }
+
+  static func watchTarget(for text: String) -> String {
+    _watchTarget(for: text)
+  }
+
+  static func evaluateFromText(_ input: String) throws -> Bool {
+    try _evaluateFromText(input)
+  }
+
+  static func formatData(json: EVYJson, format: String) throws -> String {
+    try _formatData(json: json, format: format)
+  }
+
+  static func formatDataOrToString(json: EVYJson, format: String) throws -> String {
+    if format.isEmpty {
+      return json.toString()
+    }
+    return try formatData(json: json, format: format)
+  }
+
+  static func ensureDraftExists(
+    variableName: String,
+    initialData: Data? = nil,
+    scopeId: String? = nil
+  ) {
+    guard let resolvedScopeId = scopeId ?? data.activeDraftScopeId,
+      let binding = try? data.draftBinding(
+        fromParsedProps: variableName,
+        scopeId: resolvedScopeId
+      )
+    else {
+      return
+    }
+    guard !data.exists(key: variableName),
+      !data.hasDraft(binding: binding)
+    else {
+      return
+    }
+    let emptyData = initialData ?? "\"\"".data(using: .utf8)!
+    do {
+      try data.createDraft(binding: binding, data: emptyData)
+    } catch {
+    }
+  }
+
+  static func create(key: String, draftScopeId: String? = nil) throws {
+    struct UpsertParams: Encodable {
+      let service: String
+      let resource: String
+      let filter: Filter?
+      let data: EVYJson
     }
 
-    static func getDataFromProps(_ props: String) throws -> EVYJson {
-        try _getDataFromProps(props)
+    let existing = try data.get(key: key)
+    let newId = UUID().uuidString
+    let payload = try existing.decoded()
+    guard case .dictionary = payload else {
+      throw EVYParamError.invalidProps
     }
 
-    static func getValueFromText(_ input: String, editing: Bool = false) throws -> EVYValue {
-        try _getValueFromText(input, editing: editing)
+    var mergedPayload = payload
+
+    let scopeForMerge = draftScopeId ?? data.activeDraftScopeId
+    let draftRows: [EVYDraft] = {
+      guard let s = scopeForMerge else { return [] }
+      return (try? data.drafts(forScopeId: s)) ?? []
+    }()
+    for draftRow in draftRows {
+      let draftValue = try draftRow.decoded()
+      if case .string(let s) = draftValue, s.isEmpty {
+        continue
+      }
+      mergedPayload = draftRow.merged(into: mergedPayload, draftValue: draftValue)
     }
 
-    static func parsePropsFromText(_ input: String) -> String {
-        _parsePropsFromText(input)
+    guard case .dictionary(var dict) = mergedPayload else {
+      throw EVYParamError.invalidProps
     }
+    dict["id"] = .string(newId)
+    let dataWithId = EVYJson.dictionary(dict)
+    let params = UpsertParams(
+      service: "marketplace",
+      resource: "\(key)s",
+      filter: Filter(id: newId),
+      data: dataWithId
+    )
+    existing.data = try JSONEncoder().encode(dataWithId)
+    existing.key = newId
 
-    static func watchTarget(for text: String) -> String {
-        _watchTarget(for: text)
-    }
-
-    static func evaluateFromText(_ input: String) throws -> Bool {
-        try _evaluateFromText(input)
-    }
-
-    static func formatData(json: EVYJson, format: String) throws -> String {
-        try _formatData(json: json, format: format)
-    }
-
-    static func formatDataOrToString(json: EVYJson, format: String) throws -> String {
-        if format.isEmpty {
-            return json.toString()
-        }
-        return try formatData(json: json, format: format)
-    }
-
-    static func ensureDraftExists(
-        variableName: String,
-        initialData: Data? = nil,
-        scopeId: String? = nil
-    ) {
-        guard let resolvedScopeId = scopeId ?? data.activeDraftScopeId,
-              let binding = try? data.draftBinding(
-            fromParsedProps: variableName,
-            scopeId: resolvedScopeId
-        ) else {
-            return
-        }
-        guard !data.exists(key: variableName),
-              !data.hasDraft(binding: binding) else {
-            return
-        }
-        let emptyData = initialData ?? "\"\"".data(using: .utf8)!
-        do {
-            try data.createDraft(binding: binding, data: emptyData)
-        } catch {
-        }
-    }
-
-    static func create(key: String, draftScopeId: String? = nil) throws {
-        struct UpsertParams: Encodable {
-            let service: String
-            let resource: String
-            let filter: Filter?
-            let data: EVYJson
-        }
-
-        let existing = try data.get(key: key)
-        let newId = UUID().uuidString
-        let payload = try existing.decoded()
-        guard case .dictionary = payload else {
-            throw EVYParamError.invalidProps
-        }
-
-        var mergedPayload = payload
-
-        let scopeForMerge = draftScopeId ?? data.activeDraftScopeId
-        let draftRows: [EVYDraft] = {
-            guard let s = scopeForMerge else { return [] }
-            return (try? data.drafts(forScopeId: s)) ?? []
-        }()
-        for draftRow in draftRows {
-            let draftValue = try draftRow.decoded()
-            if case .string(let s) = draftValue, s.isEmpty {
-                continue
-            }
-            mergedPayload = draftRow.merged(into: mergedPayload, draftValue: draftValue)
-        }
-
-        guard case .dictionary(var dict) = mergedPayload else {
-            throw EVYParamError.invalidProps
-        }
-        dict["id"] = .string(newId)
-        let dataWithId = EVYJson.dictionary(dict)
-        let params = UpsertParams(
-            service: "marketplace",
-            resource: "\(key)s",
-            filter: Filter(id: newId),
-            data: dataWithId
+    Task { @MainActor in
+      do {
+        _ = try await EVYAPIManager.shared.fetch(
+          method: "upsert",
+          params: params,
+          expecting: EVYJson.self
         )
-        existing.data = try JSONEncoder().encode(dataWithId)
-        existing.key = newId
+      } catch {
+        NotificationCenter.default.post(
+          name: .evyErrorOccurred,
+          object: error
+        )
+      }
+    }
+  }
 
-        Task { @MainActor in
-            do {
-                _ = try await EVYAPIManager.shared.fetch(
-                    method: "upsert",
-                    params: params,
-                    expecting: EVYJson.self
-                )
-            } catch {
-                NotificationCenter.default.post(
-                    name: .evyErrorOccurred,
-                    object: error
-                )
-            }
-        }
+  static func updateValue(_ value: String, at: String, scopeId: String? = nil) throws {
+    let destinationProps = _parsePropsFromText(at)
+    if let (functionName, functionArgs) = parseFunctionCall(destinationProps) {
+      switch functionName {
+      case "buildCurrency":
+        try updateData(
+          try evyBuildCurrency(functionArgs, value), at: functionArgs, scopeId: scopeId)
+        return
+      case "buildAddress":
+        try updateData(try evyBuildAddress(functionArgs, value), at: functionArgs, scopeId: scopeId)
+        return
+      default:
+        break
+      }
+    }
+    try updateData("\"\(value)\"".data(using: .utf8)!, at: at, scopeId: scopeId)
+  }
+
+  static func updateData(_ newData: Data, at: String, scopeId: String? = nil) throws {
+    let variableName = _parsePropsFromText(at)
+    let splitProps = try splitPropsFromText(variableName)
+    let rootVariable = splitProps.first!
+    let resolvedScopeId = scopeId ?? data.activeDraftScopeId
+    let draftBinding = try resolvedScopeId.map {
+      try data.draftBinding(fromParsedProps: variableName, scopeId: $0)
     }
 
-    static func updateValue(_ value: String, at: String, scopeId: String? = nil) throws {
-        let destinationProps = _parsePropsFromText(at)
-        if let (functionName, functionArgs) = parseFunctionCall(destinationProps) {
-            switch functionName {
-            case "buildCurrency":
-                try updateData(try evyBuildCurrency(functionArgs, value), at: functionArgs, scopeId: scopeId)
-                return
-            case "buildAddress":
-                try updateData(try evyBuildAddress(functionArgs, value), at: functionArgs, scopeId: scopeId)
-                return
-            default:
-                break
-            }
-        }
-        try updateData("\"\(value)\"".data(using: .utf8)!, at: at, scopeId: scopeId)
+    if let draftBinding,
+      let existingDraft = data.draftIfPresent(binding: draftBinding)
+    {
+      let remainingProps = EVYDraft.remainingPropsAfterDraftPrefix(
+        splitProps: splitProps,
+        binding: draftBinding
+      )
+      if remainingProps.isEmpty {
+        existingDraft.data = newData
+      } else {
+        let wrapper = EVYData(key: "_draft", data: existingDraft.data)
+        try wrapper.updateDataWithData(newData, props: remainingProps)
+        existingDraft.data = wrapper.data
+      }
+      NotificationCenter.default.post(
+        name: .evyDataUpdated,
+        object: draftBinding.notificationKey
+      )
+    } else if data.exists(key: rootVariable) {
+      let dataObj = try data.get(key: rootVariable)
+      let remainingProps = Array(splitProps.dropFirst())
+      if remainingProps.isEmpty {
+        dataObj.data = newData
+      } else {
+        try dataObj.updateDataWithData(newData, props: remainingProps)
+      }
+      try data.update(props: splitProps, data: dataObj.data)
+    } else {
+      guard let draftBinding else {
+        throw EVYDataError.keyNotFound
+      }
+      try data.upsertDraft(binding: draftBinding, data: newData)
     }
-
-    static func updateData(_ newData: Data, at: String, scopeId: String? = nil) throws {
-        let variableName = _parsePropsFromText(at)
-        let splitProps = try splitPropsFromText(variableName)
-        let rootVariable = splitProps.first!
-        let resolvedScopeId = scopeId ?? data.activeDraftScopeId
-        let draftBinding = try resolvedScopeId.map {
-            try data.draftBinding(fromParsedProps: variableName, scopeId: $0)
-        }
-
-        if let draftBinding,
-           let existingDraft = data.draftIfPresent(binding: draftBinding)
-        {
-            let remainingProps = EVYDraft.remainingPropsAfterDraftPrefix(
-                splitProps: splitProps,
-                binding: draftBinding
-            )
-            if remainingProps.isEmpty {
-                existingDraft.data = newData
-            } else {
-                let wrapper = EVYData(key: "_draft", data: existingDraft.data)
-                try wrapper.updateDataWithData(newData, props: remainingProps)
-                existingDraft.data = wrapper.data
-            }
-            NotificationCenter.default.post(
-                name: .evyDataUpdated,
-                object: draftBinding.notificationKey
-            )
-        } else if data.exists(key: rootVariable) {
-            let dataObj = try data.get(key: rootVariable)
-            let remainingProps = Array(splitProps.dropFirst())
-            if remainingProps.isEmpty {
-                dataObj.data = newData
-            } else {
-                try dataObj.updateDataWithData(newData, props: remainingProps)
-            }
-            try data.update(props: splitProps, data: dataObj.data)
-        } else {
-            guard let draftBinding else {
-                throw EVYDataError.keyNotFound
-            }
-            try data.upsertDraft(binding: draftBinding, data: newData)
-        }
-    }
+  }
 }
 
 struct AsyncPreview<VisualContent: View, ViewData>: View {
-	var viewBuilder: (ViewData) -> VisualContent
-	var view: () async throws -> ViewData?
+  var viewBuilder: (ViewData) -> VisualContent
+  var view: () async throws -> ViewData?
 
-	@State private var viewData: ViewData?
-	@State private var error: Error?
+  @State private var viewData: ViewData?
+  @State private var error: Error?
 
-	var body: some View {
-		safeView.task {
-			do {
-				self.viewData = try await view()
-			} catch {
-				self.error = error
-			}
-		}
-	}
+  var body: some View {
+    safeView.task {
+      do {
+        self.viewData = try await view()
+      } catch {
+        self.error = error
+      }
+    }
+  }
 
-	@ViewBuilder
-	private var safeView: some View {
-		if let viewData {
-			viewBuilder(viewData)
-		} else if let error {
-			Text(error.localizedDescription)
-		} else {
-			Text("Building view...")
-		}
-	}
+  @ViewBuilder
+  private var safeView: some View {
+    if let viewData {
+      viewBuilder(viewData)
+    } else if let error {
+      Text(error.localizedDescription)
+    } else {
+      Text("Building view...")
+    }
+  }
 }

--- a/ios/evy/UI/Atoms/EVYCarouselIndicator.swift
+++ b/ios/evy/UI/Atoms/EVYCarouselIndicator.swift
@@ -8,22 +8,22 @@
 import SwiftUI
 
 struct EVYCarouselIndicator: View {
-    let indices: ClosedRange<Int>
-    let selectionIndex: Int
-    let color: Color
-    
-    var body: some View {
-        HStack {
-            ForEach(indices, id: \.self) { index in
-                Capsule()
-                    .fill(color.opacity(selectionIndex == index ? 1 : 0.2))
-                    .frame(width: Constants.base*9, height: Constants.base*2)
-            }
-        }
-        .padding()
+  let indices: ClosedRange<Int>
+  let selectionIndex: Int
+  let color: Color
+
+  var body: some View {
+    HStack {
+      ForEach(indices, id: \.self) { index in
+        Capsule()
+          .fill(color.opacity(selectionIndex == index ? 1 : 0.2))
+          .frame(width: Constants.base * 9, height: Constants.base * 2)
+      }
     }
+    .padding()
+  }
 }
 
 #Preview {
-    EVYCarouselIndicator(indices: (1...3), selectionIndex: 2, color: .black)
+  EVYCarouselIndicator(indices: (1...3), selectionIndex: 2, color: .black)
 }

--- a/ios/evy/UI/Atoms/EVYRadioButton.swift
+++ b/ios/evy/UI/Atoms/EVYRadioButton.swift
@@ -7,60 +7,60 @@
 
 import SwiftUI
 
-let radioSize: CGFloat = Constants.base*5
+let radioSize: CGFloat = Constants.base * 5
 
 public enum EVYRadioStyle: String {
-    case single
-    case multi
+  case single
+  case multi
 }
 
 struct EVYRadioButton: View {
-    let isSelected: Bool
-    let style: EVYRadioStyle
-    var body: some View {
-        buttonView
-    }
+  let isSelected: Bool
+  let style: EVYRadioStyle
+  var body: some View {
+    buttonView
+  }
 }
 
-private extension EVYRadioButton {
-    @ViewBuilder var buttonView: some View {
-        switch style {
-        case .single:
-            Circle()
-                .fill(innerColor)
-                .padding(Constants.padding)
-                .overlay(
-                    Circle().stroke(outlineColor, lineWidth: Constants.borderWidth)
-                )
-                .frame(width: radioSize, height: radioSize)
-        case .multi:
-            RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
-                .fill(innerColor)
-                .padding(Constants.padding)
-                .overlay(
-                    RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
-                        .stroke(outlineColor, lineWidth: Constants.borderWidth)
-                )
-                .frame(width: radioSize, height: radioSize)
-        }
+extension EVYRadioButton {
+  @ViewBuilder fileprivate var buttonView: some View {
+    switch style {
+    case .single:
+      Circle()
+        .fill(innerColor)
+        .padding(Constants.padding)
+        .overlay(
+          Circle().stroke(outlineColor, lineWidth: Constants.borderWidth)
+        )
+        .frame(width: radioSize, height: radioSize)
+    case .multi:
+      RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
+        .fill(innerColor)
+        .padding(Constants.padding)
+        .overlay(
+          RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
+            .stroke(outlineColor, lineWidth: Constants.borderWidth)
+        )
+        .frame(width: radioSize, height: radioSize)
     }
+  }
 }
 
-private extension EVYRadioButton {
-   var innerColor: Color {
-       isSelected ? Constants.actionColor : Color.clear
-   }
+extension EVYRadioButton {
+  fileprivate var innerColor: Color {
+    isSelected ? Constants.actionColor : Color.clear
+  }
 
-   var outlineColor: Color {
-      isSelected ? Constants.actionColor : Constants.borderColor
-   }
+  fileprivate var outlineColor: Color {
+    isSelected ? Constants.actionColor : Constants.borderColor
+  }
 }
 
 #Preview {
-    VStack {
-        EVYRadioButton(isSelected: true, style: .single)
-        EVYRadioButton(isSelected: false, style: .single)
-        EVYRadioButton(isSelected: true, style: .multi)
-        EVYRadioButton(isSelected: false, style: .multi)
-    }
+  VStack {
+    EVYRadioButton(isSelected: true, style: .single)
+    EVYRadioButton(isSelected: false, style: .single)
+    EVYRadioButton(isSelected: true, style: .multi)
+    EVYRadioButton(isSelected: false, style: .multi)
+  }
 }

--- a/ios/evy/UI/Atoms/EVYRectangle.swift
+++ b/ios/evy/UI/Atoms/EVYRectangle.swift
@@ -8,72 +8,73 @@
 import SwiftUI
 
 public enum EVYRectangleStyle: String {
-    case primary
-    case secondary
-    case clear
+  case primary
+  case secondary
+  case clear
 }
 
 public enum EVYRectangleWidth: String {
-    case fixed
-    case fit
+  case fixed
+  case fit
 }
 
 struct EVYRectangle: View {
-	@Environment(\.colorScheme) var colorScheme
-	
-    let content: any View
-	let style: EVYRectangleStyle
-    let width: CGFloat?
-    
-    private let height: CGFloat = 40
-    
-    static func fixedWidth(content: any View,
-						   style: EVYRectangleStyle,
-						   width: CGFloat) -> EVYRectangle
-	{
-        EVYRectangle(content: content, style: style, width: width)
-    }
-    
-    static func fitWidth(content: any View,
-						 style: EVYRectangleStyle) -> EVYRectangle
-	{
-        EVYRectangle(content: content, style: style, width: nil)
-    }
-    
-    var body: some View {
-		var textColor: Color
-		var buttonFill: Color
-		switch style {
-		case .primary:
-			textColor =  (colorScheme == .light ? .white : .black)
-			buttonFill = (colorScheme == .light ? Constants.buttonColor : .white)
-		case .secondary:
-			textColor = (colorScheme == .light ? .black : .white)
-			buttonFill = (colorScheme == .light ? Constants.inactiveBackground : Constants.buttonDisabledColor)
-		default:
-			textColor = (colorScheme == .light ? .black : .white)
-			buttonFill = .clear
-		}
-		
-        return AnyView(content)
-            .foregroundColor(textColor)
-            .padding(Constants.majorPadding)
-            .frame(width: width, height: height)
-            .background(content: {
-                RoundedRectangle(cornerRadius: Constants.mainCornerRadius)
-                    .fill(buttonFill)
-            })
-    }
-}
+  @Environment(\.colorScheme) var colorScheme
 
+  let content: any View
+  let style: EVYRectangleStyle
+  let width: CGFloat?
+
+  private let height: CGFloat = 40
+
+  static func fixedWidth(
+    content: any View,
+    style: EVYRectangleStyle,
+    width: CGFloat
+  ) -> EVYRectangle {
+    EVYRectangle(content: content, style: style, width: width)
+  }
+
+  static func fitWidth(
+    content: any View,
+    style: EVYRectangleStyle
+  ) -> EVYRectangle {
+    EVYRectangle(content: content, style: style, width: nil)
+  }
+
+  var body: some View {
+    var textColor: Color
+    var buttonFill: Color
+    switch style {
+    case .primary:
+      textColor = (colorScheme == .light ? .white : .black)
+      buttonFill = (colorScheme == .light ? Constants.buttonColor : .white)
+    case .secondary:
+      textColor = (colorScheme == .light ? .black : .white)
+      buttonFill =
+        (colorScheme == .light ? Constants.inactiveBackground : Constants.buttonDisabledColor)
+    default:
+      textColor = (colorScheme == .light ? .black : .white)
+      buttonFill = .clear
+    }
+
+    return AnyView(content)
+      .foregroundColor(textColor)
+      .padding(Constants.majorPadding)
+      .frame(width: width, height: height)
+      .background(content: {
+        RoundedRectangle(cornerRadius: Constants.mainCornerRadius)
+          .fill(buttonFill)
+      })
+  }
+}
 
 #Preview {
-    VStack {
-        EVYRectangle.fixedWidth(content: EVYTextView("test"), style: .primary, width: 60)
-        EVYRectangle.fixedWidth(content: EVYTextView("test"), style: .secondary, width: 60)
-        EVYRectangle.fixedWidth(content: EVYTextView("test"), style: .clear, width: 60)
-        EVYRectangle.fitWidth(content: EVYTextView("looooooooong"), style: .primary)
-        EVYRectangle.fixedWidth(content: EVYTextView("toooo looong"), style: .primary, width: 70)
-    }
+  VStack {
+    EVYRectangle.fixedWidth(content: EVYTextView("test"), style: .primary, width: 60)
+    EVYRectangle.fixedWidth(content: EVYTextView("test"), style: .secondary, width: 60)
+    EVYRectangle.fixedWidth(content: EVYTextView("test"), style: .clear, width: 60)
+    EVYRectangle.fitWidth(content: EVYTextView("looooooooong"), style: .primary)
+    EVYRectangle.fixedWidth(content: EVYTextView("toooo looong"), style: .primary, width: 70)
+  }
 }
-

--- a/ios/evy/UI/Atoms/EVYRowTitle.swift
+++ b/ios/evy/UI/Atoms/EVYRowTitle.swift
@@ -6,12 +6,12 @@
 import SwiftUI
 
 struct EVYRowTitle: View {
-	let title: String
+  let title: String
 
-	var body: some View {
-		if !title.isEmpty {
-			EVYTextView(title)
-				.padding(.vertical, Constants.padding)
-		}
-	}
+  var body: some View {
+    if !title.isEmpty {
+      EVYTextView(title)
+        .padding(.vertical, Constants.padding)
+    }
+  }
 }

--- a/ios/evy/UI/Atoms/EVYTextView.swift
+++ b/ios/evy/UI/Atoms/EVYTextView.swift
@@ -10,144 +10,148 @@ import SwiftUI
 import UIKit
 
 public enum EVYTextStyle: String {
-    case body
-    case title
-    case info
-    case button
-    case action
+  case body
+  case title
+  case info
+  case button
+  case action
 }
 
 struct EVYTextView: View {
-	@Environment(\.colorScheme) var colorScheme
+  @Environment(\.colorScheme) var colorScheme
 
-	private static let iconTokenRegex = try! Regex("::[a-zA-Z0-9-]+::")
+  private static let iconTokenRegex = try! Regex("::[a-zA-Z0-9-]+::")
 
-	var text: EVYState<EVYValue>
-    let style: EVYTextStyle
-    
-	init(_ text: String, placeholder: String = "", style: EVYTextStyle = .body) {
-        self.style = style
-		
-		let props = EVY.parsePropsFromText(text)
-		
-		// If the props don't include any data and are just plain text
-		// instanciate a simple version of state without any watching
-		if props == text {
-			self.text = EVYState(staticString: EVYValue(text, nil, nil))
-			
-		// Otherwise, go all out
-		} else {
-			let placeholderVal = EVYValue(placeholder, nil, nil)
-			let templateText = text
-			let watchKey = EVY.watchTarget(for: templateText)
+  var text: EVYState<EVYValue>
+  let style: EVYTextStyle
 
-			self.text = EVYState(watch: watchKey, setter: { _ in
-				guard let value = try? EVY.getValueFromText(templateText) else {
-					return placeholderVal
-				}
+  init(_ text: String, placeholder: String = "", style: EVYTextStyle = .body) {
+    self.style = style
 
-				if props == templateText {
-					return value
-				}
-				if templateText.contains(value.value) {
-					return placeholderVal
-				}
-				return value
-			})
-		}
-    }
-    
-    var body: some View {
-        HStack(alignment: .top, spacing: .zero, content: {
-            if let prefix = text.value.prefix {
-                parsedText(prefix, style)
-            }
-            parsedText(text.value.value, style)
-            if let suffix = text.value.suffix {
-                parsedText(suffix, style)
-            }
+    let props = EVY.parsePropsFromText(text)
+
+    // If the props don't include any data and are just plain text
+    // instanciate a simple version of state without any watching
+    if props == text {
+      self.text = EVYState(staticString: EVYValue(text, nil, nil))
+
+      // Otherwise, go all out
+    } else {
+      let placeholderVal = EVYValue(placeholder, nil, nil)
+      let templateText = text
+      let watchKey = EVY.watchTarget(for: templateText)
+
+      self.text = EVYState(
+        watch: watchKey,
+        setter: { _ in
+          guard let value = try? EVY.getValueFromText(templateText) else {
+            return placeholderVal
+          }
+
+          if props == templateText {
+            return value
+          }
+          if templateText.contains(value.value) {
+            return placeholderVal
+          }
+          return value
         })
     }
-    
-    func toText() -> Text {
-        parsedText(toString(), style)
+  }
+
+  var body: some View {
+    HStack(
+      alignment: .top, spacing: .zero,
+      content: {
+        if let prefix = text.value.prefix {
+          parsedText(prefix, style)
+        }
+        parsedText(text.value.value, style)
+        if let suffix = text.value.suffix {
+          parsedText(suffix, style)
+        }
+      })
+  }
+
+  func toText() -> Text {
+    parsedText(toString(), style)
+  }
+
+  func toString() -> String {
+    text.value.toString()
+  }
+
+  private func parsedText(_ input: String, _ style: EVYTextStyle = .body) -> Text {
+    if input.count < 1 {
+      return Text(input)
     }
-    
-    func toString() -> String {
-        text.value.toString()
+
+    if let match = input.firstMatch(of: Self.iconTokenRegex) {
+      let imageStart = match.range.lowerBound
+      let imageEnd = match.range.upperBound
+
+      let matchString = String(match.0)
+      let imageName = matchString.trimmingCharacters(in: CharacterSet(charactersIn: ":"))
+      let imageText: Text
+      if let uiImage = UIImage(lucideId: imageName) {
+        imageText = Text(Image(uiImage: uiImage).renderingMode(.template))
+      } else {
+        imageText = styledPlainText(matchString, style)
+      }
+
+      var result = imageText
+      if imageStart > input.startIndex {
+        let start = String(input.prefix(upTo: imageStart))
+        result = parsedText(start, style) + result
+      }
+      if imageEnd < input.endIndex {
+        let end = String(input.suffix(from: imageEnd))
+        result = result + parsedText(end, style)
+      }
+      return result
     }
-	
-	private func parsedText(_ input: String, _ style: EVYTextStyle = .body) -> Text {
-		if input.count < 1 {
-			return Text(input)
-		}
 
-		if let match = input.firstMatch(of: Self.iconTokenRegex) {
-			let imageStart = match.range.lowerBound
-			let imageEnd = match.range.upperBound
+    return styledPlainText(input, style)
+  }
 
-			let matchString = String(match.0)
-			let imageName = matchString.trimmingCharacters(in: CharacterSet(charactersIn: ":"))
-			let imageText: Text
-			if let uiImage = UIImage(lucideId: imageName) {
-				imageText = Text(Image(uiImage: uiImage).renderingMode(.template))
-			} else {
-				imageText = styledPlainText(matchString, style)
-			}
-
-			var result = imageText
-			if imageStart > input.startIndex {
-				let start = String(input.prefix(upTo: imageStart))
-				result = parsedText(start, style) + result
-			}
-			if imageEnd < input.endIndex {
-				let end = String(input.suffix(from: imageEnd))
-				result = result + parsedText(end, style)
-			}
-			return result
-		}
-		
-		return styledPlainText(input, style)
-	}
-	
-	private func styledPlainText(_ input: String, _ style: EVYTextStyle) -> Text {
-		switch style {
-		case .title:
-			return Text(input)
-				.font(.evyTitle)
-		case .info:
-			return Text(input)
-				.font(.evy)
-				.foregroundStyle(Constants.textGreyColor)
-		case .button:
-			return Text(input)
-				.font(.evy)
-				.foregroundStyle(colorScheme == .light ? .white : .black)
-		case .action:
-			return Text(input)
-				.font(.evy)
-				.foregroundStyle(colorScheme == .light ? Constants.actionColor : .white)
-		default:
-			return Text(input).font(.evy)
-		}
-	}
+  private func styledPlainText(_ input: String, _ style: EVYTextStyle) -> Text {
+    switch style {
+    case .title:
+      return Text(input)
+        .font(.evyTitle)
+    case .info:
+      return Text(input)
+        .font(.evy)
+        .foregroundStyle(Constants.textGreyColor)
+    case .button:
+      return Text(input)
+        .font(.evy)
+        .foregroundStyle(colorScheme == .light ? .white : .black)
+    case .action:
+      return Text(input)
+        .font(.evy)
+        .foregroundStyle(colorScheme == .light ? Constants.actionColor : .white)
+    default:
+      return Text(input).font(.evy)
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
-		return VStack {
-			EVYTextView("::star::")
-			EVYTextView("Body style", style: EVYTextStyle.body)
-			EVYTextView("Info style", style: EVYTextStyle.info)
-			EVYTextView("Title style", style: EVYTextStyle.title)
-			EVYButton(label: "button", action: {})
-			EVYTextView("Action", style: EVYTextStyle.action)
-			EVYTextView("{item.title} ::star:: and more text")
-			EVYTextView("count: {count(item.photo_ids)}")
-			EVYTextView("{item.title} has {count(item.photo_ids)} photos ::star::")
-		}
-	}
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
+    return VStack {
+      EVYTextView("::star::")
+      EVYTextView("Body style", style: EVYTextStyle.body)
+      EVYTextView("Info style", style: EVYTextStyle.info)
+      EVYTextView("Title style", style: EVYTextStyle.title)
+      EVYButton(label: "button", action: {})
+      EVYTextView("Action", style: EVYTextStyle.action)
+      EVYTextView("{item.title} ::star:: and more text")
+      EVYTextView("count: {count(item.photo_ids)}")
+      EVYTextView("{item.title} has {count(item.photo_ids)} photos ::star::")
+    }
+  }
 }

--- a/ios/evy/UI/EVYActionRunner.swift
+++ b/ios/evy/UI/EVYActionRunner.swift
@@ -7,106 +7,109 @@ import Foundation
 
 @MainActor
 enum EVYActionRunner {
-    static func run(actions: [UI_RowAction],
-                    navigate: @escaping (NavOperation) -> Void)
-    {
-        guard !actions.isEmpty else { return }
+  static func run(
+    actions: [UI_RowAction],
+    navigate: @escaping (NavOperation) -> Void
+  ) {
+    guard !actions.isEmpty else { return }
 
-        for action in actions {
-            let condition = action.condition.trimmingCharacters(in: .whitespacesAndNewlines)
-            let executeTrueBranch: Bool
+    for action in actions {
+      let condition = action.condition.trimmingCharacters(in: .whitespacesAndNewlines)
+      let executeTrueBranch: Bool
 
-            if condition.isEmpty {
-                executeTrueBranch = true
-            } else {
-                executeTrueBranch = (try? EVY.evaluateFromText(condition)) ?? false
-            }
+      if condition.isEmpty {
+        executeTrueBranch = true
+      } else {
+        executeTrueBranch = (try? EVY.evaluateFromText(condition)) ?? false
+      }
 
-            if !executeTrueBranch {
-                let falseBranch = action.`false`.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !falseBranch.isEmpty {
-                    do {
-                        try execute(branch: falseBranch, navigate: navigate)
-                    } catch {
-                        NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
-                    }
-                }
-                return
-            }
-
-            let trueBranch = action.`true`.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trueBranch.isEmpty { continue }
-
-            do {
-                try execute(branch: trueBranch, navigate: navigate)
-            } catch {
-                NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
-            }
+      if !executeTrueBranch {
+        let falseBranch = action.`false`.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !falseBranch.isEmpty {
+          do {
+            try execute(branch: falseBranch, navigate: navigate)
+          } catch {
+            NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
+          }
         }
+        return
+      }
+
+      let trueBranch = action.`true`.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trueBranch.isEmpty { continue }
+
+      do {
+        try execute(branch: trueBranch, navigate: navigate)
+      } catch {
+        NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
+      }
+    }
+  }
+
+  private static func execute(
+    branch: String,
+    navigate: @escaping (NavOperation) -> Void
+  ) throws {
+    let unwrappedBranch = unwrapActionBranch(branch)
+
+    if let operation = parseColonFormat(unwrappedBranch) ?? parseColonFormat(branch) {
+      navigate(operation)
+      return
     }
 
-    private static func execute(branch: String,
-                                navigate: @escaping (NavOperation) -> Void) throws
-    {
-        let unwrappedBranch = unwrapActionBranch(branch)
+    guard branch.hasPrefix("{"), branch.hasSuffix("}") else { return }
 
-        if let operation = parseColonFormat(unwrappedBranch) ?? parseColonFormat(branch) {
-            navigate(operation)
-            return
+    if let (functionName, functionArgs) = parseFunctionCall(unwrappedBranch) {
+      switch functionName {
+      case "navigate":
+        let args = splitFunctionArguments(functionArgs)
+        guard args.count == 2 else {
+          throw EVYError.invalidData(context: "navigate requires flowId and pageId")
         }
-
-        guard branch.hasPrefix("{"), branch.hasSuffix("}") else { return }
-
-        if let (functionName, functionArgs) = parseFunctionCall(unwrappedBranch) {
-            switch functionName {
-            case "navigate":
-                let args = splitFunctionArguments(functionArgs)
-                guard args.count == 2 else {
-                    throw EVYError.invalidData(context: "navigate requires flowId and pageId")
-                }
-                navigate(.navigate(Route(flowId: args[0], pageId: args[1])))
-            case "create":
-                let args = splitFunctionArguments(functionArgs)
-                guard let key = args.first, !key.isEmpty else {
-                    throw EVYError.invalidData(context: "create requires a key")
-                }
-                navigate(.create(key))
-            case "close":
-                navigate(.close)
-            case "highlight_required":
-                let args = splitFunctionArguments(functionArgs)
-                let alias = args.first ?? "field"
-                let fieldName = alias
-                    .replacingOccurrences(of: "_", with: " ")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                let readableField = fieldName.isEmpty ? "Field" : fieldName.capitalized
-                navigate(.highlightRequired(readableField))
-            default:
-                throw EVYError.invalidData(context: "Unsupported action function: \(functionName)")
-            }
-        } else {
-            return
+        navigate(.navigate(Route(flowId: args[0], pageId: args[1])))
+      case "create":
+        let args = splitFunctionArguments(functionArgs)
+        guard let key = args.first, !key.isEmpty else {
+          throw EVYError.invalidData(context: "create requires a key")
         }
+        navigate(.create(key))
+      case "close":
+        navigate(.close)
+      case "highlight_required":
+        let args = splitFunctionArguments(functionArgs)
+        let alias = args.first ?? "field"
+        let fieldName =
+          alias
+          .replacingOccurrences(of: "_", with: " ")
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        let readableField = fieldName.isEmpty ? "Field" : fieldName.capitalized
+        navigate(.highlightRequired(readableField))
+      default:
+        throw EVYError.invalidData(context: "Unsupported action function: \(functionName)")
+      }
+    } else {
+      return
     }
+  }
 
-    private static func parseColonFormat(_ value: String) -> NavOperation? {
-        let parts = value.split(separator: ":")
-        guard let keyword = parts.first else { return nil }
-        switch keyword {
-        case "navigate":
-            guard parts.count >= 3 else { return nil }
-            return .navigate(Route(flowId: String(parts[1]), pageId: String(parts[2])))
-        case "create":
-            guard parts.count == 2 else { return nil }
-            return .create(String(parts[1]))
+  private static func parseColonFormat(_ value: String) -> NavOperation? {
+    let parts = value.split(separator: ":")
+    guard let keyword = parts.first else { return nil }
+    switch keyword {
+    case "navigate":
+      guard parts.count >= 3 else { return nil }
+      return .navigate(Route(flowId: String(parts[1]), pageId: String(parts[2])))
+    case "create":
+      guard parts.count == 2 else { return nil }
+      return .create(String(parts[1]))
 
-        default:
-            return nil
-        }
+    default:
+      return nil
     }
+  }
 
-    private static func unwrapActionBranch(_ branch: String) -> String {
-        guard branch.hasPrefix("{"), branch.hasSuffix("}") else { return branch }
-        return String(branch.dropFirst().dropLast())
-    }
+  private static func unwrapActionBranch(_ branch: String) -> String {
+    guard branch.hasPrefix("{"), branch.hasSuffix("}") else { return branch }
+    return String(branch.dropFirst().dropLast())
+  }
 }

--- a/ios/evy/UI/EVYFlow.swift
+++ b/ios/evy/UI/EVYFlow.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 extension UI_Flow {
-	func getPageById(_ id: String) -> UI_Page? {
-		pages.first { $0.id == id }
-	}
+  func getPageById(_ id: String) -> UI_Page? {
+    pages.first { $0.id == id }
+  }
 }

--- a/ios/evy/UI/EVYPage.swift
+++ b/ios/evy/UI/EVYPage.swift
@@ -9,82 +9,86 @@ import SwiftUI
 import UIKit
 
 private struct EVYDraftScopeEnvironmentKey: EnvironmentKey {
-    static let defaultValue: String? = nil
+  static let defaultValue: String? = nil
 }
 
 extension EnvironmentValues {
-    var evyDraftScopeId: String? {
-        get { self[EVYDraftScopeEnvironmentKey.self] }
-        set { self[EVYDraftScopeEnvironmentKey.self] = newValue }
-    }
+  var evyDraftScopeId: String? {
+    get { self[EVYDraftScopeEnvironmentKey.self] }
+    set { self[EVYDraftScopeEnvironmentKey.self] = newValue }
+  }
 }
 
 extension UI_Page: View {
-    public var body: some View {
-        EVYPageBody(page: self)
-    }
+  public var body: some View {
+    EVYPageBody(page: self)
+  }
 }
 
 private struct EVYPageBody: View {
-    let page: UI_Page
-    @Environment(\.evyDraftScopeId) private var evyDraftScopeId
+  let page: UI_Page
+  @Environment(\.evyDraftScopeId) private var evyDraftScopeId
 
-    var body: some View {
-        Group {
-            ScrollView {
-                ForEach(page.rows, id: \.id) { row in
-                    EVYRow(row: row)
-                        .padding(.horizontal, Constants.majorPadding)
-                        .padding(.vertical, Constants.minorPadding)
-                }
-            }
-            .navigationTitle(page.title)
-            .accessibilityIdentifier("page_\(page.id)")
-            if let footer = page.footer {
-                EVYRow(row: footer)
-                    .overlay(alignment: .top, content: {
-                        Rectangle()
-                            .fill(Constants.borderColor)
-                            .frame(height: 1)
-                            .padding(.top, -Constants.minorPadding)
-                    })
-                    .accessibilityIdentifier("pageFooter_\(page.id)")
-            }
+  var body: some View {
+    Group {
+      ScrollView {
+        ForEach(page.rows, id: \.id) { row in
+          EVYRow(row: row)
+            .padding(.horizontal, Constants.majorPadding)
+            .padding(.vertical, Constants.minorPadding)
         }
-        .onAppear {
-            EVY.data.activeDraftScopeId = evyDraftScopeId
-            bootstrapDrafts(in: page, scopeId: evyDraftScopeId)
-        }
-        .simultaneousGesture(TapGesture().onEnded {
-            UIApplication.shared.sendAction(
-                #selector(UIResponder.resignFirstResponder),
-                to: nil,
-                from: nil,
-                for: nil
-            )
-        })
+      }
+      .navigationTitle(page.title)
+      .accessibilityIdentifier("page_\(page.id)")
+      if let footer = page.footer {
+        EVYRow(row: footer)
+          .overlay(
+            alignment: .top,
+            content: {
+              Rectangle()
+                .fill(Constants.borderColor)
+                .frame(height: 1)
+                .padding(.top, -Constants.minorPadding)
+            }
+          )
+          .accessibilityIdentifier("pageFooter_\(page.id)")
+      }
     }
+    .onAppear {
+      EVY.data.activeDraftScopeId = evyDraftScopeId
+      bootstrapDrafts(in: page, scopeId: evyDraftScopeId)
+    }
+    .simultaneousGesture(
+      TapGesture().onEnded {
+        UIApplication.shared.sendAction(
+          #selector(UIResponder.resignFirstResponder),
+          to: nil,
+          from: nil,
+          for: nil
+        )
+      })
+  }
 
-    /// Ensures a draft exists for each row `destination` binding in the active scope.
-    @MainActor
-    private func bootstrapDrafts(in page: UI_Page, scopeId: String?) {
-        forEachRow(in: page) { row in
-            guard !row.destination.isEmpty else { return }
-            let variableName = parsePropsFromText(row.destination)
-            guard !variableName.isEmpty else { return }
-            let initialData: Data?
-            if row.type == .inlinePicker {
-                initialData = "[]".data(using: .utf8)
-            } else if row.type == .calendar {
-                initialData = try? EVY.data.getForBinding(key: "timeslots").data
-            } else {
-                initialData = nil
-            }
-            EVY.ensureDraftExists(
-                variableName: variableName,
-                initialData: initialData,
-                scopeId: scopeId
-            )
-        }
+  /// Ensures a draft exists for each row `destination` binding in the active scope.
+  @MainActor
+  private func bootstrapDrafts(in page: UI_Page, scopeId: String?) {
+    forEachRow(in: page) { row in
+      guard !row.destination.isEmpty else { return }
+      let variableName = parsePropsFromText(row.destination)
+      guard !variableName.isEmpty else { return }
+      let initialData: Data?
+      if row.type == .inlinePicker {
+        initialData = "[]".data(using: .utf8)
+      } else if row.type == .calendar {
+        initialData = try? EVY.data.getForBinding(key: "timeslots").data
+      } else {
+        initialData = nil
+      }
+      EVY.ensureDraftExists(
+        variableName: variableName,
+        initialData: initialData,
+        scopeId: scopeId
+      )
     }
+  }
 }

--- a/ios/evy/UI/EVYRow.swift
+++ b/ios/evy/UI/EVYRow.swift
@@ -8,55 +8,56 @@
 import SwiftUI
 
 public enum RowCodingKeys: String, CodingKey {
-	case type
-	case view
-	case destination
-	case actions
+  case type
+  case view
+  case destination
+  case actions
 }
 
 public enum EVYRowError: Error {
-	case cannotParseRow
+  case cannotParseRow
 }
 
 protocol EVYRowProtocol: View {
-	static var JSONType: String { get }
+  static var JSONType: String { get }
 }
 
 struct EVYRow: View, Identifiable {
-	let row: UI_Row
-	var id: String { row.id }
+  let row: UI_Row
+  var id: String { row.id }
 
-	var body: some View {
-		if let payload = try? UI_RowPayload.from(row: row) {
-			rowView(for: payload)
-		}
-	}
+  var body: some View {
+    if let payload = try? UI_RowPayload.from(row: row) {
+      rowView(for: payload)
+    }
+  }
 
-	@ViewBuilder
-	private func rowView(for payload: UI_RowPayload) -> some View {
-		switch payload {
-		case .button(let v, _, _, let a): EVYButtonRow(view: v, actions: a)
-		case .calendar(let v, _, _, _): EVYCalendarRow(view: v)
-		case .columnContainer(let v, _, _, _): EVYColumnContainerRow(view: v)
-		case .dropdown(let v, let s, let d, _): EVYDropdownRow(view: v, source: s, destination: d)
-		case .info(let v, _, _, _): EVYInfoRow(view: v)
-		case .inlinePicker(let v, let s, let d, _): EVYInlinePickerRow(view: v, source: s, destination: d)
-		case .inputList(let v, let s, _, _): EVYInputListRow(view: v, source: s)
-		case .input(let v, _, let d, _): EVYInputRow(view: v, destination: d)
-		case .listContainer(let v, _, _, _): EVYListContainerRow(view: v)
-		case .search(let v, let s, let d, _): EVYSearchRow(view: v, source: s, destination: d)
-		case .selectPhoto(let v, _, let d, _): EVYSelectPhotoRow(view: v, destination: d)
-		case .selectSegmentContainer(let v, _, _, _): EVYSelectSegmentContainerRow(view: v)
-		case .sheetContainer(let v, _, _, _): EVYSheetContainerRow(view: v)
-		case .textAction(let v, _, _, let a): EVYTextActionRow(view: v, actions: a)
-		case .textArea(let v, _, let d, _): EVYTextAreaRow(view: v, destination: d)
-		case .text(let v, _, _, _): EVYTextRow(view: v)
-		case .textSelect(let v, _, let d, let a):
-			if let row = EVYTextSelectRow(view: v, destination: d, actions: a) {
-				row
-			} else {
-				EmptyView()
-			}
-		}
-	}
+  @ViewBuilder
+  private func rowView(for payload: UI_RowPayload) -> some View {
+    switch payload {
+    case .button(let v, _, _, let a): EVYButtonRow(view: v, actions: a)
+    case .calendar(let v, _, _, _): EVYCalendarRow(view: v)
+    case .columnContainer(let v, _, _, _): EVYColumnContainerRow(view: v)
+    case .dropdown(let v, let s, let d, _): EVYDropdownRow(view: v, source: s, destination: d)
+    case .info(let v, _, _, _): EVYInfoRow(view: v)
+    case .inlinePicker(let v, let s, let d, _):
+      EVYInlinePickerRow(view: v, source: s, destination: d)
+    case .inputList(let v, let s, _, _): EVYInputListRow(view: v, source: s)
+    case .input(let v, _, let d, _): EVYInputRow(view: v, destination: d)
+    case .listContainer(let v, _, _, _): EVYListContainerRow(view: v)
+    case .search(let v, let s, let d, _): EVYSearchRow(view: v, source: s, destination: d)
+    case .selectPhoto(let v, _, let d, _): EVYSelectPhotoRow(view: v, destination: d)
+    case .selectSegmentContainer(let v, _, _, _): EVYSelectSegmentContainerRow(view: v)
+    case .sheetContainer(let v, _, _, _): EVYSheetContainerRow(view: v)
+    case .textAction(let v, _, _, let a): EVYTextActionRow(view: v, actions: a)
+    case .textArea(let v, _, let d, _): EVYTextAreaRow(view: v, destination: d)
+    case .text(let v, _, _, _): EVYTextRow(view: v)
+    case .textSelect(let v, _, let d, let a):
+      if let row = EVYTextSelectRow(view: v, destination: d, actions: a) {
+        row
+      } else {
+        EmptyView()
+      }
+    }
+  }
 }

--- a/ios/evy/UI/Rows/Action/EVYButtonRow.swift
+++ b/ios/evy/UI/Rows/Action/EVYButtonRow.swift
@@ -8,34 +8,34 @@
 import SwiftUI
 
 struct EVYButtonRow: View, EVYRowProtocol {
-	@Environment(\.navigate) private var navigate
+  @Environment(\.navigate) private var navigate
 
-	public static let JSONType = "Button"
+  public static let JSONType = "Button"
 
-	private let view: ButtonRowViewData
-	private let actions: [UI_RowAction]
+  private let view: ButtonRowViewData
+  private let actions: [UI_RowAction]
 
-	init(view: ButtonRowViewData, actions: [UI_RowAction]) {
-		self.view = view
-		self.actions = actions
-	}
+  init(view: ButtonRowViewData, actions: [UI_RowAction]) {
+    self.view = view
+    self.actions = actions
+  }
 
-	private func performAction() {
-		EVYActionRunner.run(actions: actions, navigate: navigate)
-	}
+  private func performAction() {
+    EVYActionRunner.run(actions: actions, navigate: navigate)
+  }
 
-	var body: some View {
-		EVYButton(label: view.content.label, action: performAction)
-			.frame(maxWidth: .infinity, alignment: .center)
-			.padding(.top, Constants.minorPadding)
-			.padding(.bottom, Constants.majorPadding)
-	}
+  var body: some View {
+    EVYButton(label: view.content.label, action: performAction)
+      .frame(maxWidth: .infinity, alignment: .center)
+      .padding(.top, Constants.minorPadding)
+      .padding(.bottom, Constants.majorPadding)
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "footer"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["1", "pages", "0", "footer"])
+  }
 }

--- a/ios/evy/UI/Rows/Action/EVYTextActionRow.swift
+++ b/ios/evy/UI/Rows/Action/EVYTextActionRow.swift
@@ -8,37 +8,42 @@
 import SwiftUI
 
 struct EVYTextActionRow: View, EVYRowProtocol {
-	public static let JSONType = "TextAction"
+  public static let JSONType = "TextAction"
 
-	private let view: TextActionRowViewData
-	private let actions: [UI_RowAction]
+  private let view: TextActionRowViewData
+  private let actions: [UI_RowAction]
 
-	init(view: TextActionRowViewData, actions: [UI_RowAction]) {
-		self.view = view
-		self.actions = actions
-	}
+  init(view: TextActionRowViewData, actions: [UI_RowAction]) {
+    self.view = view
+    self.actions = actions
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			HStack {
-				EVYTextView(view.content.text,
-				            placeholder: view.content.placeholder,
-				            style: .info)
-					.frame(maxWidth: .infinity, alignment: .leading)
-				EVYTextView(view.content.action, style: .action)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      HStack {
+        EVYTextView(
+          view.content.text,
+          placeholder: view.content.placeholder,
+          style: .info
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+        EVYTextView(view.content.action, style: .action)
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "2", "rows", "0", "view", "content", "children", "0", "child", "view", "content", "children", "1", "child"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow([
+      "2", "pages", "2", "rows", "0", "view", "content", "children", "0", "child", "view",
+      "content", "children", "1", "child",
+    ])
+  }
 }

--- a/ios/evy/UI/Rows/Container/EVYColumnContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYColumnContainerRow.swift
@@ -8,33 +8,33 @@
 import SwiftUI
 
 struct EVYColumnContainerRow: View, EVYRowProtocol {
-	public static let JSONType = "ColumnContainer"
+  public static let JSONType = "ColumnContainer"
 
-	private let view: ColumnContainerRowViewData
+  private let view: ColumnContainerRowViewData
 
-	init(view: ColumnContainerRowViewData) {
-		self.view = view
-	}
+  init(view: ColumnContainerRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			HStack(alignment: .top) {
-				ForEach(Array(view.content.children.enumerated()), id: \.offset) { _, child in
-					EVYRow(row: child)
-				}
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      HStack(alignment: .top) {
+        ForEach(Array(view.content.children.enumerated()), id: \.offset) { _, child in
+          EVYRow(row: child)
+        }
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "5"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "5"])
+  }
 }

--- a/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
@@ -8,31 +8,31 @@
 import SwiftUI
 
 struct EVYListContainerRow: View, EVYRowProtocol {
-	public static let JSONType = "ListContainer"
+  public static let JSONType = "ListContainer"
 
-	private let view: ListContainerRowViewData
+  private let view: ListContainerRowViewData
 
-	init(view: ListContainerRowViewData) {
-		self.view = view
-	}
+  init(view: ListContainerRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			ForEach(view.content.children, id: \.id) { child in
-				EVYRow(row: child)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      ForEach(view.content.children, id: \.id) { child in
+        EVYRow(row: child)
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "3", "rows", "1"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "3", "rows", "1"])
+  }
 }

--- a/ios/evy/UI/Rows/Container/EVYSelectSegmentContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYSelectSegmentContainerRow.swift
@@ -8,39 +8,39 @@
 import SwiftUI
 
 struct EVYSelectSegmentContainerRow: View, EVYRowProtocol {
-	public static let JSONType = "SelectSegmentContainer"
+  public static let JSONType = "SelectSegmentContainer"
 
-	private let view: SelectSegmentContainerRowViewData
-	@State private var selected: Int = 0
+  private let view: SelectSegmentContainerRowViewData
+  @State private var selected: Int = 0
 
-	init(view: SelectSegmentContainerRowViewData) {
-		self.view = view
-	}
+  init(view: SelectSegmentContainerRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-			}
-			Picker("", selection: $selected) {
-				ForEach(Array(view.content.segments.enumerated()), id: \.offset) { index, segment in
-					Text(segment).tag(index)
-				}
-			}
-			.pickerStyle(.segmented)
-			.padding(.bottom, Constants.majorPadding)
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+      }
+      Picker("", selection: $selected) {
+        ForEach(Array(view.content.segments.enumerated()), id: \.offset) { index, segment in
+          Text(segment).tag(index)
+        }
+      }
+      .pickerStyle(.segmented)
+      .padding(.bottom, Constants.majorPadding)
 
-			if selected < view.content.children.count {
-				EVYRow(row: view.content.children[selected])
-			}
-		}
-	}
+      if selected < view.content.children.count {
+        EVYRow(row: view.content.children[selected])
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "2", "rows", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "2", "rows", "0"])
+  }
 }

--- a/ios/evy/UI/Rows/Container/EVYSheetContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYSheetContainerRow.swift
@@ -8,46 +8,46 @@
 import SwiftUI
 
 struct EVYSheetContainerRow: View, EVYRowProtocol {
-	public static let JSONType = "SheetContainer"
+  public static let JSONType = "SheetContainer"
 
-	private let view: SheetContainerRowViewData
-	@State private var showSheet: Bool = false
+  private let view: SheetContainerRowViewData
+  @State private var showSheet: Bool = false
 
-	init(view: SheetContainerRowViewData) {
-		self.view = view
-	}
+  init(view: SheetContainerRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-			}
-			if let child = view.content.child {
-				EVYRow(row: child)
-					.contentShape(Rectangle())
-					.onTapGesture { showSheet.toggle() }
-					.sheet(isPresented: $showSheet) {
-						VStack {
-							ForEach(view.content.children, id: \.id) { row in
-								EVYRow(row: row)
-							}
-						}
-						.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-						.background(Color.white.ignoresSafeArea())
-						.padding(.top, Constants.majorPadding)
-						.presentationDetents([.medium, .large])
-						.presentationDragIndicator(.visible)
-						.presentationBackground(.white)
-					}
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+      }
+      if let child = view.content.child {
+        EVYRow(row: child)
+          .contentShape(Rectangle())
+          .onTapGesture { showSheet.toggle() }
+          .sheet(isPresented: $showSheet) {
+            VStack {
+              ForEach(view.content.children, id: \.id) { row in
+                EVYRow(row: row)
+              }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .background(Color.white.ignoresSafeArea())
+            .padding(.top, Constants.majorPadding)
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+            .presentationBackground(.white)
+          }
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "6"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "6"])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
@@ -8,27 +8,30 @@
 import SwiftUI
 
 struct EVYCalendarRow: View, EVYRowProtocol {
-	public static let JSONType = "Calendar"
+  public static let JSONType = "Calendar"
 
-	private let view: CalendarRowViewData
+  private let view: CalendarRowViewData
 
-	init(view: CalendarRowViewData) {
-		self.view = view
-	}
+  init(view: CalendarRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		if view.content.title.count > 0 {
-			EVYTextView(view.content.title)
-				.padding(.vertical, Constants.padding)
-		}
-		EVYCalendar(primary: view.content.primary, secondary: view.content.secondary)
-	}
+  var body: some View {
+    if view.content.title.count > 0 {
+      EVYTextView(view.content.title)
+        .padding(.vertical, Constants.padding)
+    }
+    EVYCalendar(primary: view.content.primary, secondary: view.content.secondary)
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "2", "rows", "0", "view", "content", "children", "0", "view", "content", "children", "4"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow([
+      "2", "pages", "2", "rows", "0", "view", "content", "children", "0", "view", "content",
+      "children", "4",
+    ])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
@@ -8,41 +8,41 @@
 import SwiftUI
 
 struct EVYDropdownRow: View, EVYRowProtocol {
-	public static let JSONType = "Dropdown"
+  public static let JSONType = "Dropdown"
 
-	private let view: DropdownRowViewData
-	private let source: String
-	private let destination: String
+  private let view: DropdownRowViewData
+  private let source: String
+  private let destination: String
 
-	init(view: DropdownRowViewData, source: String, destination: String) {
-		self.view = view
-		self.source = source
-		self.destination = destination
-	}
+  init(view: DropdownRowViewData, source: String, destination: String) {
+    self.view = view
+    self.source = source
+    self.destination = destination
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			if !destination.isEmpty {
-				EVYDropdown(
-					title: view.content.title,
-					placeholder: view.content.placeholder,
-					data: source,
-					format: view.content.format,
-					destination: destination
-				)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      if !destination.isEmpty {
+        EVYDropdown(
+          title: view.content.title,
+          placeholder: view.content.placeholder,
+          data: source,
+          format: view.content.format,
+          destination: destination
+        )
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "3"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "3"])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
@@ -8,40 +8,43 @@
 import SwiftUI
 
 struct EVYInlinePickerRow: View, EVYRowProtocol {
-	public static let JSONType = "InlinePicker"
+  public static let JSONType = "InlinePicker"
 
-	private let view: InlinePickerRowViewData
-	private let source: String
-	private let destination: String
+  private let view: InlinePickerRowViewData
+  private let source: String
+  private let destination: String
 
-	init(view: InlinePickerRowViewData, source: String, destination: String) {
-		self.view = view
-		self.source = source
-		self.destination = destination
-	}
+  init(view: InlinePickerRowViewData, source: String, destination: String) {
+    self.view = view
+    self.source = source
+    self.destination = destination
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			if !destination.isEmpty {
-				EVYInlinePicker(
-					title: view.content.title,
-					data: source,
-					format: view.content.format,
-					destination: destination
-				)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      if !destination.isEmpty {
+        EVYInlinePicker(
+          title: view.content.title,
+          data: source,
+          format: view.content.format,
+          destination: destination
+        )
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "2", "rows", "0", "view", "content", "children", "1", "view", "content", "children", "3"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow([
+      "2", "pages", "2", "rows", "0", "view", "content", "children", "1", "view", "content",
+      "children", "3",
+    ])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYInputRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInputRow.swift
@@ -8,34 +8,34 @@
 import SwiftUI
 
 struct EVYInputRow: View, EVYRowProtocol {
-	public static let JSONType = "Input"
+  public static let JSONType = "Input"
 
-	private let view: InputRowViewData
-	private let destination: String
+  private let view: InputRowViewData
+  private let destination: String
 
-	init(view: InputRowViewData, destination: String) {
-		self.view = view
-		self.destination = destination
-	}
+  init(view: InputRowViewData, destination: String) {
+    self.view = view
+    self.destination = destination
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			EVYRowTitle(title: view.content.title)
-			if !destination.isEmpty {
-				EVYTextField(
-					input: view.content.value,
-					destination: destination,
-					placeholder: view.content.placeholder
-				)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      EVYRowTitle(title: view.content.title)
+      if !destination.isEmpty {
+        EVYTextField(
+          input: view.content.value,
+          destination: destination,
+          placeholder: view.content.placeholder
+        )
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "1"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "1"])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
@@ -8,41 +8,41 @@
 import SwiftUI
 
 struct EVYSearchRow: View, EVYRowProtocol {
-	public static let JSONType = "Search"
+  public static let JSONType = "Search"
 
-	private let view: SearchRowViewData
-	private let source: String
-	private let destination: String
-	@State private var showSheet = false
+  private let view: SearchRowViewData
+  private let source: String
+  private let destination: String
+  @State private var showSheet = false
 
-	init(view: SearchRowViewData, source: String, destination: String) {
-		self.view = view
-		self.source = source
-		self.destination = destination
-	}
+  init(view: SearchRowViewData, source: String, destination: String) {
+    self.view = view
+    self.source = source
+    self.destination = destination
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			if !destination.isEmpty {
-				EVYSearch(
-					source: source,
-					destination: destination,
-					placeholder: view.content.placeholder,
-					resultTemplate: view.content.child
-				)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      if !destination.isEmpty {
+        EVYSearch(
+          source: source,
+          destination: destination,
+          placeholder: view.content.placeholder,
+          resultTemplate: view.content.child
+        )
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "6", "view", "content", "children", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "6", "view", "content", "children", "0"])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
@@ -5,41 +5,41 @@
 //  Created by Clemence Chalot on 18/02/2024.
 //
 
-import SwiftUI
 import PhotosUI
+import SwiftUI
 
 struct EVYSelectPhotoRow: View, EVYRowProtocol {
-	public static let JSONType = "SelectPhoto"
+  public static let JSONType = "SelectPhoto"
 
-	private let view: SelectPhotoRowViewData
-	private let destination: String
+  private let view: SelectPhotoRowViewData
+  private let destination: String
 
-	init(view: SelectPhotoRowViewData, destination: String) {
-		self.view = view
-		self.destination = destination
-	}
+  init(view: SelectPhotoRowViewData, destination: String) {
+    self.view = view
+    self.destination = destination
+  }
 
-	var body: some View {
-		if !destination.isEmpty {
-			EVYSelectPhoto(
-				title: view.content.title,
-				subtitle: view.content.subtitle,
-				icon: view.content.icon,
-				content: view.content.content,
-				data: view.content.photos,
-				destination: destination
-			)
-		} else {
-			Text("Failed to load photo selector")
-				.foregroundColor(.red)
-		}
-	}
+  var body: some View {
+    if !destination.isEmpty {
+      EVYSelectPhoto(
+        title: view.content.title,
+        subtitle: view.content.subtitle,
+        icon: view.content.icon,
+        content: view.content.content,
+        data: view.content.photos,
+        destination: destination
+      )
+    } else {
+      Text("Failed to load photo selector")
+        .foregroundColor(.red)
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "0"])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
@@ -8,38 +8,38 @@
 import SwiftUI
 
 struct EVYTextAreaRow: View, EVYRowProtocol {
-	public static let JSONType = "TextArea"
+  public static let JSONType = "TextArea"
 
-	private let view: TextAreaRowViewData
-	private let destination: String
+  private let view: TextAreaRowViewData
+  private let destination: String
 
-	init(view: TextAreaRowViewData, destination: String) {
-		self.view = view
-		self.destination = destination
-	}
+  init(view: TextAreaRowViewData, destination: String) {
+    self.view = view
+    self.destination = destination
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			if !destination.isEmpty {
-				EVYTextField(
-					input: view.content.value,
-					destination: destination,
-					placeholder: view.content.placeholder,
-					multiLine: true
-				)
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      if !destination.isEmpty {
+        EVYTextField(
+          input: view.content.value,
+          destination: destination,
+          placeholder: view.content.placeholder,
+          multiLine: true
+        )
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "1", "rows", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "1", "rows", "0"])
+  }
 }

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -8,59 +8,64 @@
 import SwiftUI
 
 struct EVYTextSelectRow: View, EVYRowProtocol {
-	public static let JSONType = "TextSelect"
+  public static let JSONType = "TextSelect"
 
-	private let view: TextSelectRowViewData
-	private let destination: String
-	private let actions: [UI_RowAction]
-	private let value: EVYJson
-	private let selected: EVYState<Bool>
+  private let view: TextSelectRowViewData
+  private let destination: String
+  private let actions: [UI_RowAction]
+  private let value: EVYJson
+  private let selected: EVYState<Bool>
 
-	init?(view: TextSelectRowViewData, destination: String, actions: [UI_RowAction]) {
-		guard !destination.isEmpty else { return nil }
-		self.view = view
-		self.destination = destination
-		self.actions = actions
-		self.selected = EVYState(watch: destination, setter: {
-			do {
-				return try EVY.evaluateFromText($0)
-			} catch {
-				return false
-			}
-		})
-		let temporaryId = UUID().uuidString
-		let temporaryScopeId = EVYDraft.createMergeScopeId(flowId: "temporary", entityKey: temporaryId)
+  init?(view: TextSelectRowViewData, destination: String, actions: [UI_RowAction]) {
+    guard !destination.isEmpty else { return nil }
+    self.view = view
+    self.destination = destination
+    self.actions = actions
+    self.selected = EVYState(
+      watch: destination,
+      setter: {
+        do {
+          return try EVY.evaluateFromText($0)
+        } catch {
+          return false
+        }
+      })
+    let temporaryId = UUID().uuidString
+    let temporaryScopeId = EVYDraft.createMergeScopeId(flowId: "temporary", entityKey: temporaryId)
 
-		guard (try? EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)) != nil,
-		      let binding = try? EVY.data.draftBinding(fromParsedProps: temporaryId, scopeId: temporaryScopeId),
-		      let draft = EVY.data.draftIfPresent(binding: binding),
-		      let decoded = try? draft.decoded() else { return nil }
-		self.value = decoded
-	}
+    guard
+      (try? EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)) != nil,
+      let binding = try? EVY.data.draftBinding(
+        fromParsedProps: temporaryId, scopeId: temporaryScopeId),
+      let draft = EVY.data.draftIfPresent(binding: binding),
+      let decoded = try? draft.decoded()
+    else { return nil }
+    self.value = decoded
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			EVYSelectItem(
-				destination: destination,
-				value: value,
-				format: "",
-				selectionStyle: .multi,
-				target: .single_bool,
-				textStyle: .info
-			)
-			.frame(maxWidth: .infinity, alignment: .leading)
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      EVYSelectItem(
+        destination: destination,
+        value: value,
+        format: "",
+        selectionStyle: .multi,
+        target: .single_bool,
+        textStyle: .info
+      )
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "3", "rows", "1", "view", "content", "children", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "3", "rows", "1", "view", "content", "children", "0"])
+  }
 }

--- a/ios/evy/UI/Rows/View/EVYInfoRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInfoRow.swift
@@ -8,71 +8,76 @@
 import SwiftUI
 
 struct EVYInfoRow: View, EVYRowProtocol {
-	public static let JSONType = "Info"
+  public static let JSONType = "Info"
 
-	private static let leadingIconMinWidth: CGFloat = 32
+  private static let leadingIconMinWidth: CGFloat = 32
 
-	private let view: InfoRowViewData
+  private let view: InfoRowViewData
 
-	init(view: InfoRowViewData) {
-		self.view = view
-	}
+  init(view: InfoRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		let content = view.content
-		let hasTitle = !content.title.isEmpty
-		let hasSubtitle = !content.subtitle.isEmpty
-		let icon = content.icon.trimmingCharacters(in: .whitespacesAndNewlines)
-		let showIcon = !icon.isEmpty
+  var body: some View {
+    let content = view.content
+    let hasTitle = !content.title.isEmpty
+    let hasSubtitle = !content.subtitle.isEmpty
+    let icon = content.icon.trimmingCharacters(in: .whitespacesAndNewlines)
+    let showIcon = !icon.isEmpty
 
-		HStack(alignment: .top, spacing: Constants.minorPadding) {
-			if showIcon {
-				EVYTextView(icon, style: .body)
-					.frame(minWidth: Self.leadingIconMinWidth, alignment: .center)
-			}
-			infoTextColumn(content: content, hasTitle: hasTitle, hasSubtitle: hasSubtitle)
-		}
-		.infoRowOuterWidth(expands: !hasTitle)
-		.padding(Constants.minorPadding)
-	}
+    HStack(alignment: .top, spacing: Constants.minorPadding) {
+      if showIcon {
+        EVYTextView(icon, style: .body)
+          .frame(minWidth: Self.leadingIconMinWidth, alignment: .center)
+      }
+      infoTextColumn(content: content, hasTitle: hasTitle, hasSubtitle: hasSubtitle)
+    }
+    .infoRowOuterWidth(expands: !hasTitle)
+    .padding(Constants.minorPadding)
+  }
 
-	@ViewBuilder
-	private func infoTextColumn(content: InfoRowContent, hasTitle: Bool, hasSubtitle: Bool) -> some View {
-		VStack(alignment: hasTitle && hasSubtitle ? .leading : .center, spacing: 0) {
-			if hasTitle {
-				EVYTextView(content.title)
-					.frame(maxWidth: .infinity, alignment: .leading)
-					.lineLimit(1)
-					.truncationMode(.tail)
-			}
-			if hasSubtitle {
-				EVYTextView(content.subtitle, style: .info)
-					.frame(maxWidth: .infinity,
-						   alignment: hasTitle && hasSubtitle ? .leading : .center)
-					.lineLimit(3)
-					.truncationMode(.tail)
-			}
-		}
-		.frame(maxWidth: .infinity,
-			   alignment: hasTitle && hasSubtitle ? .leading : .center)
-	}
+  @ViewBuilder
+  private func infoTextColumn(content: InfoRowContent, hasTitle: Bool, hasSubtitle: Bool)
+    -> some View
+  {
+    VStack(alignment: hasTitle && hasSubtitle ? .leading : .center, spacing: 0) {
+      if hasTitle {
+        EVYTextView(content.title)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+      if hasSubtitle {
+        EVYTextView(content.subtitle, style: .info)
+          .frame(
+            maxWidth: .infinity,
+            alignment: hasTitle && hasSubtitle ? .leading : .center
+          )
+          .lineLimit(3)
+          .truncationMode(.tail)
+      }
+    }
+    .frame(
+      maxWidth: .infinity,
+      alignment: hasTitle && hasSubtitle ? .leading : .center)
+  }
 }
 
-private extension View {
-	@ViewBuilder
-	func infoRowOuterWidth(expands: Bool) -> some View {
-		if expands {
-			frame(maxWidth: .infinity)
-		} else {
-			self
-		}
-	}
+extension View {
+  @ViewBuilder
+  fileprivate func infoRowOuterWidth(expands: Bool) -> some View {
+    if expands {
+      frame(maxWidth: .infinity)
+    } else {
+      self
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "4", "rows", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "4", "rows", "0"])
+  }
 }

--- a/ios/evy/UI/Rows/View/EVYInputListRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInputListRow.swift
@@ -8,35 +8,35 @@
 import SwiftUI
 
 struct EVYInputListRow: View, EVYRowProtocol {
-	public static let JSONType = "InputList"
+  public static let JSONType = "InputList"
 
-	private let view: InputListRowViewData
-	private let source: String
+  private let view: InputListRowViewData
+  private let source: String
 
-	init(view: InputListRowViewData, source: String) {
-		self.view = view
-		self.source = source
-	}
+  init(view: InputListRowViewData, source: String) {
+    self.view = view
+    self.source = source
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			EVYInputList(
-				data: source,
-				format: view.content.format,
-				placeholder: view.content.placeholder
-			)
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      EVYInputList(
+        data: source,
+        format: view.content.format,
+        placeholder: view.content.placeholder
+      )
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["2", "pages", "0", "rows", "6", "view", "content", "child"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["2", "pages", "0", "rows", "6", "view", "content", "child"])
+  }
 }

--- a/ios/evy/UI/Rows/View/EVYTextRow.swift
+++ b/ios/evy/UI/Rows/View/EVYTextRow.swift
@@ -8,57 +8,57 @@
 import SwiftUI
 
 struct EVYTextRow: View, EVYRowProtocol {
-	public static let JSONType = "Text"
+  public static let JSONType = "Text"
 
-	private let view: TextRowViewData
-	@State private var showSheet = false
-	@State private var canBeExpanded: Bool = false
+  private let view: TextRowViewData
+  @State private var showSheet = false
+  @State private var canBeExpanded: Bool = false
 
-	init(view: TextRowViewData) {
-		self.view = view
-	}
+  init(view: TextRowViewData) {
+    self.view = view
+  }
 
-	var body: some View {
-		VStack(alignment: .leading) {
-			if view.content.title.count > 0 {
-				EVYTextView(view.content.title)
-					.padding(.vertical, Constants.padding)
-			}
-			EVYTextView(view.content.text)
-				.frame(maxWidth: .infinity, alignment: .leading)
-				.lineLimit(Int(view.max_lines.isEmpty ? "1" : view.max_lines) ?? 1)
-				.background {
-					ViewThatFits(in: .vertical) {
-						EVYTextView(view.content.text).hidden()
-						Color.clear.onAppear {
-							canBeExpanded = true
-						}
-					}
-				}
-				.sheet(isPresented: $showSheet) {
-					EVYTextView(view.content.text)
-						.frame(maxHeight: .infinity, alignment: .top)
-						.padding(.top, Constants.majorPadding)
-						.presentationDragIndicator(.visible)
-				}
-			if canBeExpanded {
-				EVYTextView("Read more", style: .action)
-					.padding(.vertical, Constants.padding)
-			}
-		}
-		.contentShape(Rectangle())
-		.onTapGesture {
-			if canBeExpanded {
-				showSheet.toggle()
-			}
-		}
-	}
+  var body: some View {
+    VStack(alignment: .leading) {
+      if view.content.title.count > 0 {
+        EVYTextView(view.content.title)
+          .padding(.vertical, Constants.padding)
+      }
+      EVYTextView(view.content.text)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .lineLimit(Int(view.max_lines.isEmpty ? "1" : view.max_lines) ?? 1)
+        .background {
+          ViewThatFits(in: .vertical) {
+            EVYTextView(view.content.text).hidden()
+            Color.clear.onAppear {
+              canBeExpanded = true
+            }
+          }
+        }
+        .sheet(isPresented: $showSheet) {
+          EVYTextView(view.content.text)
+            .frame(maxHeight: .infinity, alignment: .top)
+            .padding(.top, Constants.majorPadding)
+            .presentationDragIndicator(.visible)
+        }
+      if canBeExpanded {
+        EVYTextView("Read more", style: .action)
+          .padding(.vertical, Constants.padding)
+      }
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      if canBeExpanded {
+        showSheet.toggle()
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		EVYRow(row: asyncView)
-	} view: {
-		try! await EVY.getRow(["1", "pages", "0", "rows", "0"])
-	}
+  AsyncPreview { asyncView in
+    EVYRow(row: asyncView)
+  } view: {
+    try! await EVY.getRow(["1", "pages", "0", "rows", "0"])
+  }
 }

--- a/ios/evy/UI/Views/EVYButton.swift
+++ b/ios/evy/UI/Views/EVYButton.swift
@@ -8,31 +8,33 @@
 import SwiftUI
 
 struct EVYButton: View {
-	@Environment(\.colorScheme) var colorScheme
-	
-    let label: String
-    let action: () -> Void
-    
-    init(label: String, action: @escaping () -> Void) {
-        self.label = label
-        self.action = action
+  @Environment(\.colorScheme) var colorScheme
+
+  let label: String
+  let action: () -> Void
+
+  init(label: String, action: @escaping () -> Void) {
+    self.label = label
+    self.action = action
+  }
+
+  var body: some View {
+    Button(action: action) {
+      EVYTextView(label, style: .button).frame(maxWidth: .infinity)
     }
-    
-    var body: some View {
-        Button(action: action) {
-			EVYTextView(label, style: .button).frame(maxWidth: .infinity)
-        }
-		.buttonStyle(.plain)
-        .padding(Constants.majorPadding)
-        .frame(maxWidth: 150)
-		.background(colorScheme == .light ? Constants.buttonColor : .white)
-        .cornerRadius(Constants.smallCornerRadius)
-        .accessibilityIdentifier("button_\(label)")
-    }
+    .buttonStyle(.plain)
+    .padding(Constants.majorPadding)
+    .frame(maxWidth: 150)
+    .background(colorScheme == .light ? Constants.buttonColor : .white)
+    .cornerRadius(Constants.smallCornerRadius)
+    .accessibilityIdentifier("button_\(label)")
+  }
 }
 
 #Preview {
-	EVYButton(label: "Button", action: {
-		print("clicked button")
-	})
+  EVYButton(
+    label: "Button",
+    action: {
+      print("clicked button")
+    })
 }

--- a/ios/evy/UI/Views/EVYCalendar.swift
+++ b/ios/evy/UI/Views/EVYCalendar.swift
@@ -14,365 +14,376 @@ private let animationDuration: CGFloat = 0.1
 
 private let falseAsData = "false".data(using: .utf8)!
 private let trueAsData = "true".data(using: .utf8)!
-/**
- * Calendar operations system
- */
+/// Calendar operations system
 enum EVYCalendarOperation {
-    case select(index: Int)
-    case unselect(index: Int)
-    case unselectRow(y: Int)
-    case selectRow(y: Int)
-    case unselectColumn(x: Int)
-    case selectColumn(x: Int)
+  case select(index: Int)
+  case unselect(index: Int)
+  case unselectRow(y: Int)
+  case selectRow(y: Int)
+  case unselectColumn(x: Int)
+  case selectColumn(x: Int)
 }
 
 struct EVYCalendarOperationKey: EnvironmentKey {
-    static let defaultValue: (EVYCalendarOperation) -> Void = { _ in }
+  static let defaultValue: (EVYCalendarOperation) -> Void = { _ in }
 }
 
 extension EnvironmentValues {
-    var operate: (EVYCalendarOperation) -> Void {
-        get { self[EVYCalendarOperationKey.self] }
-        set { self[EVYCalendarOperationKey.self] = newValue }
-    }
+  var operate: (EVYCalendarOperation) -> Void {
+    get { self[EVYCalendarOperationKey.self] }
+    set { self[EVYCalendarOperationKey.self] = newValue }
+  }
 }
 
-/**
- * Main views
- */
+/// Main views
 struct EVYCalendarTimeslots: View {
-    @Environment(\.operate) private var operate
-	@Environment(\.colorScheme) var colorScheme
-    
-    let rows: Int
-    let columns: Int
-    
-    let primaryTimeslotsData: [EVYCalendarTimeslotData]
-    let secondaryTimeslotsData: [EVYCalendarTimeslotData]
-    
-    var body: some View {
-		let actionColor = colorScheme == .light ? Constants.actionColor : .white
-        HStack(spacing: .zero) {
-            ForEach(0..<columns, id: \.self) { x in
-                VStack(alignment: .leading, spacing: .zero) {
-                    ForEach(0..<rows, id: \.self) { y in
-                        let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: rows)
-						let fill: Color = primaryTimeslotsData[relevantIndex].selected ?
-							actionColor :
-                                (secondaryTimeslotsData[relevantIndex].selected ?
-                                 Constants.inactiveBackground :
-                                    Constants.tappableClearColor
-                        )
-                        Rectangle()
-                            .fill(fill)
-                            .frame(height: rowHeight)
-                            .frame(width: columnWidth)
-                            .onTapGesture(perform: {
-                                if primaryTimeslotsData[relevantIndex].selected {
-                                    operate(EVYCalendarOperation.unselect(index: relevantIndex))
-                                } else {
-                                    operate(EVYCalendarOperation.select(index: relevantIndex))
-                                }
-                            })
-                    }
-                }.overlay(
-                    Divider()
-                        .opacity(Constants.borderOpacity)
-                        .frame(maxWidth: Constants.thinBorderWidth, maxHeight: .infinity)
-                        .background(Constants.inactiveBackground), alignment: .leading
-                )
-            }
-        }
+  @Environment(\.operate) private var operate
+  @Environment(\.colorScheme) var colorScheme
+
+  let rows: Int
+  let columns: Int
+
+  let primaryTimeslotsData: [EVYCalendarTimeslotData]
+  let secondaryTimeslotsData: [EVYCalendarTimeslotData]
+
+  var body: some View {
+    let actionColor = colorScheme == .light ? Constants.actionColor : .white
+    HStack(spacing: .zero) {
+      ForEach(0..<columns, id: \.self) { x in
+        VStack(alignment: .leading, spacing: .zero) {
+          ForEach(0..<rows, id: \.self) { y in
+            let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: rows)
+            let fill: Color =
+              primaryTimeslotsData[relevantIndex].selected
+              ? actionColor
+              : (secondaryTimeslotsData[relevantIndex].selected
+                ? Constants.inactiveBackground : Constants.tappableClearColor)
+            Rectangle()
+              .fill(fill)
+              .frame(height: rowHeight)
+              .frame(width: columnWidth)
+              .onTapGesture(perform: {
+                if primaryTimeslotsData[relevantIndex].selected {
+                  operate(EVYCalendarOperation.unselect(index: relevantIndex))
+                } else {
+                  operate(EVYCalendarOperation.select(index: relevantIndex))
+                }
+              })
+          }
+        }.overlay(
+          Divider()
+            .opacity(Constants.borderOpacity)
+            .frame(maxWidth: Constants.thinBorderWidth, maxHeight: .infinity)
+            .background(Constants.inactiveBackground), alignment: .leading
+        )
+      }
     }
+  }
 }
 
 struct EVYCalendarLabel {
-    let value: String
-    var full: Bool
+  let value: String
+  var full: Bool
 }
 
 struct EVYAxisLabel: View {
-    let label: String
-    @State var full: Bool
-    let action: (_ full: Bool) -> Void
-    
-    var body: some View {
-        Button(action: {
-            action(full)
-            full.toggle()
-        }, label: {
-            let label = label.count > 0 ? label : "-"
-            EVYTextView(label, style: full ? .action : .info)
-        })
-        .frame(height: rowHeight)
-        .frame(width: columnWidth)
-    }
+  let label: String
+  @State var full: Bool
+  let action: (_ full: Bool) -> Void
+
+  var body: some View {
+    Button(
+      action: {
+        action(full)
+        full.toggle()
+      },
+      label: {
+        let label = label.count > 0 ? label : "-"
+        EVYTextView(label, style: full ? .action : .info)
+      }
+    )
+    .frame(height: rowHeight)
+    .frame(width: columnWidth)
+  }
 }
 
 enum EVYAxisType {
-    case x
-    case y
+  case x
+  case y
 }
 struct EVYCalendarAxisView: View {
-    @Environment(\.operate) private var operate
-    let type: EVYAxisType
-    let labels: [EVYCalendarLabel]
-    @Binding var offset: CGPoint
-    
-    var body: some View {
-        switch type {
-        case .x:
-            ScrollView([.horizontal]) {
-                HStack(spacing: .zero) {
-                    ForEach(labels.indices, id: \.self)  { x in
-                        EVYAxisLabel(label: labels[x].value,
-                                     full: labels[x].full,
-                                     action: { full in
-                            if full {
-                                operate(EVYCalendarOperation.unselectColumn(x: x))
-                            } else {
-                                operate(EVYCalendarOperation.selectColumn(x: x))
-                            }
-                        })
-                    }
-                }.offset(x: offset.x)
-            }.scrollDisabled(true)
-        case .y:
-            VStack(spacing: .zero) {
-                // empty corner
-                Color.clear.frame(width: .zero, height: rowHeight-spaceForFirstLabel)
-                ScrollView([.vertical]) {
-                    // Offset based on scroll position but also add to center correctly
-                    VStack(spacing: .zero) {
-                        ForEach(labels.indices, id: \.self)  { y in
-                            EVYAxisLabel(label: labels[y].value,
-                                         full: labels[y].full,
-                                         action: { full in
-                                if full {
-                                    operate(EVYCalendarOperation.unselectRow(y: y))
-                                } else {
-                                    operate(EVYCalendarOperation.selectRow(y: y))
-                                }
-                            })
-                        }
-                    }.offset(y: offset.y-spaceForFirstLabel)
-                }.scrollDisabled(true)
+  @Environment(\.operate) private var operate
+  let type: EVYAxisType
+  let labels: [EVYCalendarLabel]
+  @Binding var offset: CGPoint
+
+  var body: some View {
+    switch type {
+    case .x:
+      ScrollView([.horizontal]) {
+        HStack(spacing: .zero) {
+          ForEach(labels.indices, id: \.self) { x in
+            EVYAxisLabel(
+              label: labels[x].value,
+              full: labels[x].full,
+              action: { full in
+                if full {
+                  operate(EVYCalendarOperation.unselectColumn(x: x))
+                } else {
+                  operate(EVYCalendarOperation.selectColumn(x: x))
+                }
+              })
+          }
+        }.offset(x: offset.x)
+      }.scrollDisabled(true)
+    case .y:
+      VStack(spacing: .zero) {
+        // empty corner
+        Color.clear.frame(width: .zero, height: rowHeight - spaceForFirstLabel)
+        ScrollView([.vertical]) {
+          // Offset based on scroll position but also add to center correctly
+          VStack(spacing: .zero) {
+            ForEach(labels.indices, id: \.self) { y in
+              EVYAxisLabel(
+                label: labels[y].value,
+                full: labels[y].full,
+                action: { full in
+                  if full {
+                    operate(EVYCalendarOperation.unselectRow(y: y))
+                  } else {
+                    operate(EVYCalendarOperation.selectRow(y: y))
+                  }
+                })
             }
-        }
+          }.offset(y: offset.y - spaceForFirstLabel)
+        }.scrollDisabled(true)
+      }
     }
+  }
 }
 
 struct ViewOffsetKey: PreferenceKey {
-    static var defaultValue: CGPoint { CGPoint.zero }
-    static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {
-        value.x += nextValue().x
-        value.y += nextValue().y
-    }
+  static var defaultValue: CGPoint { CGPoint.zero }
+  static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {
+    value.x += nextValue().x
+    value.y += nextValue().y
+  }
 }
 
 struct EVYCalendar: View {
-    private let primarySource: String
-    private let secondarySource: String
-    
-    @State private var yLabels: [EVYCalendarLabel]
-    @State private var xLabels: [EVYCalendarLabel]
-    @State private var scrollOffset = CGPoint.zero
-    @State private var calendarTimeslots: EVYCalendarTimeslots
-    
-    init(primary: String, secondary: String) {
-        primarySource = primary
-        secondarySource = secondary
+  private let primarySource: String
+  private let secondarySource: String
 
-        let (xl, yl, timeslots) = Self.buildCalendarData(
-            primarySource: primary,
-            secondarySource: secondary
-        )
-        _xLabels = State(initialValue: xl)
-        _yLabels = State(initialValue: yl)
-        _calendarTimeslots = State(initialValue: timeslots)
-    }
-    
-    private static func buildCalendarData(
-        primarySource: String,
-        secondarySource: String
-    ) -> ([EVYCalendarLabel], [EVYCalendarLabel], EVYCalendarTimeslots) {
-        let primaryTimeslotsData = getTimeslotsData(primarySource)
-        let secondaryTimeslotsData = getTimeslotsData(secondarySource)
-        
-        var xLabels = primaryTimeslotsData
-            .filter { $0.y == 0 }
-            .map {
-                EVYCalendarLabel(value: String($0.header),
-                                 full: false)
-            }
-        var yLabels = primaryTimeslotsData
-            .filter { $0.x == 0 }
-            .map {
-                EVYCalendarLabel(value: String($0.start_label),
-                                 full: false)
-            }
-        
-        for x in 0..<xLabels.count {
-            let selectedInColumn = primaryTimeslotsData
-                .filter { $0.x == x && $0.selected }
-            guard selectedInColumn.count == yLabels.count else {
-                continue
-            }
-            xLabels[x].full = true
-        }
-        for y in 0..<yLabels.count {
-            let selectedInColumn = primaryTimeslotsData
-                .filter { $0.y == y && $0.selected }
-            guard selectedInColumn.count == xLabels.count else {
-                continue
-            }
-            yLabels[y].full = true
-        }
-        
-        if !primaryTimeslotsData.isEmpty {
-            yLabels.append(
-                EVYCalendarLabel(value: primaryTimeslotsData.last!.end_label,
-                                 full: false)
-            )
-        }
-        
-        let timeslots = EVYCalendarTimeslots(
-            rows: max(yLabels.count - 1, 0),
-            columns: xLabels.count,
-            primaryTimeslotsData: primaryTimeslotsData,
-            secondaryTimeslotsData: secondaryTimeslotsData
-        )
-        
-        return (xLabels, yLabels, timeslots)
-    }
-    
-    private func reloadData(animated: Bool = false) {
-        let (xl, yl, timeslots) = Self.buildCalendarData(
-            primarySource: primarySource,
-            secondarySource: secondarySource
-        )
-        if animated {
-            withAnimation(.linear(duration: animationDuration)) {
-                xLabels = xl
-                yLabels = yl
-                calendarTimeslots = timeslots
-            }
-        } else {
-            xLabels = xl
-            yLabels = yl
-            calendarTimeslots = timeslots
-        }
-    }
-    
-    private func handleOperation(_ operation: EVYCalendarOperation) {
-        let sourceProps = EVY.parsePropsFromText(primarySource)
-        switch operation {
-        case let .select(index):
-            let props = "{\(sourceProps)[\(index)].selected}"
-            try! EVY.updateData(trueAsData, at: props)
+  @State private var yLabels: [EVYCalendarLabel]
+  @State private var xLabels: [EVYCalendarLabel]
+  @State private var scrollOffset = CGPoint.zero
+  @State private var calendarTimeslots: EVYCalendarTimeslots
 
-        case let .unselect(index):
-            let props = "{\(sourceProps)[\(index)].selected}"
-            try! EVY.updateData(falseAsData, at: props)
+  init(primary: String, secondary: String) {
+    primarySource = primary
+    secondarySource = secondary
 
-        case let .selectRow(y):
-            for x in 0..<xLabels.count {
-                let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count-1)
-                let props = "{\(sourceProps)[\(relevantIndex)].selected}"
-                try! EVY.updateData(trueAsData, at: props)
-            }
-        case let .unselectRow(y):
-            for x in 0..<xLabels.count {
-                let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count-1)
-                let props = "{\(sourceProps)[\(relevantIndex)].selected}"
-                try! EVY.updateData(falseAsData, at: props)
-            }
-            
-        case let .selectColumn(x):
-            for y in 0..<yLabels.count-1 {
-                let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count-1)
-                let props = "{\(sourceProps)[\(relevantIndex)].selected}"
-                try! EVY.updateData(trueAsData, at: props)
-            }
-            
-        case let .unselectColumn(x):
-            for y in 0..<yLabels.count-1 {
-                let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count-1)
-                let props = "{\(sourceProps)[\(relevantIndex)].selected}"
-                try! EVY.updateData(falseAsData, at: props)
-            }
-        }
-        
-        reloadData(animated: true)
+    let (xl, yl, timeslots) = Self.buildCalendarData(
+      primarySource: primary,
+      secondarySource: secondary
+    )
+    _xLabels = State(initialValue: xl)
+    _yLabels = State(initialValue: yl)
+    _calendarTimeslots = State(initialValue: timeslots)
+  }
+
+  private static func buildCalendarData(
+    primarySource: String,
+    secondarySource: String
+  ) -> ([EVYCalendarLabel], [EVYCalendarLabel], EVYCalendarTimeslots) {
+    let primaryTimeslotsData = getTimeslotsData(primarySource)
+    let secondaryTimeslotsData = getTimeslotsData(secondarySource)
+
+    var xLabels =
+      primaryTimeslotsData
+      .filter { $0.y == 0 }
+      .map {
+        EVYCalendarLabel(
+          value: String($0.header),
+          full: false)
+      }
+    var yLabels =
+      primaryTimeslotsData
+      .filter { $0.x == 0 }
+      .map {
+        EVYCalendarLabel(
+          value: String($0.start_label),
+          full: false)
+      }
+
+    for x in 0..<xLabels.count {
+      let selectedInColumn =
+        primaryTimeslotsData
+        .filter { $0.x == x && $0.selected }
+      guard selectedInColumn.count == yLabels.count else {
+        continue
+      }
+      xLabels[x].full = true
     }
-    
-    var body: some View {
-        HStack(spacing: .zero) {
-            EVYCalendarAxisView(type: .y, labels: yLabels, offset: $scrollOffset)
-            VStack(spacing: .zero) {
-                EVYCalendarAxisView(type: .x, labels: xLabels, offset: $scrollOffset)
-                ScrollViewReader { _ in
-                    ScrollView([.vertical, .horizontal]) {
-                        calendarTimeslots
-                            .background( GeometryReader { geo in
-                                Color.clear
-                                    .preference(key: ViewOffsetKey.self,
-                                                value: geo.frame(in: .named("scroll")).origin)
-                            })
-                            .onPreferenceChange(ViewOffsetKey.self) { value in
-                                scrollOffset = value
-                            }
-                    }.scrollIndicators(.hidden)
-                }.coordinateSpace(name: "scroll")
-            }
-        }
-        .environment(\.operate) { calendarOperation in
-            handleOperation(calendarOperation)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .evyDataUpdated)) { _ in
-            reloadData()
-        }
+    for y in 0..<yLabels.count {
+      let selectedInColumn =
+        primaryTimeslotsData
+        .filter { $0.y == y && $0.selected }
+      guard selectedInColumn.count == xLabels.count else {
+        continue
+      }
+      yLabels[y].full = true
     }
+
+    if !primaryTimeslotsData.isEmpty {
+      yLabels.append(
+        EVYCalendarLabel(
+          value: primaryTimeslotsData.last!.end_label,
+          full: false)
+      )
+    }
+
+    let timeslots = EVYCalendarTimeslots(
+      rows: max(yLabels.count - 1, 0),
+      columns: xLabels.count,
+      primaryTimeslotsData: primaryTimeslotsData,
+      secondaryTimeslotsData: secondaryTimeslotsData
+    )
+
+    return (xLabels, yLabels, timeslots)
+  }
+
+  private func reloadData(animated: Bool = false) {
+    let (xl, yl, timeslots) = Self.buildCalendarData(
+      primarySource: primarySource,
+      secondarySource: secondarySource
+    )
+    if animated {
+      withAnimation(.linear(duration: animationDuration)) {
+        xLabels = xl
+        yLabels = yl
+        calendarTimeslots = timeslots
+      }
+    } else {
+      xLabels = xl
+      yLabels = yl
+      calendarTimeslots = timeslots
+    }
+  }
+
+  private func handleOperation(_ operation: EVYCalendarOperation) {
+    let sourceProps = EVY.parsePropsFromText(primarySource)
+    switch operation {
+    case .select(let index):
+      let props = "{\(sourceProps)[\(index)].selected}"
+      try! EVY.updateData(trueAsData, at: props)
+
+    case .unselect(let index):
+      let props = "{\(sourceProps)[\(index)].selected}"
+      try! EVY.updateData(falseAsData, at: props)
+
+    case .selectRow(let y):
+      for x in 0..<xLabels.count {
+        let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count - 1)
+        let props = "{\(sourceProps)[\(relevantIndex)].selected}"
+        try! EVY.updateData(trueAsData, at: props)
+      }
+    case .unselectRow(let y):
+      for x in 0..<xLabels.count {
+        let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count - 1)
+        let props = "{\(sourceProps)[\(relevantIndex)].selected}"
+        try! EVY.updateData(falseAsData, at: props)
+      }
+
+    case .selectColumn(let x):
+      for y in 0..<yLabels.count - 1 {
+        let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count - 1)
+        let props = "{\(sourceProps)[\(relevantIndex)].selected}"
+        try! EVY.updateData(trueAsData, at: props)
+      }
+
+    case .unselectColumn(let x):
+      for y in 0..<yLabels.count - 1 {
+        let relevantIndex = calculateIndex(x: x, y: y, numberOfRows: yLabels.count - 1)
+        let props = "{\(sourceProps)[\(relevantIndex)].selected}"
+        try! EVY.updateData(falseAsData, at: props)
+      }
+    }
+
+    reloadData(animated: true)
+  }
+
+  var body: some View {
+    HStack(spacing: .zero) {
+      EVYCalendarAxisView(type: .y, labels: yLabels, offset: $scrollOffset)
+      VStack(spacing: .zero) {
+        EVYCalendarAxisView(type: .x, labels: xLabels, offset: $scrollOffset)
+        ScrollViewReader { _ in
+          ScrollView([.vertical, .horizontal]) {
+            calendarTimeslots
+              .background(
+                GeometryReader { geo in
+                  Color.clear
+                    .preference(
+                      key: ViewOffsetKey.self,
+                      value: geo.frame(in: .named("scroll")).origin)
+                }
+              )
+              .onPreferenceChange(ViewOffsetKey.self) { value in
+                scrollOffset = value
+              }
+          }.scrollIndicators(.hidden)
+        }.coordinateSpace(name: "scroll")
+      }
+    }
+    .environment(\.operate) { calendarOperation in
+      handleOperation(calendarOperation)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .evyDataUpdated)) { _ in
+      reloadData()
+    }
+  }
 }
 
 private func calculateIndex(x: Int, y: Int, numberOfRows: Int) -> Int {
-    y+(x*(numberOfRows))
+  y + (x * (numberOfRows))
 }
 
 @MainActor
 private func getTimeslotsData(_ source: String) -> [EVYCalendarTimeslotData] {
-    do {
-        let timeslotsJSON = try EVY.getDataFromText(source)
-        return try JSONDecoder().decode(
-            [EVYCalendarTimeslotData].self,
-            from: timeslotsJSON.toString().data(using: .utf8)!
-        )
-    } catch {
-        return []
-    }
+  do {
+    let timeslotsJSON = try EVY.getDataFromText(source)
+    return try JSONDecoder().decode(
+      [EVYCalendarTimeslotData].self,
+      from: timeslotsJSON.toString().data(using: .utf8)!
+    )
+  } catch {
+    return []
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
 
-		let timeslotsData = (try? EVY.data.getForBinding(key: "timeslots"))?.data
-        let previewScopeId = EVYDraft.createMergeScopeId(flowId: "preview", entityKey: "timeslots")
-        EVY.data.activeDraftScopeId = previewScopeId
-		EVY.ensureDraftExists(
-            variableName: "pickup_timeslots",
-            initialData: timeslotsData,
-            scopeId: previewScopeId
-        )
-		EVY.ensureDraftExists(
-            variableName: "delivery_timeslots",
-            initialData: timeslotsData,
-            scopeId: previewScopeId
-        )
+    let timeslotsData = (try? EVY.data.getForBinding(key: "timeslots"))?.data
+    let previewScopeId = EVYDraft.createMergeScopeId(flowId: "preview", entityKey: "timeslots")
+    EVY.data.activeDraftScopeId = previewScopeId
+    EVY.ensureDraftExists(
+      variableName: "pickup_timeslots",
+      initialData: timeslotsData,
+      scopeId: previewScopeId
+    )
+    EVY.ensureDraftExists(
+      variableName: "delivery_timeslots",
+      initialData: timeslotsData,
+      scopeId: previewScopeId
+    )
 
-		return EVYCalendar(primary: "{pickup_timeslots}",
-					   secondary: "{delivery_timeslots}")
-	}
+    return EVYCalendar(
+      primary: "{pickup_timeslots}",
+      secondary: "{delivery_timeslots}")
+  }
 }

--- a/ios/evy/UI/Views/EVYCarouselOverlay.swift
+++ b/ios/evy/UI/Views/EVYCarouselOverlay.swift
@@ -8,57 +8,61 @@
 import SwiftUI
 
 struct EVYCarouselOverlay: View {
-    @Environment(\.dismiss) var dismiss
-    
-    let imageNames: [String]
-    private var topPadding: CGFloat
-    @State private var selectedIndex: Int = 0
-    
-    init(imageNames: [String], selectedIndex: Int) {
-        self.imageNames = imageNames
-        topPadding = Constants.majorPadding*2
-        
-        if UIDevice.current.hasDynamicIsland {
-            topPadding *= 2
-        }
-        
-        _selectedIndex = State(initialValue: selectedIndex)
+  @Environment(\.dismiss) var dismiss
+
+  let imageNames: [String]
+  private var topPadding: CGFloat
+  @State private var selectedIndex: Int = 0
+
+  init(imageNames: [String], selectedIndex: Int) {
+    self.imageNames = imageNames
+    topPadding = Constants.majorPadding * 2
+
+    if UIDevice.current.hasDynamicIsland {
+      topPadding *= 2
     }
-    
-    var body: some View {
-        TabView(selection: $selectedIndex) {
-            ForEach(0..<imageNames.count, id: \.self) { index in
-                EVYZoomableContainer{
-                    Image("\(imageNames[index])")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                }.background(Color.black)
-            }
-        }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-        .overlay {
-            VStack {
-                Button(action: { dismiss() }) {
-                    Label("", systemImage: "xmark")
-                        .foregroundColor(.white)
-                        .font(.evyButton)
-                }
-                .padding(EdgeInsets(top: topPadding,
-                                    leading: Constants.majorPadding,
-                                    bottom: 0,
-                                    trailing: 0))
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                
-                EVYCarouselIndicator(indices: (0...imageNames.count-1),
-                                     selectionIndex: selectedIndex,
-                                     color: .white)
-            }
-        }
-        .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-        .ignoresSafeArea()
+
+    _selectedIndex = State(initialValue: selectedIndex)
+  }
+
+  var body: some View {
+    TabView(selection: $selectedIndex) {
+      ForEach(0..<imageNames.count, id: \.self) { index in
+        EVYZoomableContainer {
+          Image("\(imageNames[index])")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+        }.background(Color.black)
+      }
     }
+    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+    .overlay {
+      VStack {
+        Button(action: { dismiss() }) {
+          Label("", systemImage: "xmark")
+            .foregroundColor(.white)
+            .font(.evyButton)
+        }
+        .padding(
+          EdgeInsets(
+            top: topPadding,
+            leading: Constants.majorPadding,
+            bottom: 0,
+            trailing: 0)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+        EVYCarouselIndicator(
+          indices: (0...imageNames.count - 1),
+          selectionIndex: selectedIndex,
+          color: .white)
+      }
+    }
+    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+    .ignoresSafeArea()
+  }
 }
 
 #Preview {
-    EVYCarouselOverlay(imageNames: ["printer", "printer"], selectedIndex: 0)
+  EVYCarouselOverlay(imageNames: ["printer", "printer"], selectedIndex: 0)
 }

--- a/ios/evy/UI/Views/EVYDropdown.swift
+++ b/ios/evy/UI/Views/EVYDropdown.swift
@@ -8,106 +8,118 @@
 import SwiftUI
 
 struct EVYDropdown: View {
-    let title: String
-    let destination: String
-    let format: String
-    let placeholder: String
+  let title: String
+  let destination: String
+  let format: String
+  let placeholder: String
 
-    private var options: [EVYJson] = []
-    private var selection: EVYState<String>
-    @State private var showSheet = false
+  private var options: [EVYJson] = []
+  private var selection: EVYState<String>
+  @State private var showSheet = false
 
-    init(title: String = "",
-         placeholder: String = "",
-         data: String,
-         format: String,
-         destination: String)
-    {
-        self.title = title
-        self.destination = destination
-        self.format = format
-        self.placeholder = placeholder
+  init(
+    title: String = "",
+    placeholder: String = "",
+    data: String,
+    format: String,
+    destination: String
+  ) {
+    self.title = title
+    self.destination = destination
+    self.format = format
+    self.placeholder = placeholder
 
-        var loadedOptions: [EVYJson] = []
+    var loadedOptions: [EVYJson] = []
 
+    do {
+      let data = try EVY.getDataFromText(data)
+      if case .array(let arrayValue) = data {
+        loadedOptions = arrayValue
+      }
+    } catch {
+    }
+    options = loadedOptions
+
+    selection = EVYState(
+      watch: destination,
+      setter: {
         do {
-            let data = try EVY.getDataFromText(data)
-            if case let .array(arrayValue) = data {
-                loadedOptions = arrayValue
+          let value = try EVY.getDataFromText($0)
+          if case .string(let identifier) = value {
+            if identifier.isEmpty { return "" }
+            if let matchingOption = loadedOptions.first(where: {
+              $0.identifierValue() == identifier
+            }) {
+              return try EVY.formatDataOrToString(json: matchingOption, format: format)
             }
+          }
+          return try EVY.formatDataOrToString(json: value, format: format)
         } catch {
+          return ""
         }
-        options = loadedOptions
+      })
+  }
 
-        selection = EVYState(watch: destination, setter: {
-            do {
-                let value = try EVY.getDataFromText($0)
-                if case let .string(identifier) = value {
-                    if identifier.isEmpty { return "" }
-                    if let matchingOption = loadedOptions.first(where: { $0.identifierValue() == identifier }) {
-                        return try EVY.formatDataOrToString(json: matchingOption, format: format)
-                    }
-                }
-                return try EVY.formatDataOrToString(json: value, format: format)
-            } catch {
-                return ""
-            }
-        })
-    }
-
-    var body: some View {
-        HStack {
-            Button(action: { showSheet.toggle() }) {
-                if selection.value.count > 0 {
-                    EVYTextView(selection.value)
-                } else {
-					EVYTextView(placeholder, style: .info)
-                }
-            }
-            Spacer()
-            EVYTextView("::chevron-down::")
+  var body: some View {
+    HStack {
+      Button(action: { showSheet.toggle() }) {
+        if selection.value.count > 0 {
+          EVYTextView(selection.value)
+        } else {
+          EVYTextView(placeholder, style: .info)
         }
-		.buttonStyle(.plain)
-        .padding(EdgeInsets(top: Constants.fieldPadding,
-                            leading: Constants.minorPadding,
-                            bottom: Constants.fieldPadding,
-                            trailing: Constants.minorPadding))
-        .background(
-            RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
-                .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
-                .opacity(Constants.borderOpacity)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { showSheet.toggle() }
-        .sheet(isPresented: $showSheet, content: {
-            VStack {
-                if title.count > 0 {
-                    EVYTextView(title).padding(.top, Constants.majorPadding)
-                }
-                EVYSelectList(options: options,
-                              format: format,
-                              destination: destination)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .background(Color.white.ignoresSafeArea())
-            .presentationDetents([.medium, .large])
-            .presentationDragIndicator(.visible)
-            .presentationBackground(.white)
-        })
+      }
+      Spacer()
+      EVYTextView("::chevron-down::")
     }
+    .buttonStyle(.plain)
+    .padding(
+      EdgeInsets(
+        top: Constants.fieldPadding,
+        leading: Constants.minorPadding,
+        bottom: Constants.fieldPadding,
+        trailing: Constants.minorPadding)
+    )
+    .background(
+      RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
+        .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
+        .opacity(Constants.borderOpacity)
+    )
+    .contentShape(Rectangle())
+    .onTapGesture { showSheet.toggle() }
+    .sheet(
+      isPresented: $showSheet,
+      content: {
+        VStack {
+          if title.count > 0 {
+            EVYTextView(title).padding(.top, Constants.majorPadding)
+          }
+          EVYSelectList(
+            options: options,
+            format: format,
+            destination: destination)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.white.ignoresSafeArea())
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(.white)
+      })
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! EVY.getUserData()
-		try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! EVY.getUserData()
+    try! await EVY.createItem()
 
-		return EVYDropdown(title: "Dropdown",
-						   placeholder: "A placeholder",
-						   data: "{conditions}",
-						   format: "{$datum:value}",
-						   destination: "{condition}")
-	}
+    return EVYDropdown(
+      title: "Dropdown",
+      placeholder: "A placeholder",
+      data: "{conditions}",
+      format: "{$datum:value}",
+      destination: "{condition}")
+  }
 }

--- a/ios/evy/UI/Views/EVYImageOverlay.swift
+++ b/ios/evy/UI/Views/EVYImageOverlay.swift
@@ -8,28 +8,28 @@
 import SwiftUI
 
 struct EVYImageOverlay: View {
-    @Environment(\.dismiss) var dismiss
-    
-    let imageName: String
-    
-    var body: some View {
-        ZStack {
-            EVYZoomableContainer{
-                Image(imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            }.background(Color.black)
-            Button(action: { dismiss() }) {
-                Label("", systemImage: "xmark")
-                    .font(.evyButton)
-            }
-			.buttonStyle(.plain)
-            .padding(Constants.majorPadding)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        }
+  @Environment(\.dismiss) var dismiss
+
+  let imageName: String
+
+  var body: some View {
+    ZStack {
+      EVYZoomableContainer {
+        Image(imageName)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+      }.background(Color.black)
+      Button(action: { dismiss() }) {
+        Label("", systemImage: "xmark")
+          .font(.evyButton)
+      }
+      .buttonStyle(.plain)
+      .padding(Constants.majorPadding)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
+  }
 }
 
 #Preview {
-    EVYImageOverlay(imageName: "printer")
+  EVYImageOverlay(imageName: "printer")
 }

--- a/ios/evy/UI/Views/EVYInlinePicker.swift
+++ b/ios/evy/UI/Views/EVYInlinePicker.swift
@@ -8,98 +8,105 @@
 import SwiftUI
 
 struct EVYInlinePicker: View {
-    let title: String
-    let format: String
-    let destination: String
+  let title: String
+  let format: String
+  let destination: String
 
-    private var options: [EVYJson] = []
-    private var selectedIdentifiers: EVYState<[String]>
+  private var options: [EVYJson] = []
+  private var selectedIdentifiers: EVYState<[String]>
 
-    init(title: String,
-         data: String,
-         format: String,
-         destination: String)
-    {
-        self.title = title
-        self.format = format
-        self.destination = destination
+  init(
+    title: String,
+    data: String,
+    format: String,
+    destination: String
+  ) {
+    self.title = title
+    self.format = format
+    self.destination = destination
 
-        var loadedOptions: [EVYJson] = []
+    var loadedOptions: [EVYJson] = []
+    do {
+      let data = try EVY.getDataFromText(data)
+      if case .array(let arrayValue) = data {
+        loadedOptions.append(contentsOf: arrayValue)
+      }
+    } catch {
+      #if DEBUG
+        print("[EVYInlinePicker] Error loading options: \(error)")
+      #endif
+    }
+    options = loadedOptions
+
+    selectedIdentifiers = EVYState(
+      watch: destination,
+      setter: {
         do {
-            let data = try EVY.getDataFromText(data)
-            if case let .array(arrayValue) = data {
-                loadedOptions.append(contentsOf: arrayValue)
-            }
+          let selected = try EVY.getDataFromText($0)
+          guard case .array(let arrayValue) = selected else {
+            throw EVYError.invalidData(
+              context: "InlinePicker destination '\($0)' must be an array.")
+          }
+          return arrayValue.map { $0.identifierValue() }
         } catch {
-            #if DEBUG
-            print("[EVYInlinePicker] Error loading options: \(error)")
-            #endif
+          NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
+          #if DEBUG
+            print("[EVYInlinePicker] Error loading selection: \(error)")
+          #endif
         }
-        options = loadedOptions
+        return []
+      })
+  }
 
-        selectedIdentifiers = EVYState(watch: destination, setter: {
-            do {
-                let selected = try EVY.getDataFromText($0)
-                guard case let .array(arrayValue) = selected else {
-                    throw EVYError.invalidData(context: "InlinePicker destination '\($0)' must be an array.")
-                }
-                return arrayValue.map { $0.identifierValue() }
-            } catch {
-                NotificationCenter.default.post(name: .evyErrorOccurred, object: error)
-                #if DEBUG
-                print("[EVYInlinePicker] Error loading selection: \(error)")
-                #endif
-            }
-            return []
-        })
+  private func performAction(option: EVYJson) {
+    let optionIdentifier = option.identifierValue()
+    do {
+      var updatedIdentifiers = selectedIdentifiers.value.filter {
+        $0 != optionIdentifier
+      }
+      if updatedIdentifiers.count == selectedIdentifiers.value.count {
+        updatedIdentifiers.append(optionIdentifier)
+      }
+      let encoded = try JSONEncoder().encode(updatedIdentifiers)
+      try EVY.updateData(encoded, at: destination)
+    } catch {
+      #if DEBUG
+        print("[EVYInlinePicker] Error updating selection: \(error)")
+      #endif
     }
+  }
 
-    private func performAction(option: EVYJson) {
-        let optionIdentifier = option.identifierValue()
-        do {
-            var updatedIdentifiers = selectedIdentifiers.value.filter {
-                $0 != optionIdentifier
-            }
-            if updatedIdentifiers.count == selectedIdentifiers.value.count {
-                updatedIdentifiers.append(optionIdentifier)
-            }
-            let encoded = try JSONEncoder().encode(updatedIdentifiers)
-            try EVY.updateData(encoded, at: destination)
-        } catch {
-            #if DEBUG
-            print("[EVYInlinePicker] Error updating selection: \(error)")
-            #endif
+  var body: some View {
+    HStack {
+      ForEach(Array(options.enumerated()), id: \.offset) { _, option in
+        let isSelected = selectedIdentifiers.value.contains(option.identifierValue())
+        Button(action: {
+          performAction(option: option)
+        }) {
+          let formatted =
+            (try? EVY.formatDataOrToString(json: option, format: format))
+            ?? option.toString()
+          let textView = EVYTextView(formatted)
+          EVYRectangle.fitWidth(
+            content: textView,
+            style: isSelected ? .primary : .secondary)
         }
+      }
     }
-
-    var body: some View {
-        HStack {
-            ForEach(Array(options.enumerated()), id: \.offset) { _, option in
-                let isSelected = selectedIdentifiers.value.contains(option.identifierValue())
-                Button(action: {
-                    performAction(option: option)
-                }) {
-                    let formatted = (try? EVY.formatDataOrToString(json: option, format: format))
-                        ?? option.toString()
-                    let textView = EVYTextView(formatted)
-                    EVYRectangle.fitWidth(content: textView,
-                                            style: isSelected ? .primary : .secondary)
-                }
-            }
-        }
-    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! EVY.getUserData()
-		try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! EVY.getUserData()
+    try! await EVY.createItem()
 
-		return EVYInlinePicker(title: "Dropdown",
-							   data: "{durations}",
-							   format: "{$datum:value}",
-							   destination: "{duration}")
-	}
+    return EVYInlinePicker(
+      title: "Dropdown",
+      data: "{durations}",
+      format: "{$datum:value}",
+      destination: "{duration}")
+  }
 }

--- a/ios/evy/UI/Views/EVYInputList.swift
+++ b/ios/evy/UI/Views/EVYInputList.swift
@@ -8,63 +8,72 @@
 import SwiftUI
 
 struct EVYInputList: View {
-    let data: String
-    let format: String
-    var placeholder: String
-    private var values: EVYState<[String]>
+  let data: String
+  let format: String
+  var placeholder: String
+  private var values: EVYState<[String]>
 
-    init(data: String, format: String, placeholder: String) {
-        self.data = data
-        self.format = format
-        self.placeholder = placeholder
+  init(data: String, format: String, placeholder: String) {
+    self.data = data
+    self.format = format
+    self.placeholder = placeholder
 
-        values = EVYState(watch: data, setter: {
-            do {
-                let data = try EVY.getDataFromText($0)
-                if case let .array(arrayValue) = data {
-                    return try arrayValue.map { json in
-                        try EVY.formatDataOrToString(json: json, format: format)
-                    }
-                } else {
-                    return [
-                        try EVY.formatDataOrToString(json: data, format: format),
-                    ]
-                }
-            } catch {
+    values = EVYState(
+      watch: data,
+      setter: {
+        do {
+          let data = try EVY.getDataFromText($0)
+          if case .array(let arrayValue) = data {
+            return try arrayValue.map { json in
+              try EVY.formatDataOrToString(json: json, format: format)
             }
+          } else {
+            return [
+              try EVY.formatDataOrToString(json: data, format: format)
+            ]
+          }
+        } catch {
+        }
 
-            return []
-        })
-    }
+        return []
+      })
+  }
 
-    var body: some View {
-        EVYTextField(input: "",
-                     destination: "",
-                     placeholder: values.value.isEmpty ? placeholder : "")
-            .disabled(true)
-            .overlay {
-                ScrollView(.horizontal, content: {
-                    HStack(spacing: Constants.majorPadding) {
-                        ForEach(values.value, id: \.self) { value in
-                            EVYRectangle.fitWidth(content: EVYTextView(value),
-                                                  style: .primary)
-                        }
-                    }
-                    .padding(Constants.majorPadding)
-                })
-                .scrollIndicators(.hidden)
+  var body: some View {
+    EVYTextField(
+      input: "",
+      destination: "",
+      placeholder: values.value.isEmpty ? placeholder : ""
+    )
+    .disabled(true)
+    .overlay {
+      ScrollView(
+        .horizontal,
+        content: {
+          HStack(spacing: Constants.majorPadding) {
+            ForEach(values.value, id: \.self) { value in
+              EVYRectangle.fitWidth(
+                content: EVYTextView(value),
+                style: .primary)
             }
+          }
+          .padding(Constants.majorPadding)
+        }
+      )
+      .scrollIndicators(.hidden)
     }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
 
-		return EVYInputList(data: "{tags}",
-							format: "{$datum:value}",
-							placeholder: "Add tags to improve search")
-	}
+    return EVYInputList(
+      data: "{tags}",
+      format: "{$datum:value}",
+      placeholder: "Add tags to improve search")
+  }
 }

--- a/ios/evy/UI/Views/EVYMap.swift
+++ b/ios/evy/UI/Views/EVYMap.swift
@@ -5,26 +5,27 @@
 //  Created by Clemence Chalot on 20/12/2023.
 //
 
-import SwiftUI
 import MapKit
+import SwiftUI
 
 struct EVYMap: View {
-    let location: CLLocationCoordinate2D
-    let markerLabel: String
+  let location: CLLocationCoordinate2D
+  let markerLabel: String
 
-    var body: some View {
-        let span = MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
-        let region = MKCoordinateRegion(center: location, span: span)
-        Map(initialPosition: .region(region)) {
-            Marker(markerLabel, coordinate: location)
-        }
-        .mapStyle(.standard(elevation: .realistic))
-        .cornerRadius(Constants.mainCornerRadius)
+  var body: some View {
+    let span = MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+    let region = MKCoordinateRegion(center: location, span: span)
+    Map(initialPosition: .region(region)) {
+      Marker(markerLabel, coordinate: location)
     }
+    .mapStyle(.standard(elevation: .realistic))
+    .cornerRadius(Constants.mainCornerRadius)
+  }
 }
 
 #Preview {
-    let testLocation = CLLocationCoordinate2D(latitude: -33.91514116915074,
-                                              longitude: 151.20676069630827)
-    return EVYMap(location: testLocation, markerLabel: "Rosebery")
+  let testLocation = CLLocationCoordinate2D(
+    latitude: -33.91514116915074,
+    longitude: 151.20676069630827)
+  return EVYMap(location: testLocation, markerLabel: "Rosebery")
 }

--- a/ios/evy/UI/Views/EVYSearch.swift
+++ b/ios/evy/UI/Views/EVYSearch.swift
@@ -8,51 +8,51 @@
 import SwiftUI
 
 struct EVYSearch: View {
-    private let canSelectMultiple: Bool
+  private let canSelectMultiple: Bool
 
-    let source: String
-    let destination: String
-    let placeholder: String
-    let resultTemplate: UI_Row?
+  let source: String
+  let destination: String
+  let placeholder: String
+  let resultTemplate: UI_Row?
 
-    init(
-        source: String,
-        destination: String,
-        placeholder: String,
-        resultTemplate: UI_Row?,
-    ) {
-        self.source = source
-        self.destination = destination
-        self.placeholder = placeholder
-        self.resultTemplate = resultTemplate
+  init(
+    source: String,
+    destination: String,
+    placeholder: String,
+    resultTemplate: UI_Row?,
+  ) {
+    self.source = source
+    self.destination = destination
+    self.placeholder = placeholder
+    self.resultTemplate = resultTemplate
 
-        do {
-            let data = try EVY.getDataFromText(destination)
-            if case .array = data {
-                canSelectMultiple = true
-            } else {
-                canSelectMultiple = false
-            }
-        } catch {
-            canSelectMultiple = false
-        }
+    do {
+      let data = try EVY.getDataFromText(destination)
+      if case .array = data {
+        canSelectMultiple = true
+      } else {
+        canSelectMultiple = false
+      }
+    } catch {
+      canSelectMultiple = false
     }
+  }
 
-    var body: some View {
-        if canSelectMultiple {
-            EVYSearchMultiple(
-                source: source,
-                resultTemplate: resultTemplate,
-                destination: destination,
-                placeholder: placeholder,
-            )
-        } else {
-            EVYSearchSingle(
-                source: source,
-                resultTemplate: resultTemplate,
-                destination: destination,
-                placeholder: placeholder,
-            )
-        }
+  var body: some View {
+    if canSelectMultiple {
+      EVYSearchMultiple(
+        source: source,
+        resultTemplate: resultTemplate,
+        destination: destination,
+        placeholder: placeholder,
+      )
+    } else {
+      EVYSearchSingle(
+        source: source,
+        resultTemplate: resultTemplate,
+        destination: destination,
+        placeholder: placeholder,
+      )
     }
+  }
 }

--- a/ios/evy/UI/Views/EVYSearchMultiple.swift
+++ b/ios/evy/UI/Views/EVYSearchMultiple.swift
@@ -9,153 +9,161 @@ import LucideIcons
 import SwiftUI
 
 struct EVYSearchMultiple: View {
-    @State private var selected: [EVYSearchResult] = []
-    @State private var searchFieldValue = ""
-    @ObservedObject private var searchController: EVYSearchController
+  @State private var selected: [EVYSearchResult] = []
+  @State private var searchFieldValue = ""
+  @ObservedObject private var searchController: EVYSearchController
 
-    let source: String
-    let destination: String
-    let placeholder: String
-    let resultTemplate: UI_Row?
+  let source: String
+  let destination: String
+  let placeholder: String
+  let resultTemplate: UI_Row?
 
-    init(
-        source: String,
-        resultTemplate: UI_Row?,
-        destination: String,
-        placeholder: String,
-    ) {
-        self.source = source
-        self.resultTemplate = resultTemplate
-        self.destination = destination
-        self.placeholder = placeholder
+  init(
+    source: String,
+    resultTemplate: UI_Row?,
+    destination: String,
+    placeholder: String,
+  ) {
+    self.source = source
+    self.resultTemplate = resultTemplate
+    self.destination = destination
+    self.placeholder = placeholder
 
-        searchController = EVYSearchController(source: source, resultTemplate: resultTemplate)
+    searchController = EVYSearchController(source: source, resultTemplate: resultTemplate)
+  }
+
+  func refresh() {
+    guard resultTemplate != nil else {
+      return
     }
+    do {
+      let existingData = try EVY.getDataFromText(destination)
+      guard case .array(let arrayValue) = existingData else {
+        return
+      }
 
-    func refresh() {
-        guard resultTemplate != nil else {
-            return
+      var seenValues = Set(selected.map(\.value))
+      var next = selected
+      next.reserveCapacity(selected.count + arrayValue.count)
+      for value in arrayValue {
+        let result = try searchController.makeSearchResult(datum: value)
+        if seenValues.insert(result.value).inserted {
+          next.append(result)
         }
-        do {
-            let existingData = try EVY.getDataFromText(destination)
-            guard case let .array(arrayValue) = existingData else {
-                return
-            }
-
-            var seenValues = Set(selected.map(\.value))
-            var next = selected
-            next.reserveCapacity(selected.count + arrayValue.count)
-            for value in arrayValue {
-                let result = try searchController.makeSearchResult(datum: value)
-                if seenValues.insert(result.value).inserted {
-                    next.append(result)
-                }
-            }
-            selected = next
-        } catch {
-            #if DEBUG
-            print("[EVYSearchMultiple] Error refreshing data: \(error)")
-            #endif
-        }
+      }
+      selected = next
+    } catch {
+      #if DEBUG
+        print("[EVYSearchMultiple] Error refreshing data: \(error)")
+      #endif
     }
+  }
 
-    func select(_ element: EVYSearchResult) {
-        do {
-            selected.append(element)
+  func select(_ element: EVYSearchResult) {
+    do {
+      selected.append(element)
 
-            let encoded = try JSONEncoder().encode(selected.map { $0.data })
-            try EVY.updateData(encoded, at: destination)
-            searchController.results.removeAll { $0.value == element.value }
-        } catch {
-            selected.removeAll { $0.value == element.value }
-        }
+      let encoded = try JSONEncoder().encode(selected.map { $0.data })
+      try EVY.updateData(encoded, at: destination)
+      searchController.results.removeAll { $0.value == element.value }
+    } catch {
+      selected.removeAll { $0.value == element.value }
     }
+  }
 
-    func unselect(_ element: EVYSearchResult) {
-        do {
-            selected.removeAll { $0.value == element.value }
-            try EVY.updateData(try JSONEncoder().encode(selected.map { $0.data }),
-                               at: destination)
-        } catch {
-            searchController.results.removeAll { $0.value == element.value }
-        }
+  func unselect(_ element: EVYSearchResult) {
+    do {
+      selected.removeAll { $0.value == element.value }
+      try EVY.updateData(
+        try JSONEncoder().encode(selected.map { $0.data }),
+        at: destination)
+    } catch {
+      searchController.results.removeAll { $0.value == element.value }
     }
+  }
 
-    var body: some View {
-        VStack {
+  var body: some View {
+    VStack {
+      HStack {
+        Image(uiImage: Lucide.search)
+          .padding(.leading, Constants.minorPadding)
+        TextField(placeholder, text: $searchFieldValue).font(.evy)
+      }
+      .padding(
+        EdgeInsets(
+          top: Constants.fieldPadding,
+          leading: Constants.minorPadding,
+          bottom: Constants.fieldPadding,
+          trailing: Constants.minorPadding,
+        )
+      )
+      .background(
+        RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
+          .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
+          .opacity(Constants.borderOpacity)
+      )
+      .contentShape(Rectangle())
+      .padding(.horizontal, Constants.majorPadding)
+      .onChange(of: searchFieldValue) { _, newValue in
+        Task(operation: {
+          if !newValue.isEmpty && newValue.count > 3 {
+            await searchController.search(name: newValue)
+          } else {
+            searchController.results.removeAll()
+          }
+        })
+      }
+
+      if selected.count > 0 {
+        ScrollView(
+          .horizontal,
+          content: {
             HStack {
-                Image(uiImage: Lucide.search)
-                    .padding(.leading, Constants.minorPadding)
-                TextField(placeholder, text: $searchFieldValue).font(.evy)
+              ForEach(selected.reversed(), id: \.value) { result in
+                EVYRectangle.fitWidth(
+                  content: EVYTextView(result.value),
+                  style: .primary
+                )
+                .onTapGesture { unselect(result) }
+              }
             }
-            .padding(EdgeInsets(
-                top: Constants.fieldPadding,
-                leading: Constants.minorPadding,
-                bottom: Constants.fieldPadding,
-                trailing: Constants.minorPadding,
-            ))
-            .background(
-                RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
-                    .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
-                    .opacity(Constants.borderOpacity)
-            )
-            .contentShape(Rectangle())
-            .padding(.horizontal, Constants.majorPadding)
-            .onChange(of: searchFieldValue) { _, newValue in
-                Task(operation: {
-                    if !newValue.isEmpty && newValue.count > 3 {
-                        await searchController.search(name: newValue)
-                    } else {
-                        searchController.results.removeAll()
-                    }
-                })
-            }
+            .offset(x: Constants.majorPadding)
+          }
+        )
+        .scrollIndicators(.hidden)
+      }
 
-            if selected.count > 0 {
-                ScrollView(.horizontal, content: {
-                    HStack {
-                        ForEach(selected.reversed(), id: \.value) { result in
-                            EVYRectangle.fitWidth(content: EVYTextView(result.value),
-                                                  style: .primary)
-                                .onTapGesture { unselect(result) }
-                        }
-                    }
-                    .offset(x: Constants.majorPadding)
-                })
-                .scrollIndicators(.hidden)
-            }
-
-            List {
-                ForEach(searchController.results, id: \.value) { result in
-                    EVYRow(row: result.displayRow)
-                        .onTapGesture { select(result) }
-                }
-                .onChange(of: searchController.results) { _, _ in
-                    searchController.results.removeAll { r in
-                        selected.contains { $0.value == r.value }
-                    }
-                }
-            }
-            .listStyle(.plain)
-            .listRowSpacing(20)
-            .scrollContentBackground(.hidden)
-            .background(Color.white)
+      List {
+        ForEach(searchController.results, id: \.value) { result in
+          EVYRow(row: result.displayRow)
+            .onTapGesture { select(result) }
         }
-        .onAppear { refresh() }
+        .onChange(of: searchController.results) { _, _ in
+          searchController.results.removeAll { r in
+            selected.contains { $0.value == r.value }
+          }
+        }
+      }
+      .listStyle(.plain)
+      .listRowSpacing(20)
+      .scrollContentBackground(.hidden)
+      .background(Color.white)
     }
+    .onAppear { refresh() }
+  }
 }
 
 #Preview {
-    AsyncPreview { asyncView in
-        asyncView
-    } view: {
-        try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
 
-        return EVYSearch(
-            source: "{$api:tags}",
-            destination: "{tags}",
-            placeholder: "Search",
-            resultTemplate: nil,
-        )
-    }
+    return EVYSearch(
+      source: "{$api:tags}",
+      destination: "{tags}",
+      placeholder: "Search",
+      resultTemplate: nil,
+    )
+  }
 }

--- a/ios/evy/UI/Views/EVYSearchSingle.swift
+++ b/ios/evy/UI/Views/EVYSearchSingle.swift
@@ -9,121 +9,124 @@ import LucideIcons
 import SwiftUI
 
 struct EVYSearchSingle: View {
-    @State private var selected: String = ""
-    @State private var value: String = ""
-    @ObservedObject private var searchController: EVYSearchController
+  @State private var selected: String = ""
+  @State private var value: String = ""
+  @ObservedObject private var searchController: EVYSearchController
 
-    let destination: String
-    let placeholder: String
+  let destination: String
+  let placeholder: String
 
-    init(
-        source: String,
-        resultTemplate: UI_Row?,
-        destination: String,
-        placeholder: String,
-    ) {
-        self.destination = destination
-        self.placeholder = placeholder
+  init(
+    source: String,
+    resultTemplate: UI_Row?,
+    destination: String,
+    placeholder: String,
+  ) {
+    self.destination = destination
+    self.placeholder = placeholder
 
-        searchController = EVYSearchController(source: source, resultTemplate: resultTemplate)
+    searchController = EVYSearchController(source: source, resultTemplate: resultTemplate)
+  }
+
+  func select(_ element: EVYSearchResult) {
+    do {
+      value = element.value
+      selected = element.value
+      let encoded = try JSONEncoder().encode(element.data)
+      try EVY.updateData(encoded, at: destination)
+    } catch {
+      #if DEBUG
+        print("[EVYSearchSingle] Error selecting element: \(error)")
+      #endif
     }
+  }
 
-    func select(_ element: EVYSearchResult) {
-        do {
-            value = element.value
-            selected = element.value
-            let encoded = try JSONEncoder().encode(element.data)
-            try EVY.updateData(encoded, at: destination)
-        } catch {
-            #if DEBUG
-            print("[EVYSearchSingle] Error selecting element: \(error)")
-            #endif
+  func unselect() {
+    do {
+      value = ""
+      selected = ""
+      try EVY.updateValue("{}", at: destination)
+    } catch {
+      #if DEBUG
+        print("[EVYSearchSingle] Error unselecting: \(error)")
+      #endif
+    }
+  }
+
+  var body: some View {
+    VStack {
+      // Search bar
+      HStack {
+        if value.isEmpty {
+          Image(uiImage: Lucide.search)
+            .padding(.leading, Constants.minorPadding)
         }
-    }
 
-    func unselect() {
-        do {
-            value = ""
-            selected = ""
-            try EVY.updateValue("{}", at: destination)
-        } catch {
-            #if DEBUG
-            print("[EVYSearchSingle] Error unselecting: \(error)")
-            #endif
+        TextField(placeholder, text: $value)
+          .font(.evy)
+
+        if !value.isEmpty {
+          Image(uiImage: Lucide.x)
+            .padding(.trailing, Constants.minorPadding)
+            .onTapGesture { unselect() }
         }
-    }
+      }
+      .padding(
+        EdgeInsets(
+          top: Constants.fieldPadding,
+          leading: Constants.minorPadding,
+          bottom: Constants.fieldPadding,
+          trailing: Constants.minorPadding,
+        )
+      )
+      .background(
+        RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
+          .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
+          .opacity(Constants.borderOpacity)
+      )
+      .contentShape(Rectangle())
+      .padding(.horizontal, Constants.majorPadding)
+      .onChange(of: value) { _, newValue in
+        Task(operation: {
+          if newValue.isEmpty {
+            return
+          }
+          if newValue.count < 3 {
+            return
+          }
+          if newValue == selected {
+            return
+          }
 
-    var body: some View {
-        VStack {
-            // Search bar
-            HStack {
-                if value.isEmpty {
-                    Image(uiImage: Lucide.search)
-                        .padding(.leading, Constants.minorPadding)
-                }
+          await searchController.search(name: newValue)
+        })
+      }
 
-                TextField(placeholder, text: $value)
-                    .font(.evy)
-
-                if !value.isEmpty {
-                    Image(uiImage: Lucide.x)
-                        .padding(.trailing, Constants.minorPadding)
-                        .onTapGesture { unselect() }
-                }
-            }
-            .padding(EdgeInsets(
-                top: Constants.fieldPadding,
-                leading: Constants.minorPadding,
-                bottom: Constants.fieldPadding,
-                trailing: Constants.minorPadding,
-            ))
-            .background(
-                RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
-                    .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
-                    .opacity(Constants.borderOpacity)
-            )
-            .contentShape(Rectangle())
-            .padding(.horizontal, Constants.majorPadding)
-            .onChange(of: value) { _, newValue in
-                Task(operation: {
-                    if newValue.isEmpty {
-                        return
-                    }
-                    if newValue.count < 3 {
-                        return
-                    }
-                    if newValue == selected {
-                        return
-                    }
-
-                    await searchController.search(name: newValue)
-                })
-            }
-
-            // Search results
-            List {
-                ForEach(searchController.results, id: \.value) { result in
-                    EVYRow(row: result.displayRow)
-						.onTapGesture { select(result) }
-                }
-            }
-            .listStyle(.plain)
-            .listRowSpacing(20)
-            .scrollContentBackground(.hidden)
-            .background(Color.white)
+      // Search results
+      List {
+        ForEach(searchController.results, id: \.value) { result in
+          EVYRow(row: result.displayRow)
+            .onTapGesture { select(result) }
         }
+      }
+      .listStyle(.plain)
+      .listRowSpacing(20)
+      .scrollContentBackground(.hidden)
+      .background(Color.white)
     }
+  }
 }
 
 #Preview {
-    AsyncPreview { asyncView in
-        asyncView
-    } view: {
-        try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
 
-        return EVYSearch(source: "{$local:address}",
-						 destination: "{address}",
-						 placeholder: "Search",
-						 resultTemplate: nil)
-    }
+    return EVYSearch(
+      source: "{$local:address}",
+      destination: "{address}",
+      placeholder: "Search",
+      resultTemplate: nil)
+  }
 }

--- a/ios/evy/UI/Views/EVYSelectItem.swift
+++ b/ios/evy/UI/Views/EVYSelectItem.swift
@@ -8,185 +8,190 @@
 import SwiftUI
 
 public enum EVYSelectItemTarget: String {
-    case single_identifier
-    case single_value
-    case single_bool
-    case single_object
-    case multi_identifier
-    case multi_value
-    case multi_object
+  case single_identifier
+  case single_value
+  case single_bool
+  case single_object
+  case multi_identifier
+  case multi_value
+  case multi_object
 }
 
 struct EVYSelectItem: View {
-    let destination: String
-    let value: EVYJson
-    let format: String
-    let selectionStyle: EVYRadioStyle
-    let target: EVYSelectItemTarget
-    let textStyle: EVYTextStyle
-    let onSelect: (() -> Void)?
+  let destination: String
+  let value: EVYJson
+  let format: String
+  let selectionStyle: EVYRadioStyle
+  let target: EVYSelectItemTarget
+  let textStyle: EVYTextStyle
+  let onSelect: (() -> Void)?
 
-    private var selected: EVYState<Bool>
+  private var selected: EVYState<Bool>
 
-    init(destination: String,
-         value: EVYJson,
-         format: String,
-         selectionStyle: EVYRadioStyle,
-         target: EVYSelectItemTarget,
-         textStyle: EVYTextStyle = .body,
-         onSelect: (() -> Void)? = nil)
-    {
-        self.destination = destination
-        self.value = value
-        self.format = format
-        self.selectionStyle = selectionStyle
-        self.target = target
-        self.textStyle = textStyle
-        self.onSelect = onSelect
+  init(
+    destination: String,
+    value: EVYJson,
+    format: String,
+    selectionStyle: EVYRadioStyle,
+    target: EVYSelectItemTarget,
+    textStyle: EVYTextStyle = .body,
+    onSelect: (() -> Void)? = nil
+  ) {
+    self.destination = destination
+    self.value = value
+    self.format = format
+    self.selectionStyle = selectionStyle
+    self.target = target
+    self.textStyle = textStyle
+    self.onSelect = onSelect
 
-        selected = EVYState(watch: destination, setter: {
-            do {
-                if target == .single_identifier {
-                    let sourceId = value.identifierValue()
-                    let destinationId = try EVY.getDataFromText($0).identifierValue()
-                    return sourceId == destinationId
-                } else if target == .single_value {
-                    let sourceString = value.toString()
-                    let destinationString = try EVY.getDataFromText($0).toString()
-                    return sourceString == destinationString
-                } else if target == .single_bool {
-                    return try EVY.evaluateFromText($0)
-                } else if target == .single_object {
-                    let existingData = try EVY.getDataFromText(destination)
-                    return existingData.identifierValue() == value.identifierValue()
-                } else if target == .multi_identifier {
-                    let existingData = try EVY.getDataFromText(destination)
-                    guard case let .array(arrayValue) = existingData else {
-                        return false
-                    }
-                    let valueId = value.identifierValue()
-                    return arrayValue.contains { $0.identifierValue() == valueId }
-                } else if target == .multi_value {
-                    let existingData = try EVY.getDataFromText(destination)
-                    guard case let .array(arrayValue) = existingData else {
-                        return false
-                    }
-                    let valueString = value.toString()
-                    return arrayValue.contains { $0.toString() == valueString }
-                } else if target == .multi_object {
-                    let existingData = try EVY.getDataFromText(destination)
-                    guard case let .array(arrayValue) = existingData else {
-                        return false
-                    }
-                    let valueId = value.identifierValue()
-                    return arrayValue.contains { $0.identifierValue() == valueId }
-                }
-            } catch {
-                return false
+    selected = EVYState(
+      watch: destination,
+      setter: {
+        do {
+          if target == .single_identifier {
+            let sourceId = value.identifierValue()
+            let destinationId = try EVY.getDataFromText($0).identifierValue()
+            return sourceId == destinationId
+          } else if target == .single_value {
+            let sourceString = value.toString()
+            let destinationString = try EVY.getDataFromText($0).toString()
+            return sourceString == destinationString
+          } else if target == .single_bool {
+            return try EVY.evaluateFromText($0)
+          } else if target == .single_object {
+            let existingData = try EVY.getDataFromText(destination)
+            return existingData.identifierValue() == value.identifierValue()
+          } else if target == .multi_identifier {
+            let existingData = try EVY.getDataFromText(destination)
+            guard case .array(let arrayValue) = existingData else {
+              return false
             }
-
-            return false
-        })
-    }
-
-    var body: some View {
-        HStack {
-            let text = (try? EVY.formatDataOrToString(json: value, format: format))
-                ?? value.toString()
-            EVYTextView(text, style: textStyle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            EVYRadioButton(isSelected: selected.value, style: selectionStyle)
-        }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            do {
-                if target == .single_identifier
-                    || target == .single_value
-                    || target == .single_bool
-                    || target == .single_object
-                {
-                    var newValue = ""
-                    switch target {
-                    case .single_identifier:
-                        if !selected.value {
-                            newValue = value.identifierValue()
-                        }
-                    case .single_bool:
-                        newValue = selected.value ? "false" : "true"
-                    default:
-                        if !selected.value {
-                            newValue = value.toString()
-                        }
-                    }
-                    try EVY.updateValue(newValue, at: destination)
-                } else {
-                    let existingData = try EVY.getDataFromText(destination)
-                    guard case let .array(arrayValue) = existingData else {
-                        return
-                    }
-
-                    if target == .multi_identifier {
-                        let valueId = value.identifierValue()
-                        var updatedData = arrayValue.filter {
-                            $0.identifierValue() != valueId
-                        }.map {
-                            $0.toString()
-                        }
-                        if updatedData.count == arrayValue.count {
-                            updatedData.append(value.identifierValue())
-                        }
-                        let encoded = try JSONEncoder().encode(updatedData)
-                        try EVY.updateData(encoded, at: destination)
-                    } else if target == .multi_value {
-                        let valueString = value.toString()
-                        var updatedData = arrayValue.filter {
-                            $0.toString() != valueString
-                        }
-                        if updatedData.count == arrayValue.count {
-                            updatedData.append(value)
-                        }
-                        let encoded = try JSONEncoder().encode(updatedData)
-                        try EVY.updateData(encoded, at: destination)
-                    } else if target == .multi_object {
-                        let valueId = value.identifierValue()
-                        var updatedData = arrayValue.filter {
-                            $0.identifierValue() != valueId
-                        }
-                        if updatedData.count == arrayValue.count {
-                            updatedData.append(value)
-                        }
-                        let encoded = try JSONEncoder().encode(updatedData)
-                        try EVY.updateData(encoded, at: destination)
-                    }
-                }
-
-                onSelect?()
-            } catch {
-                #if DEBUG
-                print("[EVYSelectItem] Error updating selection: \(error)")
-                #endif
+            let valueId = value.identifierValue()
+            return arrayValue.contains { $0.identifierValue() == valueId }
+          } else if target == .multi_value {
+            let existingData = try EVY.getDataFromText(destination)
+            guard case .array(let arrayValue) = existingData else {
+              return false
             }
+            let valueString = value.toString()
+            return arrayValue.contains { $0.toString() == valueString }
+          } else if target == .multi_object {
+            let existingData = try EVY.getDataFromText(destination)
+            guard case .array(let arrayValue) = existingData else {
+              return false
+            }
+            let valueId = value.identifierValue()
+            return arrayValue.contains { $0.identifierValue() == valueId }
+          }
+        } catch {
+          return false
         }
+
+        return false
+      })
+  }
+
+  var body: some View {
+    HStack {
+      let text =
+        (try? EVY.formatDataOrToString(json: value, format: format))
+        ?? value.toString()
+      EVYTextView(text, style: textStyle)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      EVYRadioButton(isSelected: selected.value, style: selectionStyle)
     }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      do {
+        if target == .single_identifier
+          || target == .single_value
+          || target == .single_bool
+          || target == .single_object
+        {
+          var newValue = ""
+          switch target {
+          case .single_identifier:
+            if !selected.value {
+              newValue = value.identifierValue()
+            }
+          case .single_bool:
+            newValue = selected.value ? "false" : "true"
+          default:
+            if !selected.value {
+              newValue = value.toString()
+            }
+          }
+          try EVY.updateValue(newValue, at: destination)
+        } else {
+          let existingData = try EVY.getDataFromText(destination)
+          guard case .array(let arrayValue) = existingData else {
+            return
+          }
+
+          if target == .multi_identifier {
+            let valueId = value.identifierValue()
+            var updatedData = arrayValue.filter {
+              $0.identifierValue() != valueId
+            }.map {
+              $0.toString()
+            }
+            if updatedData.count == arrayValue.count {
+              updatedData.append(value.identifierValue())
+            }
+            let encoded = try JSONEncoder().encode(updatedData)
+            try EVY.updateData(encoded, at: destination)
+          } else if target == .multi_value {
+            let valueString = value.toString()
+            var updatedData = arrayValue.filter {
+              $0.toString() != valueString
+            }
+            if updatedData.count == arrayValue.count {
+              updatedData.append(value)
+            }
+            let encoded = try JSONEncoder().encode(updatedData)
+            try EVY.updateData(encoded, at: destination)
+          } else if target == .multi_object {
+            let valueId = value.identifierValue()
+            var updatedData = arrayValue.filter {
+              $0.identifierValue() != valueId
+            }
+            if updatedData.count == arrayValue.count {
+              updatedData.append(value)
+            }
+            let encoded = try JSONEncoder().encode(updatedData)
+            try EVY.updateData(encoded, at: destination)
+          }
+        }
+
+        onSelect?()
+      } catch {
+        #if DEBUG
+          print("[EVYSelectItem] Error updating selection: \(error)")
+        #endif
+      }
+    }
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! EVY.getUserData()
-		try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! EVY.getUserData()
+    try! await EVY.createItem()
 
-		return Group {
-			let options = try! EVY.getDataFromText("{selling_reasons}")
-			switch options {
-			case let .array(arrayValue):
-				EVYSelectList(options: arrayValue,
-									 format: "{$datum:value}",
-									 destination: "{selling_reason}")
-			default:
-				Text("error")
-			}
-		}
-	}
+    return Group {
+      let options = try! EVY.getDataFromText("{selling_reasons}")
+      switch options {
+      case .array(let arrayValue):
+        EVYSelectList(
+          options: arrayValue,
+          format: "{$datum:value}",
+          destination: "{selling_reason}")
+      default:
+        Text("error")
+      }
+    }
+  }
 }

--- a/ios/evy/UI/Views/EVYSelectList.swift
+++ b/ios/evy/UI/Views/EVYSelectList.swift
@@ -8,47 +8,50 @@
 import SwiftUI
 
 struct EVYSelectList: View {
-    let options: [EVYJson]
-    let format: String
-    let destination: String
-    @Environment(\.dismiss) private var dismiss
+  let options: [EVYJson]
+  let format: String
+  let destination: String
+  @Environment(\.dismiss) private var dismiss
 
-    var body: some View {
-        List {
-            ForEach(Array(options.enumerated()), id: \.offset) { _, value in
-                EVYSelectItem(destination: destination,
-                              value: value,
-                              format: format,
-                              selectionStyle: .single,
-                              target: .single_identifier,
-                              onSelect: { dismiss() })
-				.frame(height: Constants.listRowHeight)
-            }
-            .listRowSeparator(.hidden)
-            .listRowBackground(Color.clear)
-        }
-        .listStyle(.inset)
-        .scrollContentBackground(.hidden)
+  var body: some View {
+    List {
+      ForEach(Array(options.enumerated()), id: \.offset) { _, value in
+        EVYSelectItem(
+          destination: destination,
+          value: value,
+          format: format,
+          selectionStyle: .single,
+          target: .single_identifier,
+          onSelect: { dismiss() }
+        )
+        .frame(height: Constants.listRowHeight)
+      }
+      .listRowSeparator(.hidden)
+      .listRowBackground(Color.clear)
     }
+    .listStyle(.inset)
+    .scrollContentBackground(.hidden)
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! EVY.getUserData()
-		try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! EVY.getUserData()
+    try! await EVY.createItem()
 
-		return Group {
-			let options = try! EVY.getDataFromText("{selling_reasons}")
-			switch options {
-			case let .array(arrayValue):
-				EVYSelectList(options: arrayValue,
-							  format: "{$datum:value}",
-							  destination: "{selling_reason}")
-			default:
-				Text("error")
-			}
-		}
-	}
+    return Group {
+      let options = try! EVY.getDataFromText("{selling_reasons}")
+      switch options {
+      case .array(let arrayValue):
+        EVYSelectList(
+          options: arrayValue,
+          format: "{$datum:value}",
+          destination: "{selling_reason}")
+      default:
+        Text("error")
+      }
+    }
+  }
 }

--- a/ios/evy/UI/Views/EVYSelectPhoto.swift
+++ b/ios/evy/UI/Views/EVYSelectPhoto.swift
@@ -5,218 +5,221 @@
 //  Created by Geoffroy Lesage on 28/06/2024.
 //
 
-
-import SwiftUI
 import PhotosUI
+import SwiftUI
 
 var carouselElementSize: CGFloat = 150.0
 
 struct EVYSelectPhoto: View {
-    var title: String?
-    let subtitle: String
-    let icon: String
-    let content: String
-    let destination: String
-    
-    private var options: [EVYJson] = []
-    
-    @State private var selection: EVYJson?
-    @State private var showSheet = false
-    
-    private let fm = FileManager.default
-    private var cacheDir: URL {
-        fm.urls(for: .cachesDirectory, in: .userDomainMask).first!
-     }
-    
-    @State private var photos: [String] = []
+  var title: String?
+  let subtitle: String
+  let icon: String
+  let content: String
+  let destination: String
 
-    init(title: String?,
-         subtitle: String,
-         icon: String,
-         content: String,
-         data: String,
-         destination: String)
+  private var options: [EVYJson] = []
+
+  @State private var selection: EVYJson?
+  @State private var showSheet = false
+
+  private let fm = FileManager.default
+  private var cacheDir: URL {
+    fm.urls(for: .cachesDirectory, in: .userDomainMask).first!
+  }
+
+  @State private var photos: [String] = []
+
+  init(
+    title: String?,
+    subtitle: String,
+    icon: String,
+    content: String,
+    data: String,
+    destination: String
+  ) {
+    self.title = title
+    self.icon = icon
+    self.content = content
+    self.subtitle = subtitle
+    self.destination = destination
+
+    if let props = try? EVY.getValueFromText(data),
+      let photosData = props.value.data(using: .utf8),
+      let photoObjects = try? JSONDecoder().decode([String].self, from: photosData)
     {
-        self.title = title
-        self.icon = icon
-        self.content = content
-        self.subtitle = subtitle
-        self.destination = destination
-        
-        if let props = try? EVY.getValueFromText(data),
-           let photosData = props.value.data(using: .utf8),
-           let photoObjects = try? JSONDecoder().decode([String].self, from: photosData)
-        {
-            _photos = State(initialValue: photoObjects)
-        }
+      _photos = State(initialValue: photoObjects)
     }
+  }
 
-    var body: some View {
-        VStack(alignment:.leading) {
-            if title?.count ?? 0 > 0 {
-                EVYTextView(title!)
-            }
+  var body: some View {
+    VStack(alignment: .leading) {
+      if title?.count ?? 0 > 0 {
+        EVYTextView(title!)
+      }
 
-            if photos.count > 0 {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack {
-                        EVYSelectPhotoCarousel(imageNames: photos)
-                        EVYSelectPhotoButton(fullScreen: false,
-                                             icon: icon,
-											 content: content,
-                                             photos: $photos)
-                    }
-                }
-            } else {
-                EVYSelectPhotoButton(fullScreen: true,
-                                     icon: icon,
-									 content: content,
-                                     photos: $photos)
-            }
-            
-			EVYTextView(subtitle, style: .info)
-                .padding(.vertical, Constants.padding)
+      if photos.count > 0 {
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack {
+            EVYSelectPhotoCarousel(imageNames: photos)
+            EVYSelectPhotoButton(
+              fullScreen: false,
+              icon: icon,
+              content: content,
+              photos: $photos)
+          }
         }
-        .onChange(of: photos) {
-            do {
-                let encoded = try JSONEncoder().encode(photos)
-                try EVY.updateData(encoded, at: destination)
-            } catch {
-                #if DEBUG
-                print("[EVYSelectPhoto] Error updating photos: \(error)")
-                #endif
-            }
-        }
+      } else {
+        EVYSelectPhotoButton(
+          fullScreen: true,
+          icon: icon,
+          content: content,
+          photos: $photos)
+      }
+
+      EVYTextView(subtitle, style: .info)
+        .padding(.vertical, Constants.padding)
     }
+    .onChange(of: photos) {
+      do {
+        let encoded = try JSONEncoder().encode(photos)
+        try EVY.updateData(encoded, at: destination)
+      } catch {
+        #if DEBUG
+          print("[EVYSelectPhoto] Error updating photos: \(error)")
+        #endif
+      }
+    }
+  }
 }
 
 struct EVYSelectPhotoButton: View {
-    let fullScreen: Bool
-    let icon: String
-    let content: String
-    
-    @State private var selectedItem: PhotosPickerItem?
-    @Binding var photos: [String]
-    
-    var body: some View {
-        
-        HStack {
-            PhotosPicker(
-                selection: $selectedItem,
-                label: {
-                    let stack = VStack {
-                        EVYTextView(icon)
-                        EVYTextView(content)
-                    }
-                    if fullScreen {
-                        stack
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 80)
-                            .background(
-                                RoundedRectangle(cornerRadius: Constants.mainCornerRadius)
-                                    .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth))
-                    } else {
-                        stack
-                            .frame(width: carouselElementSize, height: carouselElementSize)
-                            .background(
-                                RoundedRectangle(cornerRadius: Constants.mainCornerRadius)
-                                    .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth))
-                    }
-                }
-            )
-			.buttonStyle(.plain)
-            .onChange(of: selectedItem) {
-                Task {
-                    do {
-                        if let data = try await selectedItem?.loadTransferable(type: Data.self) {
-                            let id = UUID().description
-                            try ImageManager().writeImage(name: id, data: data)
-                            photos.append(id)
-                        }
-                    } catch {
-                        #if DEBUG
-                        print("[EVYSelectPhoto] Failed to load image: \(error)")
-                        #endif
-                        NotificationCenter.default.post(
-                            name: Notification.Name.evyErrorOccurred,
-                            object: EVYError.imageLoadFailed(name: "selected photo")
-                        )
-                    }
-                }
-            }
+  let fullScreen: Bool
+  let icon: String
+  let content: String
+
+  @State private var selectedItem: PhotosPickerItem?
+  @Binding var photos: [String]
+
+  var body: some View {
+
+    HStack {
+      PhotosPicker(
+        selection: $selectedItem,
+        label: {
+          let stack = VStack {
+            EVYTextView(icon)
+            EVYTextView(content)
+          }
+          if fullScreen {
+            stack
+              .frame(maxWidth: .infinity)
+              .padding(.vertical, 80)
+              .background(
+                RoundedRectangle(cornerRadius: Constants.mainCornerRadius)
+                  .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth))
+          } else {
+            stack
+              .frame(width: carouselElementSize, height: carouselElementSize)
+              .background(
+                RoundedRectangle(cornerRadius: Constants.mainCornerRadius)
+                  .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth))
+          }
         }
+      )
+      .buttonStyle(.plain)
+      .onChange(of: selectedItem) {
+        Task {
+          do {
+            if let data = try await selectedItem?.loadTransferable(type: Data.self) {
+              let id = UUID().description
+              try ImageManager().writeImage(name: id, data: data)
+              photos.append(id)
+            }
+          } catch {
+            #if DEBUG
+              print("[EVYSelectPhoto] Failed to load image: \(error)")
+            #endif
+            NotificationCenter.default.post(
+              name: Notification.Name.evyErrorOccurred,
+              object: EVYError.imageLoadFailed(name: "selected photo")
+            )
+          }
+        }
+      }
     }
+  }
 }
 
 struct EVYSelectPhotoCarousel: View {
-    let imageNames: [String]
-    
-    var body: some View {
-        ForEach(0..<imageNames.count, id: \.self) { index in
-            if let image = try? ImageManager().getImage(name: imageNames[index]) {
-                image
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: carouselElementSize, height: carouselElementSize)
-                    .clipShape(RoundedRectangle(cornerRadius: Constants.mainCornerRadius))
-                    .padding(.horizontal, 2)
-            } else {
-                Rectangle()
-                    .fill(Color.gray.opacity(0.3))
-                    .frame(width: carouselElementSize, height: carouselElementSize)
-                    .clipShape(RoundedRectangle(cornerRadius: Constants.mainCornerRadius))
-                    .padding(.horizontal, 2)
-            }
-        }
+  let imageNames: [String]
+
+  var body: some View {
+    ForEach(0..<imageNames.count, id: \.self) { index in
+      if let image = try? ImageManager().getImage(name: imageNames[index]) {
+        image
+          .resizable()
+          .scaledToFill()
+          .frame(width: carouselElementSize, height: carouselElementSize)
+          .clipShape(RoundedRectangle(cornerRadius: Constants.mainCornerRadius))
+          .padding(.horizontal, 2)
+      } else {
+        Rectangle()
+          .fill(Color.gray.opacity(0.3))
+          .frame(width: carouselElementSize, height: carouselElementSize)
+          .clipShape(RoundedRectangle(cornerRadius: Constants.mainCornerRadius))
+          .padding(.horizontal, 2)
+      }
     }
+  }
 }
 
 class ImageManager {
-    static let shared = ImageManager()
-    let fm = FileManager.default
-    var cachesDirectoryUrl: URL {
-		fm.urls(for: .cachesDirectory, in: .userDomainMask).first!
+  static let shared = ImageManager()
+  let fm = FileManager.default
+  var cachesDirectoryUrl: URL {
+    fm.urls(for: .cachesDirectory, in: .userDomainMask).first!
+  }
+
+  func getImage(name: String) throws -> Image {
+    let fileUrl = cachesDirectoryUrl.appendingPathComponent("\(name).png")
+    let filePath = fileUrl.path
+    if fm.fileExists(atPath: filePath) {
+      let data = try Data(contentsOf: fileUrl)
+      guard let uiImage = UIImage(data: data) else {
+        throw EVYError.imageLoadFailed(name: name)
+      }
+      return Image(uiImage: uiImage)
     }
-    
-    func getImage(name: String) throws -> Image {
-        let fileUrl = cachesDirectoryUrl.appendingPathComponent("\(name).png")
-        let filePath = fileUrl.path
-        if fm.fileExists(atPath: filePath) {
-            let data = try Data(contentsOf: fileUrl)
-            guard let uiImage = UIImage(data: data) else {
-                throw EVYError.imageLoadFailed(name: name)
-            }
-            return Image(uiImage: uiImage)
-        }
-        guard let uiImage = UIImage(named: "\(name).png") else {
-            throw EVYError.imageLoadFailed(name: name)
-        }
-        return Image(uiImage: uiImage)
+    guard let uiImage = UIImage(named: "\(name).png") else {
+      throw EVYError.imageLoadFailed(name: name)
     }
-    
-    func writeImage(name: String, data: Data) throws {
-        guard let uiImage = UIImage(data: data) else {
-            throw EVYError.imageLoadFailed(name: name)
-        }
-        guard let pngData = uiImage.pngData() else {
-            throw EVYError.imageLoadFailed(name: name)
-        }
-        let fileUrl = cachesDirectoryUrl.appendingPathComponent("\(name).png")
-        try pngData.write(to: fileUrl)
+    return Image(uiImage: uiImage)
+  }
+
+  func writeImage(name: String, data: Data) throws {
+    guard let uiImage = UIImage(data: data) else {
+      throw EVYError.imageLoadFailed(name: name)
     }
+    guard let pngData = uiImage.pngData() else {
+      throw EVYError.imageLoadFailed(name: name)
+    }
+    let fileUrl = cachesDirectoryUrl.appendingPathComponent("\(name).png")
+    try pngData.write(to: fileUrl)
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
-		
-		return EVYSelectPhoto(title: "Photos Title",
-							  subtitle: "Photos: {count(photo_ids)}/10 - Chose your listing’s main photo first.",
-							  icon: "::image-plus::",
-							  content: "A great subtitle",
-							  data: "{photo_ids}",
-							  destination: "{photo_ids}")
-	}
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
+
+    return EVYSelectPhoto(
+      title: "Photos Title",
+      subtitle: "Photos: {count(photo_ids)}/10 - Chose your listing’s main photo first.",
+      icon: "::image-plus::",
+      content: "A great subtitle",
+      data: "{photo_ids}",
+      destination: "{photo_ids}")
+  }
 }

--- a/ios/evy/UI/Views/EVYTextField.swift
+++ b/ios/evy/UI/Views/EVYTextField.swift
@@ -8,143 +8,160 @@
 import SwiftUI
 
 struct EVYTextField: View {
-    let destination: String
-    let placeholder: String
-    let multiLine: Bool
-    let input: String
-    
-    @Bindable private var displayValue: EVYState<EVYValue>
-    @Bindable private var editableValue: EVYState<EVYValue>
-    @Bindable private var placeholderValue: EVYState<EVYValue>
-    
-    @FocusState private var focused: Bool
-    @State private var editing: Bool = false
-    
-    init(input: String, destination: String, placeholder: String, multiLine: Bool) {
-        self.input = input
-        self.placeholder = placeholder
-        self.destination = destination
-        self.multiLine = multiLine
-        
-        let inputWatchTarget = EVY.watchTarget(for: input)
-        let placeholderWatchTarget = EVY.watchTarget(for: placeholder)
-        
-        self.displayValue = EVYState(watch: inputWatchTarget, setter: { _ in
-            Self.resolveValue(from: input)
-        })
-        self.editableValue = EVYState(watch: inputWatchTarget, setter: { _ in
-            Self.resolveValue(from: input, editing: true)
-        })
-        self.placeholderValue = EVYState(watch: placeholderWatchTarget, setter: { _ in
-            Self.resolveValue(from: placeholder)
-        })
-    }
-    
-    init(input: String, destination: String, placeholder: String) {
-        self.init(input: input,
-                  destination: destination,
-                  placeholder: placeholder,
-                  multiLine: false)
-    }
-    
-    private static func resolveValue(from text: String, editing: Bool = false) -> EVYValue {
-        if let resolvedValue = try? EVY.getValueFromText(text, editing: editing) {
-            return resolvedValue
-        }
-        if EVY.parsePropsFromText(text) == text {
-            return EVYValue(text, nil, nil)
-        }
-        return EVYValue("", nil, nil)
-    }
-    
-    var body: some View {
-        Group {
-            if !editing || destination.isEmpty {
-                let displayText = displayValue.value.toString()
-                let placeholderText = placeholderValue.value.toString()
+  let destination: String
+  let placeholder: String
+  let multiLine: Bool
+  let input: String
 
-                if !displayText.isEmpty {
-                    EVYTextView(displayText)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else if !placeholderText.isEmpty {
-                    EVYTextView(placeholderText, style: .info)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    // Spacer so the field stays tappable when display and placeholder are empty.
-                    Text(" ")
-                        .font(.evy)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            } else {
-                TextField(text: $editableValue.value.value,
-                          prompt: EVYTextView(placeholderValue.value.toString()).toText(),
-                          axis: multiLine ? .vertical : .horizontal,
-                          label: {})
-                .font(.evy)
-                .lineLimit(multiLine ? 10... : 1...)
-                .focused($focused)
-                .onChange(of: focused) { oldValue, newValue in
-                    if oldValue == true && newValue == false {
-                        editing = false
-                    }
-                }
-                .onChange(of: editableValue.value.value) { _, newValue in
-                    try? EVY.updateValue(newValue, at: destination)
-                }
-                .onSubmit {
-                    editing = false
-                    focused = false
-                }
-            }
-        }
-        .padding(EdgeInsets(top: Constants.fieldPadding,
-                            leading: Constants.minorPadding,
-                            bottom: Constants.fieldPadding,
-                            trailing: Constants.minorPadding))
-        .background(
-            RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
-                .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
-                .opacity(Constants.borderOpacity)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if !editing {
-                editing = true
-                focused = true
-            }
-        }
-        .accessibilityIdentifier("textField_\(destination)")
+  @Bindable private var displayValue: EVYState<EVYValue>
+  @Bindable private var editableValue: EVYState<EVYValue>
+  @Bindable private var placeholderValue: EVYState<EVYValue>
+
+  @FocusState private var focused: Bool
+  @State private var editing: Bool = false
+
+  init(input: String, destination: String, placeholder: String, multiLine: Bool) {
+    self.input = input
+    self.placeholder = placeholder
+    self.destination = destination
+    self.multiLine = multiLine
+
+    let inputWatchTarget = EVY.watchTarget(for: input)
+    let placeholderWatchTarget = EVY.watchTarget(for: placeholder)
+
+    self.displayValue = EVYState(
+      watch: inputWatchTarget,
+      setter: { _ in
+        Self.resolveValue(from: input)
+      })
+    self.editableValue = EVYState(
+      watch: inputWatchTarget,
+      setter: { _ in
+        Self.resolveValue(from: input, editing: true)
+      })
+    self.placeholderValue = EVYState(
+      watch: placeholderWatchTarget,
+      setter: { _ in
+        Self.resolveValue(from: placeholder)
+      })
+  }
+
+  init(input: String, destination: String, placeholder: String) {
+    self.init(
+      input: input,
+      destination: destination,
+      placeholder: placeholder,
+      multiLine: false)
+  }
+
+  private static func resolveValue(from text: String, editing: Bool = false) -> EVYValue {
+    if let resolvedValue = try? EVY.getValueFromText(text, editing: editing) {
+      return resolvedValue
     }
+    if EVY.parsePropsFromText(text) == text {
+      return EVYValue(text, nil, nil)
+    }
+    return EVYValue("", nil, nil)
+  }
+
+  var body: some View {
+    Group {
+      if !editing || destination.isEmpty {
+        let displayText = displayValue.value.toString()
+        let placeholderText = placeholderValue.value.toString()
+
+        if !displayText.isEmpty {
+          EVYTextView(displayText)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if !placeholderText.isEmpty {
+          EVYTextView(placeholderText, style: .info)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+          // Spacer so the field stays tappable when display and placeholder are empty.
+          Text(" ")
+            .font(.evy)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      } else {
+        TextField(
+          text: $editableValue.value.value,
+          prompt: EVYTextView(placeholderValue.value.toString()).toText(),
+          axis: multiLine ? .vertical : .horizontal,
+          label: {}
+        )
+        .font(.evy)
+        .lineLimit(multiLine ? 10... : 1...)
+        .focused($focused)
+        .onChange(of: focused) { oldValue, newValue in
+          if oldValue == true && newValue == false {
+            editing = false
+          }
+        }
+        .onChange(of: editableValue.value.value) { _, newValue in
+          try? EVY.updateValue(newValue, at: destination)
+        }
+        .onSubmit {
+          editing = false
+          focused = false
+        }
+      }
+    }
+    .padding(
+      EdgeInsets(
+        top: Constants.fieldPadding,
+        leading: Constants.minorPadding,
+        bottom: Constants.fieldPadding,
+        trailing: Constants.minorPadding)
+    )
+    .background(
+      RoundedRectangle(cornerRadius: Constants.smallCornerRadius)
+        .strokeBorder(Constants.borderColor, lineWidth: Constants.borderWidth)
+        .opacity(Constants.borderOpacity)
+    )
+    .contentShape(Rectangle())
+    .onTapGesture {
+      if !editing {
+        editing = true
+        focused = true
+      }
+    }
+    .accessibilityIdentifier("textField_\(destination)")
+  }
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! await EVY.createItem()
-		
-		return VStack {
-		EVYTextField(input: "{formatDimension(item.dimensions.width)}",
-					 destination: "{item.dimensions.width}",
-					 placeholder: "10",
-					 multiLine: true)
-		
-		EVYTextField(input: "{formatCurrency(item.price)}",
-					 destination: "{item.price}",
-					 placeholder: "10")
-					 
-		EVYTextField(input: "{item.title}",
-					 destination: "{item.title}",
-					 placeholder: "Sample placeholder",
-					 multiLine: true)
-		
-		EVYTextField(input: "{item.title}",
-					 destination: "{item.title}",
-					 placeholder: "Sample placeholder")
-			
-			EVYTextField(input: "",
-						 destination: "",
-						 placeholder: "Sample placeholder")
-		}
-	}
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! await EVY.createItem()
+
+    return VStack {
+      EVYTextField(
+        input: "{formatDimension(item.dimensions.width)}",
+        destination: "{item.dimensions.width}",
+        placeholder: "10",
+        multiLine: true)
+
+      EVYTextField(
+        input: "{formatCurrency(item.price)}",
+        destination: "{item.price}",
+        placeholder: "10")
+
+      EVYTextField(
+        input: "{item.title}",
+        destination: "{item.title}",
+        placeholder: "Sample placeholder",
+        multiLine: true)
+
+      EVYTextField(
+        input: "{item.title}",
+        destination: "{item.title}",
+        placeholder: "Sample placeholder")
+
+      EVYTextField(
+        input: "",
+        destination: "",
+        placeholder: "Sample placeholder")
+    }
+  }
 }

--- a/ios/evy/UI/Views/EVYTimeslotPicker.swift
+++ b/ios/evy/UI/Views/EVYTimeslotPicker.swift
@@ -7,94 +7,98 @@
 
 import SwiftUI
 
-let timeslotWidth: CGFloat = Constants.base*18
+let timeslotWidth: CGFloat = Constants.base * 18
 
 public struct EVYTimeslot: Decodable, Hashable {
-    let timeslot: String
-    let available: Bool
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(UUID().uuidString)
-    }
+  let timeslot: String
+  let available: Bool
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(UUID().uuidString)
+  }
 }
 public struct EVYTimeslotDate: Decodable {
-    let header: String
-    let date: String
-    let timeslots: [EVYTimeslot]
+  let header: String
+  let date: String
+  let timeslots: [EVYTimeslot]
 }
 
 struct EVYTimeslotColumn: View {
-    let timeslotDate: EVYTimeslotDate
-    let numberOfTimeslotsPerDay: Int
-    let action: () -> Void
-    
-    var body: some View {
-        VStack {
-            EVYTextView(timeslotDate.header)
-            EVYTextView(timeslotDate.date)
-            ForEach((0...(numberOfTimeslotsPerDay-1)), id: \.self) { timeslotIndex in
-                if timeslotDate.timeslots.count-1 < timeslotIndex {
-                    Button(action: action) {
-                        EVYRectangle.fixedWidth(content: EVYTextView("-"),
-                                                style: .clear,
-                                                width: timeslotWidth)
-                    }
-                }
-                else {
-                    let t = timeslotDate.timeslots[timeslotIndex]
-                    Button(action: action) {
-                        EVYRectangle.fixedWidth(content: EVYTextView(t.timeslot),
-                                                style: t.available ? .primary : .secondary,
-                                                width: timeslotWidth)
-                    }
-                }
-            }
+  let timeslotDate: EVYTimeslotDate
+  let numberOfTimeslotsPerDay: Int
+  let action: () -> Void
+
+  var body: some View {
+    VStack {
+      EVYTextView(timeslotDate.header)
+      EVYTextView(timeslotDate.date)
+      ForEach((0...(numberOfTimeslotsPerDay - 1)), id: \.self) { timeslotIndex in
+        if timeslotDate.timeslots.count - 1 < timeslotIndex {
+          Button(action: action) {
+            EVYRectangle.fixedWidth(
+              content: EVYTextView("-"),
+              style: .clear,
+              width: timeslotWidth)
+          }
+        } else {
+          let t = timeslotDate.timeslots[timeslotIndex]
+          Button(action: action) {
+            EVYRectangle.fixedWidth(
+              content: EVYTextView(t.timeslot),
+              style: t.available ? .primary : .secondary,
+              width: timeslotWidth)
+          }
         }
+      }
     }
+  }
 }
 
 struct EVYTimeslotPicker: View {
-    @State private var selectedGroupIndex: Int = 0
-    private var numberOfTimeslotsPerDay: Int = 0
-    
-    let timeslotDates: [EVYTimeslotDate]
-    
-    init(_ timeslotDates: [EVYTimeslotDate]) {
-        self.timeslotDates = timeslotDates
-        for index in 0...timeslotDates.count-1 {
-            if timeslotDates[index].timeslots.count > numberOfTimeslotsPerDay {
-                numberOfTimeslotsPerDay = timeslotDates[index].timeslots.count
-            }
-        }
-    }
-    
-    var body: some View {
-        let groupedDays = timeslotDates.chunked(with: 4)
+  @State private var selectedGroupIndex: Int = 0
+  private var numberOfTimeslotsPerDay: Int = 0
 
-        VStack {
-            TabView(selection:$selectedGroupIndex) {
-                    ForEach(groupedDays.indices, id: \.self) { index in
-                        HStack {
-                            ForEach(groupedDays[index], id: \.date) { timeslotDate in
-                                EVYTimeslotColumn(timeslotDate: timeslotDate,
-                                                  numberOfTimeslotsPerDay: numberOfTimeslotsPerDay,
-                                                  action: { print("test") })
-                                .padding(.horizontal, Constants.padding)
-                            }
-                        }
-                    }
-            }
-            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-            
-            EVYCarouselIndicator(indices: (0...groupedDays.count-1),
-                                 selectionIndex: selectedGroupIndex,
-                                 color: .black)
-        }
+  let timeslotDates: [EVYTimeslotDate]
+
+  init(_ timeslotDates: [EVYTimeslotDate]) {
+    self.timeslotDates = timeslotDates
+    for index in 0...timeslotDates.count - 1 {
+      if timeslotDates[index].timeslots.count > numberOfTimeslotsPerDay {
+        numberOfTimeslotsPerDay = timeslotDates[index].timeslots.count
+      }
     }
+  }
+
+  var body: some View {
+    let groupedDays = timeslotDates.chunked(with: 4)
+
+    VStack {
+      TabView(selection: $selectedGroupIndex) {
+        ForEach(groupedDays.indices, id: \.self) { index in
+          HStack {
+            ForEach(groupedDays[index], id: \.date) { timeslotDate in
+              EVYTimeslotColumn(
+                timeslotDate: timeslotDate,
+                numberOfTimeslotsPerDay: numberOfTimeslotsPerDay,
+                action: { print("test") }
+              )
+              .padding(.horizontal, Constants.padding)
+            }
+          }
+        }
+      }
+      .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+
+      EVYCarouselIndicator(
+        indices: (0...groupedDays.count - 1),
+        selectionIndex: selectedGroupIndex,
+        color: .black)
+    }
+  }
 }
 
 #Preview {
-    let json = """
+  let json = """
     [
         {
             "header": "Wed",
@@ -238,8 +242,8 @@ struct EVYTimeslotPicker: View {
         }
     ]
     """.data(using: .utf8)!
-    
-    let timeslotDates = try! JSONDecoder().decode([EVYTimeslotDate].self, from: json)
 
-    return EVYTimeslotPicker(timeslotDates)
+  let timeslotDates = try! JSONDecoder().decode([EVYTimeslotDate].self, from: json)
+
+  return EVYTimeslotPicker(timeslotDates)
 }

--- a/ios/evy/UI/Views/EVYZoomableContainer.swift
+++ b/ios/evy/UI/Views/EVYZoomableContainer.swift
@@ -8,111 +8,117 @@ import SwiftUI
 private let maxAllowedScale = 4.0
 
 struct EVYZoomableContainer<ZContent: View>: View {
-    let content: ZContent
+  let content: ZContent
 
-    @State private var currentScale: CGFloat = 1.0
-    @State private var tapLocation: CGPoint = .zero
+  @State private var currentScale: CGFloat = 1.0
+  @State private var tapLocation: CGPoint = .zero
 
-    init(@ViewBuilder content: () -> ZContent) {
-        self.content = content()
+  init(@ViewBuilder content: () -> ZContent) {
+    self.content = content()
+  }
+
+  func doubleTapAction(location: CGPoint) {
+    tapLocation = location
+    currentScale = currentScale == 1.0 ? maxAllowedScale : 1.0
+  }
+
+  var body: some View {
+    ZoomableScrollView(scale: $currentScale, tapLocation: $tapLocation) {
+      content
+    }
+    .onTapGesture(count: 2, perform: doubleTapAction)
+  }
+
+  fileprivate struct ZoomableScrollView<Content: View>: UIViewRepresentable {
+    private let content: Content
+    @Binding private var currentScale: CGFloat
+    @Binding private var tapLocation: CGPoint
+
+    init(
+      scale: Binding<CGFloat>, tapLocation: Binding<CGPoint>, @ViewBuilder content: () -> Content
+    ) {
+      _currentScale = scale
+      _tapLocation = tapLocation
+      self.content = content()
     }
 
-    func doubleTapAction(location: CGPoint) {
-        tapLocation = location
-        currentScale = currentScale == 1.0 ? maxAllowedScale : 1.0
+    func makeUIView(context: Context) -> UIScrollView {
+      // Setup the UIScrollView
+      let scrollView = UIScrollView()
+      scrollView.delegate = context.coordinator  // for viewForZooming(in:)
+      scrollView.maximumZoomScale = maxAllowedScale
+      scrollView.minimumZoomScale = 1
+      scrollView.bouncesZoom = true
+      scrollView.showsHorizontalScrollIndicator = false
+      scrollView.showsVerticalScrollIndicator = false
+      scrollView.clipsToBounds = false
+
+      // Create a UIHostingController to hold our SwiftUI content
+      let hostedView = context.coordinator.hostingController.view!
+      hostedView.translatesAutoresizingMaskIntoConstraints = true
+      hostedView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      hostedView.frame = scrollView.bounds
+      hostedView.backgroundColor = UIColor.black
+      scrollView.addSubview(hostedView)
+
+      return scrollView
     }
 
-    var body: some View {
-        ZoomableScrollView(scale: $currentScale, tapLocation: $tapLocation) {
-            content
-        }
-        .onTapGesture(count: 2, perform: doubleTapAction)
+    func makeCoordinator() -> Coordinator {
+      Coordinator(hostingController: UIHostingController(rootView: content), scale: $currentScale)
     }
 
-    fileprivate struct ZoomableScrollView<Content: View>: UIViewRepresentable {
-        private let content: Content
-        @Binding private var currentScale: CGFloat
-        @Binding private var tapLocation: CGPoint
+    func updateUIView(_ uiView: UIScrollView, context: Context) {
+      // Update the hosting controller's SwiftUI content
+      context.coordinator.hostingController.rootView = content
 
-        init(scale: Binding<CGFloat>, tapLocation: Binding<CGPoint>, @ViewBuilder content: () -> Content) {
-            _currentScale = scale
-            _tapLocation = tapLocation
-            self.content = content()
-        }
+      if uiView.zoomScale > uiView.minimumZoomScale {  // Scale out
+        uiView.setZoomScale(currentScale, animated: true)
+      } else if tapLocation != .zero {  // Scale in to a specific point
+        uiView.zoom(
+          to: zoomRect(for: uiView, scale: uiView.maximumZoomScale, center: tapLocation),
+          animated: true)
+        // Reset the location to prevent scaling to it in case of a negative scale (manual pinch)
+        // Use the main thread to prevent unexpected behavior
+        DispatchQueue.main.async { tapLocation = .zero }
+      }
 
-        func makeUIView(context: Context) -> UIScrollView {
-            // Setup the UIScrollView
-            let scrollView = UIScrollView()
-            scrollView.delegate = context.coordinator // for viewForZooming(in:)
-            scrollView.maximumZoomScale = maxAllowedScale
-            scrollView.minimumZoomScale = 1
-            scrollView.bouncesZoom = true
-            scrollView.showsHorizontalScrollIndicator = false
-            scrollView.showsVerticalScrollIndicator = false
-            scrollView.clipsToBounds = false
-
-            // Create a UIHostingController to hold our SwiftUI content
-            let hostedView = context.coordinator.hostingController.view!
-            hostedView.translatesAutoresizingMaskIntoConstraints = true
-            hostedView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            hostedView.frame = scrollView.bounds
-            hostedView.backgroundColor = UIColor.black
-            scrollView.addSubview(hostedView)
-
-            return scrollView
-        }
-
-        func makeCoordinator() -> Coordinator {
-            Coordinator(hostingController: UIHostingController(rootView: content), scale: $currentScale)
-        }
-
-        func updateUIView(_ uiView: UIScrollView, context: Context) {
-            // Update the hosting controller's SwiftUI content
-            context.coordinator.hostingController.rootView = content
-
-            if uiView.zoomScale > uiView.minimumZoomScale { // Scale out
-                uiView.setZoomScale(currentScale, animated: true)
-            } else if tapLocation != .zero { // Scale in to a specific point
-                uiView.zoom(to: zoomRect(for: uiView, scale: uiView.maximumZoomScale, center: tapLocation), animated: true)
-                // Reset the location to prevent scaling to it in case of a negative scale (manual pinch)
-                // Use the main thread to prevent unexpected behavior
-                DispatchQueue.main.async { tapLocation = .zero }
-            }
-
-            assert(context.coordinator.hostingController.view.superview == uiView)
-        }
-
-        // MARK: - Utils
-
-        func zoomRect(for scrollView: UIScrollView, scale: CGFloat, center: CGPoint) -> CGRect {
-            let scrollViewSize = scrollView.bounds.size
-
-            let width = scrollViewSize.width / scale
-            let height = scrollViewSize.height / scale
-            let x = center.x - (width / 2.0)
-            let y = center.y - (height / 2.0)
-
-            return CGRect(x: x, y: y, width: width, height: height)
-        }
-
-        // MARK: - Coordinator
-
-        class Coordinator: NSObject, UIScrollViewDelegate {
-            let hostingController: UIHostingController<Content>
-            @Binding var currentScale: CGFloat
-
-            init(hostingController: UIHostingController<Content>, scale: Binding<CGFloat>) {
-                self.hostingController = hostingController
-                _currentScale = scale
-            }
-
-            func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-                hostingController.view
-            }
-
-            func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
-                currentScale = scale
-            }
-        }
+      assert(context.coordinator.hostingController.view.superview == uiView)
     }
+
+    // MARK: - Utils
+
+    func zoomRect(for scrollView: UIScrollView, scale: CGFloat, center: CGPoint) -> CGRect {
+      let scrollViewSize = scrollView.bounds.size
+
+      let width = scrollViewSize.width / scale
+      let height = scrollViewSize.height / scale
+      let x = center.x - (width / 2.0)
+      let y = center.y - (height / 2.0)
+
+      return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    // MARK: - Coordinator
+
+    class Coordinator: NSObject, UIScrollViewDelegate {
+      let hostingController: UIHostingController<Content>
+      @Binding var currentScale: CGFloat
+
+      init(hostingController: UIHostingController<Content>, scale: Binding<CGFloat>) {
+        self.hostingController = hostingController
+        _currentScale = scale
+      }
+
+      func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        hostingController.view
+      }
+
+      func scrollViewDidEndZooming(
+        _ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat
+      ) {
+        currentScale = scale
+      }
+    }
+  }
 }

--- a/ios/evy/Utils/chunked.swift
+++ b/ios/evy/Utils/chunked.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 extension Array {
-    func chunked(with size: Int) -> [[Element]] {
-        stride(from: 0, to: count, by: size).map {
-            Array(self[$0 ..< Swift.min($0 + size, count)])
-        }
+  func chunked(with size: Int) -> [[Element]] {
+    stride(from: 0, to: count, by: size).map {
+      Array(self[$0..<Swift.min($0 + size, count)])
     }
+  }
 }

--- a/ios/evy/Utils/forEachRow.swift
+++ b/ios/evy/Utils/forEachRow.swift
@@ -6,20 +6,20 @@
 import Foundation
 
 func forEachRow(in page: UI_Page, visitor: (UI_Row) -> Void) {
-    for row in page.rows {
-        visit(row, visitor: visitor)
-    }
-    if let footer = page.footer {
-        visit(footer, visitor: visitor)
-    }
+  for row in page.rows {
+    visit(row, visitor: visitor)
+  }
+  if let footer = page.footer {
+    visit(footer, visitor: visitor)
+  }
 }
 
 private func visit(_ row: UI_Row, visitor: (UI_Row) -> Void) {
-    visitor(row)
-    for child in row.view.content.children {
-        visit(child, visitor: visitor)
-    }
-    if let child = row.view.content.child {
-        visit(child, visitor: visitor)
-    }
+  visitor(row)
+  for child in row.view.content.children {
+    visit(child, visitor: visitor)
+  }
+  if let child = row.view.content.child {
+    visit(child, visitor: visitor)
+  }
 }

--- a/ios/evy/Utils/functions.swift
+++ b/ios/evy/Utils/functions.swift
@@ -9,684 +9,734 @@ import Foundation
 import SwiftUI
 
 struct EVYFunctionOutput {
-    let value: String
-    let prefix: String?
-    let suffix: String?
+  let value: String
+  let prefix: String?
+  let suffix: String?
 }
 
 @MainActor
 func evyCount(_ args: String) throws -> EVYFunctionOutput {
-    let res = try EVY.getDataFromProps(args)
-    switch res {
-    case let .string(stringValue):
-        return EVYFunctionOutput(value: String(stringValue.count), prefix: nil, suffix: nil)
-    case let .array(arrayValue):
-        return EVYFunctionOutput(value: String(arrayValue.count), prefix: nil, suffix: nil)
-    case let .int(intValue):
-        return EVYFunctionOutput(value: String(intValue), prefix: nil, suffix: nil)
-    case let .decimal(decimalValue):
-        return EVYFunctionOutput(value: "\(decimalValue)", prefix: nil, suffix: nil)
-    default:
-        return EVYFunctionOutput(value: args, prefix: nil, suffix: nil)
-    }
+  let res = try EVY.getDataFromProps(args)
+  switch res {
+  case .string(let stringValue):
+    return EVYFunctionOutput(value: String(stringValue.count), prefix: nil, suffix: nil)
+  case .array(let arrayValue):
+    return EVYFunctionOutput(value: String(arrayValue.count), prefix: nil, suffix: nil)
+  case .int(let intValue):
+    return EVYFunctionOutput(value: String(intValue), prefix: nil, suffix: nil)
+  case .decimal(let decimalValue):
+    return EVYFunctionOutput(value: "\(decimalValue)", prefix: nil, suffix: nil)
+  default:
+    return EVYFunctionOutput(value: args, prefix: nil, suffix: nil)
+  }
 }
 
 @MainActor
 func evyLength(_ args: String) throws -> EVYFunctionOutput {
-    let res = try EVY.getDataFromProps(args)
-    switch res {
-    case let .string(stringValue):
-        return EVYFunctionOutput(value: String(stringValue.count), prefix: nil, suffix: nil)
-    default:
-        return EVYFunctionOutput(value: args, prefix: nil, suffix: nil)
-    }
+  let res = try EVY.getDataFromProps(args)
+  switch res {
+  case .string(let stringValue):
+    return EVYFunctionOutput(value: String(stringValue.count), prefix: nil, suffix: nil)
+  default:
+    return EVYFunctionOutput(value: args, prefix: nil, suffix: nil)
+  }
 }
 
 @MainActor
-func evyFormatCurrency(_ args: String,
-                       _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let res = try EVY.getDataFromProps(args)
-    
-    let rawValue: String
-    switch res {
-    case let .dictionary(dictValue):
-        guard let value = dictValue["value"] else {
-            throw EVYError.formatFailed(type: "currency", reason: "missing 'value' field")
-        }
-        rawValue = value.toString()
-    case let .string(stringValue):
-        rawValue = stringValue
-    case let .int(intValue):
-        rawValue = String(intValue)
-    case let .decimal(decimalValue):
-        rawValue = "\(decimalValue)"
-    default:
-        throw EVYError.formatFailed(type: "currency", reason: "expected dictionary, got \(res)")
+func evyFormatCurrency(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let res = try EVY.getDataFromProps(args)
+
+  let rawValue: String
+  switch res {
+  case .dictionary(let dictValue):
+    guard let value = dictValue["value"] else {
+      throw EVYError.formatFailed(type: "currency", reason: "missing 'value' field")
     }
-    
-    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    rawValue = value.toString()
+  case .string(let stringValue):
+    rawValue = stringValue
+  case .int(let intValue):
+    rawValue = String(intValue)
+  case .decimal(let decimalValue):
+    rawValue = "\(decimalValue)"
+  default:
+    throw EVYError.formatFailed(type: "currency", reason: "expected dictionary, got \(res)")
+  }
+
+  let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+  if trimmedValue.isEmpty {
+    return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
+  }
+  if editing {
+    return EVYFunctionOutput(value: trimmedValue, prefix: nil, suffix: nil)
+  }
+  guard let number = NumberFormatter().number(from: trimmedValue) else {
+    throw EVYError.formatFailed(
+      type: "currency", reason: "could not parse number from '\(trimmedValue)'")
+  }
+  return EVYFunctionOutput(
+    value: String(format: "%.2f", CGFloat(truncating: number)), prefix: "$", suffix: nil)
+}
+
+@MainActor
+func evyFormatDimension(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let res = try EVY.getDataFromProps(args)
+
+  let mm: Int
+  switch res {
+  case .int(let intValue):
+    mm = intValue
+  case .string(let stringValue):
+    let trimmedValue = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
     if trimmedValue.isEmpty {
-        return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
+      return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
     }
-    if editing {
-        return EVYFunctionOutput(value: trimmedValue, prefix: nil, suffix: nil)
+    guard let parsedValue = Int(trimmedValue) else {
+      throw EVYError.formatFailed(
+        type: "dimension", reason: "could not parse integer from '\(trimmedValue)'")
     }
-    guard let number = NumberFormatter().number(from: trimmedValue) else {
-        throw EVYError.formatFailed(type: "currency", reason: "could not parse number from '\(trimmedValue)'")
+    mm = parsedValue
+  default:
+    throw EVYError.formatFailed(type: "dimension", reason: "expected integer, got \(res)")
+  }
+
+  if editing {
+    return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+  }
+  if mm > 1000 {
+    let meters = Decimal(mm / 1000)
+    let truncatedMeters = NSDecimalNumber(decimal: meters).intValue
+    if meters == Decimal(integerLiteral: truncatedMeters) {
+      return EVYFunctionOutput(value: "\(truncatedMeters)", prefix: nil, suffix: "m")
     }
-    return EVYFunctionOutput(value: String(format: "%.2f", CGFloat(truncating: number)), prefix: "$", suffix: nil)
+    return EVYFunctionOutput(value: "\(meters)", prefix: nil, suffix: "m")
+  }
+  if mm > 100 {
+    let cm = Decimal(mm / 10)
+    let truncatedCM = NSDecimalNumber(decimal: cm).intValue
+    if cm == Decimal(integerLiteral: truncatedCM) {
+      return EVYFunctionOutput(value: "\(truncatedCM)", prefix: nil, suffix: "cm")
+    }
+    return EVYFunctionOutput(value: "\(cm)", prefix: nil, suffix: "cm")
+  }
+
+  let truncatedMM = NSDecimalNumber(integerLiteral: mm).intValue
+  if mm == truncatedMM {
+    return EVYFunctionOutput(value: "\(truncatedMM)", prefix: nil, suffix: "mm")
+  }
+  return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: "mm")
 }
 
 @MainActor
-func evyFormatDimension(_ args: String,
-                        _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let res = try EVY.getDataFromProps(args)
-    
-    let mm: Int
-    switch res {
-    case let .int(intValue):
-        mm = intValue
-    case let .string(stringValue):
-        let trimmedValue = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmedValue.isEmpty {
-            return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
-        }
-        guard let parsedValue = Int(trimmedValue) else {
-            throw EVYError.formatFailed(type: "dimension", reason: "could not parse integer from '\(trimmedValue)'")
-        }
-        mm = parsedValue
-    default:
-        throw EVYError.formatFailed(type: "dimension", reason: "expected integer, got \(res)")
-    }
-    
-    if editing {
-        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
-    }
-    if mm > 1000 {
-        let meters = Decimal(mm/1000)
-        let truncatedMeters = NSDecimalNumber(decimal: meters).intValue
-        if meters == Decimal(integerLiteral: truncatedMeters) {
-            return EVYFunctionOutput(value: "\(truncatedMeters)", prefix: nil, suffix: "m")
-        }
-        return EVYFunctionOutput(value: "\(meters)", prefix: nil, suffix: "m")
-    }
-    if mm > 100 {
-        let cm = Decimal(mm/10)
-        let truncatedCM = NSDecimalNumber(decimal: cm).intValue
-        if cm == Decimal(integerLiteral: truncatedCM) {
-            return EVYFunctionOutput(value: "\(truncatedCM)", prefix: nil, suffix: "cm")
-        }
-        return EVYFunctionOutput(value: "\(cm)", prefix: nil, suffix: "cm")
-    }
-    
-    let truncatedMM = NSDecimalNumber(integerLiteral: mm).intValue
-    if mm == truncatedMM {
-        return EVYFunctionOutput(value: "\(truncatedMM)", prefix: nil, suffix: "mm")
-    }
-    return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: "mm")
-}
+func evyFormatWeight(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let res = try EVY.getDataFromProps(args)
 
-@MainActor
-func evyFormatWeight(_ args: String,
-                     _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let res = try EVY.getDataFromProps(args)
-    
-    let rawValue: String
-    switch res {
-    case let .string(stringValue):
-        rawValue = stringValue
-    case let .int(intValue):
-        rawValue = String(intValue)
-    case let .decimal(decimalValue):
-        rawValue = "\(decimalValue)"
-    default:
-        throw EVYError.formatFailed(type: "weight", reason: "expected string or number, got \(res)")
+  let rawValue: String
+  switch res {
+  case .string(let stringValue):
+    rawValue = stringValue
+  case .int(let intValue):
+    rawValue = String(intValue)
+  case .decimal(let decimalValue):
+    rawValue = "\(decimalValue)"
+  default:
+    throw EVYError.formatFailed(type: "weight", reason: "expected string or number, got \(res)")
+  }
+
+  let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+  if trimmedValue.isEmpty {
+    return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
+  }
+  if editing {
+    return EVYFunctionOutput(value: trimmedValue, prefix: nil, suffix: nil)
+  }
+  guard let mg = Decimal(string: trimmedValue) else {
+    throw EVYError.formatFailed(
+      type: "weight", reason: "could not parse decimal from '\(trimmedValue)'")
+  }
+  if mg > 1_000_000 {
+    let kg = mg / 1_000_000
+    let truncatedKG = NSDecimalNumber(decimal: kg).intValue
+    if kg == Decimal(integerLiteral: truncatedKG) {
+      return EVYFunctionOutput(value: "\(truncatedKG)", prefix: nil, suffix: "kg")
     }
-    
-    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmedValue.isEmpty {
-        return EVYFunctionOutput(value: "", prefix: nil, suffix: nil)
+    return EVYFunctionOutput(value: "\(kg)", prefix: nil, suffix: "kg")
+  }
+  if mg > 1000 {
+    let gram = mg / 1000
+    let truncatedGram = NSDecimalNumber(decimal: gram).intValue
+    if gram == Decimal(integerLiteral: truncatedGram) {
+      return EVYFunctionOutput(value: "\(truncatedGram)", prefix: nil, suffix: "g")
     }
-    if editing {
-        return EVYFunctionOutput(value: trimmedValue, prefix: nil, suffix: nil)
-    }
-    guard let mg = Decimal(string: trimmedValue) else {
-        throw EVYError.formatFailed(type: "weight", reason: "could not parse decimal from '\(trimmedValue)'")
-    }
-    if mg > 1000000 {
-        let kg = mg/1000000
-        let truncatedKG = NSDecimalNumber(decimal: kg).intValue
-        if kg == Decimal(integerLiteral: truncatedKG) {
-            return EVYFunctionOutput(value: "\(truncatedKG)", prefix: nil, suffix: "kg")
-        }
-        return EVYFunctionOutput(value: "\(kg)", prefix: nil, suffix: "kg")
-    }
-    if mg > 1000 {
-        let gram = mg/1000
-        let truncatedGram = NSDecimalNumber(decimal: gram).intValue
-        if gram == Decimal(integerLiteral: truncatedGram) {
-            return EVYFunctionOutput(value: "\(truncatedGram)", prefix: nil, suffix: "g")
-        }
-        return EVYFunctionOutput(value: "\(gram)", prefix: nil, suffix: "g")
-    }
-    let truncatedMG = NSDecimalNumber(decimal: mg).intValue
-    if mg == Decimal(integerLiteral: truncatedMG) {
-        return EVYFunctionOutput(value: "\(truncatedMG)", prefix: nil, suffix: "mg")
-    }
-    return EVYFunctionOutput(value: "\(mg)", prefix: nil, suffix: "mg")
+    return EVYFunctionOutput(value: "\(gram)", prefix: nil, suffix: "g")
+  }
+  let truncatedMG = NSDecimalNumber(decimal: mg).intValue
+  if mg == Decimal(integerLiteral: truncatedMG) {
+    return EVYFunctionOutput(value: "\(truncatedMG)", prefix: nil, suffix: "mg")
+  }
+  return EVYFunctionOutput(value: "\(mg)", prefix: nil, suffix: "mg")
 }
 
 @MainActor
 func evyFormatAddress(_ args: String) throws -> EVYFunctionOutput {
-    let res = try EVY.getDataFromProps(args)
-    switch res {
-    case let .dictionary(dictValue):
-        guard let unit = dictValue["unit"],
-              let street = dictValue["street"],
-              let city = dictValue["city"],
-              let postcode = dictValue["postcode"],
-              let state = dictValue["state"]
-        else {
-            throw EVYError.formatFailed(type: "address", reason: "missing required fields (unit, street, city, postcode, or state)")
-        }
-
-        return EVYFunctionOutput(
-            value: String(format: "%@ %@, %@\n%@, %@",
-                          unit.toString(),
-                          street.toString(),
-                          postcode.toString(),
-                          city.toString(),
-                          state.toString()),
-            prefix: nil,
-            suffix: nil
-        )
-    default:
-        throw EVYError.formatFailed(type: "address", reason: "expected dictionary, got \(res)")
+  let res = try EVY.getDataFromProps(args)
+  switch res {
+  case .dictionary(let dictValue):
+    guard let unit = dictValue["unit"],
+      let street = dictValue["street"],
+      let city = dictValue["city"],
+      let postcode = dictValue["postcode"],
+      let state = dictValue["state"]
+    else {
+      throw EVYError.formatFailed(
+        type: "address", reason: "missing required fields (unit, street, city, postcode, or state)")
     }
+
+    return EVYFunctionOutput(
+      value: String(
+        format: "%@ %@, %@\n%@, %@",
+        unit.toString(),
+        street.toString(),
+        postcode.toString(),
+        city.toString(),
+        state.toString()),
+      prefix: nil,
+      suffix: nil
+    )
+  default:
+    throw EVYError.formatFailed(type: "address", reason: "expected dictionary, got \(res)")
+  }
 }
 
 @MainActor
 private func evyJsonFromFirstArgument(args: String, errorType: String) throws -> EVYJson {
-    let path = try evyTrimmedFirstPath(from: args, errorType: errorType)
-    return try EVY.getDataFromProps(path)
+  let path = try evyTrimmedFirstPath(from: args, errorType: errorType)
+  return try EVY.getDataFromProps(path)
 }
 
 @MainActor
 private func evyTrimmedFirstPath(from args: String, errorType: String) throws -> String {
-    let parts = splitFunctionArguments(args)
-    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
-        throw EVYError.formatFailed(type: errorType, reason: "missing value argument")
-    }
-    return path
+  let parts = splitFunctionArguments(args)
+  guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty
+  else {
+    throw EVYError.formatFailed(type: errorType, reason: "missing value argument")
+  }
+  return path
 }
 
 @MainActor
-func evyFormatDecimal(_ args: String,
-                      _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let parts = splitFunctionArguments(args)
-    guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
-        throw EVYError.formatFailed(type: "decimal", reason: "missing value argument")
+func evyFormatDecimal(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let parts = splitFunctionArguments(args)
+  guard let path = parts.first?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty
+  else {
+    throw EVYError.formatFailed(type: "decimal", reason: "missing value argument")
+  }
+  let places: Int
+  if parts.count >= 2 {
+    let rawPlaces = stripOptionalSurroundingQuotes(parts[1])
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let parsedPlaces = Int(rawPlaces), parsedPlaces >= 0, parsedPlaces <= 20 else {
+      throw EVYError.formatFailed(type: "decimal", reason: "invalid fraction digits '\(rawPlaces)'")
     }
-    let places: Int
-    if parts.count >= 2 {
-        let rawPlaces = stripOptionalSurroundingQuotes(parts[1])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsedPlaces = Int(rawPlaces), parsedPlaces >= 0, parsedPlaces <= 20 else {
-            throw EVYError.formatFailed(type: "decimal", reason: "invalid fraction digits '\(rawPlaces)'")
-        }
-        places = parsedPlaces
-    } else {
-        places = 2
-    }
+    places = parsedPlaces
+  } else {
+    places = 2
+  }
 
-    let res = try EVY.getDataFromProps(path)
-    let number = try evyDoubleValue(from: res, type: "decimal")
+  let res = try EVY.getDataFromProps(path)
+  let number = try evyDoubleValue(from: res, type: "decimal")
 
-    if editing {
-        return EVYFunctionOutput(value: evyPlainNumberString(number), prefix: nil, suffix: nil)
-    }
+  if editing {
+    return EVYFunctionOutput(value: evyPlainNumberString(number), prefix: nil, suffix: nil)
+  }
 
-    let formatter = NumberFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.minimumFractionDigits = max(0, places)
-    formatter.maximumFractionDigits = max(0, places)
-    formatter.roundingMode = .halfUp
-    formatter.numberStyle = .decimal
-    guard let formatted = formatter.string(from: NSNumber(value: number)) else {
-        throw EVYError.formatFailed(type: "decimal", reason: "could not format number")
-    }
-    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: nil)
+  let formatter = NumberFormatter()
+  formatter.locale = Locale(identifier: "en_US_POSIX")
+  formatter.minimumFractionDigits = max(0, places)
+  formatter.maximumFractionDigits = max(0, places)
+  formatter.roundingMode = .halfUp
+  formatter.numberStyle = .decimal
+  guard let formatted = formatter.string(from: NSNumber(value: number)) else {
+    throw EVYError.formatFailed(type: "decimal", reason: "could not format number")
+  }
+  return EVYFunctionOutput(value: formatted, prefix: nil, suffix: nil)
 }
 
 @MainActor
-func evyFormatMetricLength(_ args: String,
-                           _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let res = try evyJsonFromFirstArgument(args: args, errorType: "metricLength")
-    let mm = try evyMillimetres(from: res, errorType: "metricLength")
+func evyFormatMetricLength(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let res = try evyJsonFromFirstArgument(args: args, errorType: "metricLength")
+  let mm = try evyMillimetres(from: res, errorType: "metricLength")
 
-    if editing {
-        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
-    }
+  if editing {
+    return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+  }
 
-    let metres = Double(mm) / 1000.0
-    let formatted = String(format: "%.2f", metres)
-    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: "m")
+  let metres = Double(mm) / 1000.0
+  let formatted = String(format: "%.2f", metres)
+  return EVYFunctionOutput(value: formatted, prefix: nil, suffix: "m")
 }
 
 @MainActor
-func evyFormatImperialLength(_ args: String,
-                             _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let res = try evyJsonFromFirstArgument(args: args, errorType: "imperialLength")
-    let mm = try evyMillimetres(from: res, errorType: "imperialLength")
+func evyFormatImperialLength(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let res = try evyJsonFromFirstArgument(args: args, errorType: "imperialLength")
+  let mm = try evyMillimetres(from: res, errorType: "imperialLength")
 
-    if editing {
-        return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
-    }
+  if editing {
+    return EVYFunctionOutput(value: "\(mm)", prefix: nil, suffix: nil)
+  }
 
-    let feet = Double(mm) / 304.8
-    let formatted = String(format: "%.2f", feet)
-    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: "ft")
+  let feet = Double(mm) / 304.8
+  let formatted = String(format: "%.2f", feet)
+  return EVYFunctionOutput(value: formatted, prefix: nil, suffix: "ft")
 }
 
 @MainActor
-func evyFormatDuration(_ args: String,
-                       _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let res = try evyJsonFromFirstArgument(args: args, errorType: "duration")
-    let ms = try evyMilliseconds(from: res)
+func evyFormatDuration(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let res = try evyJsonFromFirstArgument(args: args, errorType: "duration")
+  let ms = try evyMilliseconds(from: res)
 
-    if editing {
-        return EVYFunctionOutput(value: "\(ms)", prefix: nil, suffix: nil)
-    }
+  if editing {
+    return EVYFunctionOutput(value: "\(ms)", prefix: nil, suffix: nil)
+  }
 
-    let label = evyHumanizeDuration(milliseconds: ms)
-    return EVYFunctionOutput(value: label, prefix: nil, suffix: nil)
+  let label = evyHumanizeDuration(milliseconds: ms)
+  return EVYFunctionOutput(value: label, prefix: nil, suffix: nil)
 }
 
 @MainActor
-func evyFormatDate(_ args: String,
-                   _ editing: Bool = false) throws -> EVYFunctionOutput {
-    let parts = splitFunctionArguments(args)
-    guard parts.count >= 2 else {
-        throw EVYError.formatFailed(type: "date", reason: "expected value and format pattern")
-    }
-    let path = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !path.isEmpty else {
-        throw EVYError.formatFailed(type: "date", reason: "missing value argument")
-    }
-    let pattern = evyNormalizeDateFormatPattern(
-        stripOptionalSurroundingQuotes(parts[1])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    )
-    guard !path.isEmpty, !pattern.isEmpty else {
-        throw EVYError.formatFailed(type: "date", reason: "missing value or format pattern")
-    }
+func evyFormatDate(
+  _ args: String,
+  _ editing: Bool = false
+) throws -> EVYFunctionOutput {
+  let parts = splitFunctionArguments(args)
+  guard parts.count >= 2 else {
+    throw EVYError.formatFailed(type: "date", reason: "expected value and format pattern")
+  }
+  let path = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !path.isEmpty else {
+    throw EVYError.formatFailed(type: "date", reason: "missing value argument")
+  }
+  let pattern = evyNormalizeDateFormatPattern(
+    stripOptionalSurroundingQuotes(parts[1])
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  )
+  guard !path.isEmpty, !pattern.isEmpty else {
+    throw EVYError.formatFailed(type: "date", reason: "missing value or format pattern")
+  }
 
-    let res = try EVY.getDataFromProps(path)
-    let isoString = try evyIso8601String(from: res, type: "date")
+  let res = try EVY.getDataFromProps(path)
+  let isoString = try evyIso8601String(from: res, type: "date")
 
-    if editing {
-        return EVYFunctionOutput(value: isoString, prefix: nil, suffix: nil)
-    }
+  if editing {
+    return EVYFunctionOutput(value: isoString, prefix: nil, suffix: nil)
+  }
 
-    let date = try evyParseIso8601Date(isoString)
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
-    formatter.dateFormat = pattern
-    let formatted = formatter.string(from: date)
-    return EVYFunctionOutput(value: formatted, prefix: nil, suffix: nil)
+  let date = try evyParseIso8601Date(isoString)
+  let formatter = DateFormatter()
+  formatter.locale = Locale(identifier: "en_US_POSIX")
+  formatter.timeZone = TimeZone(secondsFromGMT: 0)
+  formatter.dateFormat = pattern
+  let formatted = formatter.string(from: date)
+  return EVYFunctionOutput(value: formatted, prefix: nil, suffix: nil)
 }
 
 @MainActor
-func evyBuildCurrency(_ args: String,
-                      _ value: String) throws -> Data {
-    let existingCurrency = evyExistingCurrency(for: args) ?? "AUD"
-    let builtCurrency = EVYJson.dictionary([
-        "currency": .string(existingCurrency),
-        "value": evyJsonValue(from: value)
-    ])
-    return try JSONEncoder().encode(builtCurrency)
+func evyBuildCurrency(
+  _ args: String,
+  _ value: String
+) throws -> Data {
+  let existingCurrency = evyExistingCurrency(for: args) ?? "AUD"
+  let builtCurrency = EVYJson.dictionary([
+    "currency": .string(existingCurrency),
+    "value": evyJsonValue(from: value),
+  ])
+  return try JSONEncoder().encode(builtCurrency)
 }
 
 @MainActor
-func evyBuildAddress(_ args: String,
-                     _ value: String) throws -> Data {
-    let existingData = try? EVY.getDataFromProps(args)
-    let existingAddress: [String: EVYJson]
-    if case let .dictionary(dictValue) = existingData {
-        existingAddress = dictValue
-    } else {
-        existingAddress = [:]
-    }
-    
-    let builtAddress = EVYJson.dictionary(
-        evyAddressFields(from: value, existingAddress: existingAddress)
-    )
-    return try JSONEncoder().encode(builtAddress)
+func evyBuildAddress(
+  _ args: String,
+  _ value: String
+) throws -> Data {
+  let existingData = try? EVY.getDataFromProps(args)
+  let existingAddress: [String: EVYJson]
+  if case .dictionary(let dictValue) = existingData {
+    existingAddress = dictValue
+  } else {
+    existingAddress = [:]
+  }
+
+  let builtAddress = EVYJson.dictionary(
+    evyAddressFields(from: value, existingAddress: existingAddress)
+  )
+  return try JSONEncoder().encode(builtAddress)
 }
 
 private func evyDoubleValue(from json: EVYJson, type: String) throws -> Double {
-    switch json {
-    case let .int(intValue):
-        return Double(intValue)
-    case let .decimal(decimalValue):
-        return NSDecimalNumber(decimal: decimalValue).doubleValue
-    case let .string(stringValue):
-        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsed = Double(trimmed) else {
-            throw EVYError.formatFailed(type: type, reason: "could not parse number from '\(trimmed)'")
-        }
-        return parsed
-    default:
-        throw EVYError.formatFailed(type: type, reason: "expected number, got \(json)")
+  switch json {
+  case .int(let intValue):
+    return Double(intValue)
+  case .decimal(let decimalValue):
+    return NSDecimalNumber(decimal: decimalValue).doubleValue
+  case .string(let stringValue):
+    let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let parsed = Double(trimmed) else {
+      throw EVYError.formatFailed(type: type, reason: "could not parse number from '\(trimmed)'")
     }
+    return parsed
+  default:
+    throw EVYError.formatFailed(type: type, reason: "expected number, got \(json)")
+  }
 }
 
 private func evyPlainNumberString(_ value: Double) -> String {
-    if value.truncatingRemainder(dividingBy: 1) == 0, value <= Double(Int.max), value >= Double(Int.min) {
-        return String(Int(value))
-    }
-    return "\(value)"
+  if value.truncatingRemainder(dividingBy: 1) == 0, value <= Double(Int.max),
+    value >= Double(Int.min)
+  {
+    return String(Int(value))
+  }
+  return "\(value)"
 }
 
 private func evyMillimetres(from json: EVYJson, errorType: String) throws -> Int {
-    switch json {
-    case let .int(intValue):
-        return intValue
-    case let .string(stringValue):
-        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            throw EVYError.formatFailed(type: errorType, reason: "empty millimetre value")
-        }
-        guard let mm = Int(trimmed) else {
-            throw EVYError.formatFailed(type: errorType, reason: "could not parse integer from '\(trimmed)'")
-        }
-        return mm
-    default:
-        throw EVYError.formatFailed(type: errorType, reason: "expected integer millimetres, got \(json)")
+  switch json {
+  case .int(let intValue):
+    return intValue
+  case .string(let stringValue):
+    let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      throw EVYError.formatFailed(type: errorType, reason: "empty millimetre value")
     }
+    guard let mm = Int(trimmed) else {
+      throw EVYError.formatFailed(
+        type: errorType, reason: "could not parse integer from '\(trimmed)'")
+    }
+    return mm
+  default:
+    throw EVYError.formatFailed(
+      type: errorType, reason: "expected integer millimetres, got \(json)")
+  }
 }
 
 private func evyMilliseconds(from json: EVYJson) throws -> Int64 {
-    switch json {
-    case let .int(intValue):
-        return Int64(intValue)
-    case let .decimal(decimalValue):
-        return NSDecimalNumber(decimal: decimalValue).int64Value
-    case let .string(stringValue):
-        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            throw EVYError.formatFailed(type: "duration", reason: "empty duration value")
-        }
-        guard let parsed = Int64(trimmed) else {
-            throw EVYError.formatFailed(type: "duration", reason: "could not parse integer from '\(trimmed)'")
-        }
-        return parsed
-    default:
-        throw EVYError.formatFailed(type: "duration", reason: "expected duration in milliseconds, got \(json)")
+  switch json {
+  case .int(let intValue):
+    return Int64(intValue)
+  case .decimal(let decimalValue):
+    return NSDecimalNumber(decimal: decimalValue).int64Value
+  case .string(let stringValue):
+    let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      throw EVYError.formatFailed(type: "duration", reason: "empty duration value")
     }
+    guard let parsed = Int64(trimmed) else {
+      throw EVYError.formatFailed(
+        type: "duration", reason: "could not parse integer from '\(trimmed)'")
+    }
+    return parsed
+  default:
+    throw EVYError.formatFailed(
+      type: "duration", reason: "expected duration in milliseconds, got \(json)")
+  }
 }
 
 private func evyHumanizeDuration(milliseconds: Int64) -> String {
-    let ms = max(milliseconds, 0)
-    let units: [(Int64, String, String)] = [
-        (86_400_000, "day", "days"),
-        (3_600_000, "hour", "hours"),
-        (60_000, "minute", "minutes"),
-        (1000, "second", "seconds"),
-    ]
-    for (unitMs, singular, plural) in units {
-        if ms >= unitMs {
-            let count = ms / unitMs
-            let label = count == 1 ? singular : plural
-            return "\(count) \(label)"
-        }
+  let ms = max(milliseconds, 0)
+  let units: [(Int64, String, String)] = [
+    (86_400_000, "day", "days"),
+    (3_600_000, "hour", "hours"),
+    (60_000, "minute", "minutes"),
+    (1000, "second", "seconds"),
+  ]
+  for (unitMs, singular, plural) in units {
+    if ms >= unitMs {
+      let count = ms / unitMs
+      let label = count == 1 ? singular : plural
+      return "\(count) \(label)"
     }
-    return "\(ms) milliseconds"
+  }
+  return "\(ms) milliseconds"
 }
 
 private func evyNormalizeDateFormatPattern(_ pattern: String) -> String {
-    var result = pattern
-    result = result.replacingOccurrences(of: "YYYY", with: "yyyy")
-    result = result.replacingOccurrences(of: "DD", with: "dd")
-    return result
+  var result = pattern
+  result = result.replacingOccurrences(of: "YYYY", with: "yyyy")
+  result = result.replacingOccurrences(of: "DD", with: "dd")
+  return result
 }
 
 private func evyIso8601String(from json: EVYJson, type: String) throws -> String {
-    switch json {
-    case let .string(stringValue):
-        let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            throw EVYError.formatFailed(type: type, reason: "empty date string")
-        }
-        return trimmed
-    default:
-        throw EVYError.formatFailed(type: type, reason: "expected ISO 8601 string, got \(json)")
+  switch json {
+  case .string(let stringValue):
+    let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      throw EVYError.formatFailed(type: type, reason: "empty date string")
     }
+    return trimmed
+  default:
+    throw EVYError.formatFailed(type: type, reason: "expected ISO 8601 string, got \(json)")
+  }
 }
 
 private func evyParseIso8601Date(_ isoString: String) throws -> Date {
-    let withFraction = ISO8601DateFormatter()
-    withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    if let date = withFraction.date(from: isoString) {
-        return date
-    }
-    let basic = ISO8601DateFormatter()
-    basic.formatOptions = [.withInternetDateTime]
-    if let date = basic.date(from: isoString) {
-        return date
-    }
-    throw EVYError.formatFailed(type: "date", reason: "could not parse ISO 8601 date '\(isoString)'")
+  let withFraction = ISO8601DateFormatter()
+  withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  if let date = withFraction.date(from: isoString) {
+    return date
+  }
+  let basic = ISO8601DateFormatter()
+  basic.formatOptions = [.withInternetDateTime]
+  if let date = basic.date(from: isoString) {
+    return date
+  }
+  throw EVYError.formatFailed(type: "date", reason: "could not parse ISO 8601 date '\(isoString)'")
 }
 
 private func evyNumericValue(_ value: String) -> Decimal? {
-    Decimal(string: value.trimmingCharacters(in: .whitespacesAndNewlines))
+  Decimal(string: value.trimmingCharacters(in: .whitespacesAndNewlines))
 }
 
 private func evyJsonValue(from value: String) -> EVYJson {
-    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmedValue.isEmpty {
-        return .string("")
-    }
-    if let intValue = Int(trimmedValue) {
-        return .int(intValue)
-    }
-    if let decimalValue = Decimal(string: trimmedValue) {
-        return .decimal(decimalValue)
-    }
-    return .string(trimmedValue)
+  let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+  if trimmedValue.isEmpty {
+    return .string("")
+  }
+  if let intValue = Int(trimmedValue) {
+    return .int(intValue)
+  }
+  if let decimalValue = Decimal(string: trimmedValue) {
+    return .decimal(decimalValue)
+  }
+  return .string(trimmedValue)
 }
 
 @MainActor
 private func evyExistingCurrency(for props: String) -> String? {
-    guard let existingData = try? EVY.getDataFromProps(props),
-          case let .dictionary(dictValue) = existingData,
-          let currencyValue = dictValue["currency"]
-    else {
-        return nil
-    }
-    return currencyValue.toString()
+  guard let existingData = try? EVY.getDataFromProps(props),
+    case .dictionary(let dictValue) = existingData,
+    let currencyValue = dictValue["currency"]
+  else {
+    return nil
+  }
+  return currencyValue.toString()
 }
 
-private func evyAddressFields(from value: String,
-                              existingAddress: [String: EVYJson]) -> [String: EVYJson] {
-    let requiredKeys = ["unit", "street", "city", "postcode", "state"]
-    var addressFields = existingAddress
-    
-    for key in requiredKeys where addressFields[key] == nil {
-        addressFields[key] = .string("")
-    }
-    
-    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    if trimmedValue.isEmpty {
-        return addressFields
-    }
-    
-    let parsedFields = evyParsedAddressFields(from: trimmedValue, existingAddress: addressFields)
-    for (key, parsedValue) in parsedFields {
-        addressFields[key] = .string(parsedValue)
-    }
-    
+private func evyAddressFields(
+  from value: String,
+  existingAddress: [String: EVYJson]
+) -> [String: EVYJson] {
+  let requiredKeys = ["unit", "street", "city", "postcode", "state"]
+  var addressFields = existingAddress
+
+  for key in requiredKeys where addressFields[key] == nil {
+    addressFields[key] = .string("")
+  }
+
+  let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+  if trimmedValue.isEmpty {
     return addressFields
+  }
+
+  let parsedFields = evyParsedAddressFields(from: trimmedValue, existingAddress: addressFields)
+  for (key, parsedValue) in parsedFields {
+    addressFields[key] = .string(parsedValue)
+  }
+
+  return addressFields
 }
 
-private func evyParsedAddressFields(from value: String,
-                                    existingAddress: [String: EVYJson]) -> [String: String] {
-    let normalizedValue = value.replacingOccurrences(of: "\r\n", with: "\n")
-    let lines = normalizedValue
-        .split(separator: "\n", omittingEmptySubsequences: true)
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-    
-    if lines.count >= 2 {
-        return evyParsedTwoLineAddress(
-            firstLine: lines[0],
-            secondLine: lines[1],
-            existingAddress: existingAddress
-        )
-    }
-    
-    let commaSeparatedParts = normalizedValue
-        .split(separator: ",", omittingEmptySubsequences: true)
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-    
-    if commaSeparatedParts.count >= 2 {
-        return evyParsedSingleLineAddress(
-            firstPart: commaSeparatedParts[0],
-            secondPart: commaSeparatedParts[1],
-            existingAddress: existingAddress
-        )
-    }
-    
-    return [
-        "unit": existingAddress["unit"]?.toString() ?? "",
-        "street": normalizedValue,
-        "city": existingAddress["city"]?.toString() ?? "",
-        "postcode": existingAddress["postcode"]?.toString() ?? "",
-        "state": existingAddress["state"]?.toString() ?? ""
-    ]
-}
+private func evyParsedAddressFields(
+  from value: String,
+  existingAddress: [String: EVYJson]
+) -> [String: String] {
+  let normalizedValue = value.replacingOccurrences(of: "\r\n", with: "\n")
+  let lines =
+    normalizedValue
+    .split(separator: "\n", omittingEmptySubsequences: true)
+    .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
 
-private func evyParsedTwoLineAddress(firstLine: String,
-                                     secondLine: String,
-                                     existingAddress: [String: EVYJson]) -> [String: String] {
-    let firstLineParts = firstLine
-        .split(separator: ",", omittingEmptySubsequences: true)
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-    let secondLineParts = secondLine
-        .split(separator: ",", omittingEmptySubsequences: true)
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-    
-    let unitAndStreet = evyAddressUnitAndStreet(
-        from: firstLineParts.first ?? firstLine,
-        existingAddress: existingAddress
+  if lines.count >= 2 {
+    return evyParsedTwoLineAddress(
+      firstLine: lines[0],
+      secondLine: lines[1],
+      existingAddress: existingAddress
     )
-    
-    return [
-        "unit": unitAndStreet.unit,
-        "street": unitAndStreet.street,
-        "city": secondLineParts.first ?? "",
-        "postcode": firstLineParts.count > 1 ? firstLineParts[1] : "",
-        "state": secondLineParts.count > 1 ? secondLineParts[1] : ""
-    ]
-}
+  }
 
-private func evyParsedSingleLineAddress(firstPart: String,
-                                        secondPart: String,
-                                        existingAddress: [String: EVYJson]) -> [String: String] {
-    let unitAndStreet = evyAddressUnitAndStreet(
-        from: firstPart,
-        existingAddress: existingAddress
+  let commaSeparatedParts =
+    normalizedValue
+    .split(separator: ",", omittingEmptySubsequences: true)
+    .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+
+  if commaSeparatedParts.count >= 2 {
+    return evyParsedSingleLineAddress(
+      firstPart: commaSeparatedParts[0],
+      secondPart: commaSeparatedParts[1],
+      existingAddress: existingAddress
     )
-    let locationParts = secondPart
-        .split(separator: " ", omittingEmptySubsequences: true)
-        .map(String.init)
-    
-    let postcode = locationParts.last ?? ""
-    let state = locationParts.count > 1 ? locationParts[locationParts.count - 2] : ""
-    let city = locationParts.count > 2
-        ? locationParts.dropLast(2).joined(separator: " ")
-        : ""
-    
-    return [
-        "unit": unitAndStreet.unit,
-        "street": unitAndStreet.street,
-        "city": city,
-        "postcode": postcode,
-        "state": state
-    ]
+  }
+
+  return [
+    "unit": existingAddress["unit"]?.toString() ?? "",
+    "street": normalizedValue,
+    "city": existingAddress["city"]?.toString() ?? "",
+    "postcode": existingAddress["postcode"]?.toString() ?? "",
+    "state": existingAddress["state"]?.toString() ?? "",
+  ]
 }
 
-private func evyAddressUnitAndStreet(from input: String,
-                                     existingAddress: [String: EVYJson]) -> (unit: String, street: String) {
-    let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
-    let existingStreet = existingAddress["street"]?.toString() ?? ""
-    
-    if !existingStreet.isEmpty, trimmedInput.hasSuffix(existingStreet) {
-        let unit = String(trimmedInput.dropLast(existingStreet.count))
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return (unit, existingStreet)
-    }
-    
-    let parts = trimmedInput.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
-    if parts.count == 2 {
-        return (String(parts[0]), String(parts[1]))
-    }
-    
-    return ("", trimmedInput)
+private func evyParsedTwoLineAddress(
+  firstLine: String,
+  secondLine: String,
+  existingAddress: [String: EVYJson]
+) -> [String: String] {
+  let firstLineParts =
+    firstLine
+    .split(separator: ",", omittingEmptySubsequences: true)
+    .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+  let secondLineParts =
+    secondLine
+    .split(separator: ",", omittingEmptySubsequences: true)
+    .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+
+  let unitAndStreet = evyAddressUnitAndStreet(
+    from: firstLineParts.first ?? firstLine,
+    existingAddress: existingAddress
+  )
+
+  return [
+    "unit": unitAndStreet.unit,
+    "street": unitAndStreet.street,
+    "city": secondLineParts.first ?? "",
+    "postcode": firstLineParts.count > 1 ? firstLineParts[1] : "",
+    "state": secondLineParts.count > 1 ? secondLineParts[1] : "",
+  ]
 }
 
-private func evyCompareValues<T: Comparable>(_ comparisonOperator: String,
-                                             left: T,
-                                             right: T) -> Bool
-{
-    switch comparisonOperator {
-    case "==":
-        return left == right
-    case "!=":
-        return left != right
-    case "<":
-        return left < right
-    case ">":
-        return left > right
-    case "<=":
-        return left <= right
-    case ">=":
-        return left >= right
-    default:
-        return false
-    }
+private func evyParsedSingleLineAddress(
+  firstPart: String,
+  secondPart: String,
+  existingAddress: [String: EVYJson]
+) -> [String: String] {
+  let unitAndStreet = evyAddressUnitAndStreet(
+    from: firstPart,
+    existingAddress: existingAddress
+  )
+  let locationParts =
+    secondPart
+    .split(separator: " ", omittingEmptySubsequences: true)
+    .map(String.init)
+
+  let postcode = locationParts.last ?? ""
+  let state = locationParts.count > 1 ? locationParts[locationParts.count - 2] : ""
+  let city =
+    locationParts.count > 2
+    ? locationParts.dropLast(2).joined(separator: " ")
+    : ""
+
+  return [
+    "unit": unitAndStreet.unit,
+    "street": unitAndStreet.street,
+    "city": city,
+    "postcode": postcode,
+    "state": state,
+  ]
+}
+
+private func evyAddressUnitAndStreet(
+  from input: String,
+  existingAddress: [String: EVYJson]
+) -> (unit: String, street: String) {
+  let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+  let existingStreet = existingAddress["street"]?.toString() ?? ""
+
+  if !existingStreet.isEmpty, trimmedInput.hasSuffix(existingStreet) {
+    let unit = String(trimmedInput.dropLast(existingStreet.count))
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return (unit, existingStreet)
+  }
+
+  let parts = trimmedInput.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+  if parts.count == 2 {
+    return (String(parts[0]), String(parts[1]))
+  }
+
+  return ("", trimmedInput)
+}
+
+private func evyCompareValues<T: Comparable>(
+  _ comparisonOperator: String,
+  left: T,
+  right: T
+) -> Bool {
+  switch comparisonOperator {
+  case "==":
+    return left == right
+  case "!=":
+    return left != right
+  case "<":
+    return left < right
+  case ">":
+    return left > right
+  case "<=":
+    return left <= right
+  case ">=":
+    return left >= right
+  default:
+    return false
+  }
 }
 
 func evyComparison(_ comparisonOperator: String, left: String, right: String) -> Bool {
-    if let leftNumber = evyNumericValue(left), let rightNumber = evyNumericValue(right) {
-        return evyCompareValues(comparisonOperator, left: leftNumber, right: rightNumber)
-    }
+  if let leftNumber = evyNumericValue(left), let rightNumber = evyNumericValue(right) {
+    return evyCompareValues(comparisonOperator, left: leftNumber, right: rightNumber)
+  }
 
-    return evyCompareValues(comparisonOperator, left: left, right: right)
+  return evyCompareValues(comparisonOperator, left: left, right: right)
 }
 
 #Preview {
-	AsyncPreview { asyncView in
-		asyncView
-	} view: {
-		try! EVY.getUserData()
-		try! await EVY.createItem()
-		
-		return VStack {
-		EVYTextView("{formatDimension(item.dimensions.width)}")
-		EVYTextView("a == a: {a == a}")
-		EVYTextView("a == b: {a == b}")
-		EVYTextView("1 == 2: {1 == 2}")
-		EVYTextView("1 == 1: {1 == 1}")
-		EVYTextView("1 != 1: {1 != 1}")
-		EVYTextView("title == Amazing: {{item.title} == Amazing}")
-		EVYTextView("title == Amazing Fridge: {{item.title} == Amazing Fridge}")
-		EVYTextView("Amazing Fridge == title: {Amazing Fridge == {item.title}}")
-		EVYTextView("count (title) == 13: {{count(item.title)} == 13}")
-		EVYTextView("count (title) == 14: {{count(item.title)} == 14}")
-		EVYTextView("count (title) > 0: {{count(item.title)} > 0}")
-		EVYTextView("{formatAddress(user.address)}")
-		}
-	}
-}
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! EVY.getUserData()
+    try! await EVY.createItem()
 
+    return VStack {
+      EVYTextView("{formatDimension(item.dimensions.width)}")
+      EVYTextView("a == a: {a == a}")
+      EVYTextView("a == b: {a == b}")
+      EVYTextView("1 == 2: {1 == 2}")
+      EVYTextView("1 == 1: {1 == 1}")
+      EVYTextView("1 != 1: {1 != 1}")
+      EVYTextView("title == Amazing: {{item.title} == Amazing}")
+      EVYTextView("title == Amazing Fridge: {{item.title} == Amazing Fridge}")
+      EVYTextView("Amazing Fridge == title: {Amazing Fridge == {item.title}}")
+      EVYTextView("count (title) == 13: {{count(item.title)} == 13}")
+      EVYTextView("count (title) == 14: {{count(item.title)} == 14}")
+      EVYTextView("count (title) > 0: {{count(item.title)} > 0}")
+      EVYTextView("{formatAddress(user.address)}")
+    }
+  }
+}

--- a/ios/evy/Utils/hasDynamicIsland.swift
+++ b/ios/evy/Utils/hasDynamicIsland.swift
@@ -8,15 +8,20 @@
 import UIKit
 
 extension UIDevice {
-    var hasDynamicIsland: Bool {
-        guard userInterfaceIdiom == .phone else {
-            return false
-        }
-               
-        guard let window = (UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap { $0.windows }.first { $0.isKeyWindow}) else {
-            return false
-        }
-       
-        return window.safeAreaInsets.top >= 50
+  var hasDynamicIsland: Bool {
+    guard userInterfaceIdiom == .phone else {
+      return false
     }
+
+    guard
+      let window =
+        (UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap {
+          $0.windows
+        }.first { $0.isKeyWindow })
+    else {
+      return false
+    }
+
+    return window.safeAreaInsets.top >= 50
+  }
 }

--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -19,596 +19,612 @@ public let PROP_SEPARATOR = "."
 
 @MainActor
 public func parsePropsFromText(_ input: String) -> String {
-    _parsePropsFromText(input)
+  _parsePropsFromText(input)
 }
 
 @MainActor
 public func splitPropsFromText(_ props: String) throws -> [String] {
-    if props.count < 1 {
-        throw EVYParamError.invalidProps
-    }
+  if props.count < 1 {
+    throw EVYParamError.invalidProps
+  }
 
-    var splitProps = props.components(separatedBy: PROP_SEPARATOR)
-    if splitProps.count < 1 {
-        throw EVYParamError.invalidProps
-    }
-    for i in splitProps.indices {
-        if let matchArray = try? firstMatch(splitProps[i],
-                                            pattern: arrayPattern)
-        {
-            splitProps[i].removeSubrange(matchArray.range)
+  var splitProps = props.components(separatedBy: PROP_SEPARATOR)
+  if splitProps.count < 1 {
+    throw EVYParamError.invalidProps
+  }
+  for i in splitProps.indices {
+    if let matchArray = try? firstMatch(
+      splitProps[i],
+      pattern: arrayPattern)
+    {
+      splitProps[i].removeSubrange(matchArray.range)
 
-            let matchIndex = String(matchArray.0.dropFirst().dropLast())
-            splitProps.insert(matchIndex, at: i + 1)
-        }
+      let matchIndex = String(matchArray.0.dropFirst().dropLast())
+      splitProps.insert(matchIndex, at: i + 1)
     }
-    return splitProps
+  }
+  return splitProps
 }
 
 @MainActor
-func parseTextFromText(_ input: String,
-                       _ editing: Bool = false) throws -> EVYValue
-{
-    try parseText(EVYValue(input, nil, nil), editing)
+func parseTextFromText(
+  _ input: String,
+  _ editing: Bool = false
+) throws -> EVYValue {
+  try parseText(EVYValue(input, nil, nil), editing)
 }
 
 @MainActor
 public func parseFunctionCall(_ input: String) -> (functionName: String, functionArgs: String)? {
-    let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
-    if let (_, functionName, functionArgs) = parseFunctionInText(trimmedInput) {
-        return (functionName, functionArgs)
-    }
-    return nil
+  let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+  if let (_, functionName, functionArgs) = parseFunctionInText(trimmedInput) {
+    return (functionName, functionArgs)
+  }
+  return nil
 }
 
 @MainActor
 func splitFunctionArguments(_ args: String) -> [String] {
-    var components: [String] = []
-    var current = ""
-    var depth = 0
-    var inString = false
+  var components: [String] = []
+  var current = ""
+  var depth = 0
+  var inString = false
 
-    for ch in args {
-        if inString {
-            current.append(ch)
-            if ch == "\"" {
-                inString = false
-            }
-            continue
-        }
-
-        switch ch {
-        case "\"":
-            inString = true
-            current.append(ch)
-        case "(":
-            depth += 1
-            current.append(ch)
-        case ")":
-            depth -= 1
-            current.append(ch)
-        case "," where depth == 0:
-            let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                components.append(trimmed)
-            }
-            current = ""
-        default:
-            current.append(ch)
-        }
+  for ch in args {
+    if inString {
+      current.append(ch)
+      if ch == "\"" {
+        inString = false
+      }
+      continue
     }
 
-    let trimmedTail = current.trimmingCharacters(in: .whitespacesAndNewlines)
-    if !trimmedTail.isEmpty {
-        components.append(trimmedTail)
+    switch ch {
+    case "\"":
+      inString = true
+      current.append(ch)
+    case "(":
+      depth += 1
+      current.append(ch)
+    case ")":
+      depth -= 1
+      current.append(ch)
+    case "," where depth == 0:
+      let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !trimmed.isEmpty {
+        components.append(trimmed)
+      }
+      current = ""
+    default:
+      current.append(ch)
     }
-    return components
+  }
+
+  let trimmedTail = current.trimmingCharacters(in: .whitespacesAndNewlines)
+  if !trimmedTail.isEmpty {
+    components.append(trimmedTail)
+  }
+  return components
 }
 
 @MainActor
 public func stripOptionalSurroundingQuotes(_ s: String) -> String {
-    let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard trimmed.count >= 2, trimmed.first == "\"", trimmed.last == "\"" else {
-        return trimmed
-    }
-    return String(trimmed.dropFirst().dropLast())
+  let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard trimmed.count >= 2, trimmed.first == "\"", trimmed.last == "\"" else {
+    return trimmed
+  }
+  return String(trimmed.dropFirst().dropLast())
 }
 
 @MainActor
 public func getDataFromText(_ input: String) throws -> EVYJson {
-    try _getDataFromText(input)
+  try _getDataFromText(input)
 }
 
 @MainActor
 public func getDataFromProps(_ props: String) throws -> EVYJson {
-    try _getDataFromProps(props)
+  try _getDataFromProps(props)
 }
 
 @MainActor
 func getValueFromText(_ input: String, editing: Bool = false) throws -> EVYValue {
-    try _getValueFromText(input, editing: editing)
+  try _getValueFromText(input, editing: editing)
 }
 
 @MainActor
 public func watchTarget(for text: String) -> String {
-    _watchTarget(for: text)
+  _watchTarget(for: text)
 }
 
 @MainActor
 public func evaluateFromText(_ input: String) throws -> Bool {
-    try _evaluateFromText(input)
+  try _evaluateFromText(input)
 }
 
 @MainActor
 public func formatData(json: EVYJson, format: String) throws -> String {
-    try _formatData(json: json, format: format)
+  try _formatData(json: json, format: format)
 }
 
 // MARK: - Internal
 
 @MainActor
 func _parsePropsFromText(_ input: String) -> String {
-    guard let match = try? firstMatch(input, pattern: propsPattern) else {
-        return input
-    }
+  guard let match = try? firstMatch(input, pattern: propsPattern) else {
+    return input
+  }
 
-    return String(match.0.dropFirst().dropLast())
+  return String(match.0.dropFirst().dropLast())
 }
 
 @MainActor
 func _getDataFromText(_ input: String) throws -> EVYJson {
-    let props = _parsePropsFromText(input)
-    return try _getDataFromProps(props)
+  let props = _parsePropsFromText(input)
+  return try _getDataFromProps(props)
 }
 
 @MainActor
 func _getDataFromProps(_ props: String) throws -> EVYJson {
-    let splitProps = try splitPropsFromText(props)
-    guard let firstProp = splitProps.first else {
-        throw EVYParamError.invalidProps
-    }
+  let splitProps = try splitPropsFromText(props)
+  guard let firstProp = splitProps.first else {
+    throw EVYParamError.invalidProps
+  }
 
-    if let scopeId = EVY.data.activeDraftScopeId,
-       let draftBinding = try? EVY.data.draftBinding(fromParsedProps: props, scopeId: scopeId),
-       let draftRow = EVY.data.draftIfPresent(binding: draftBinding)
-    {
-        let remaining = EVYDraft.remainingPropsAfterDraftPrefix(
-            splitProps: splitProps,
-            binding: draftBinding
-        )
-        return try draftRow.decoded().parseProp(props: remaining)
-    }
+  if let scopeId = EVY.data.activeDraftScopeId,
+    let draftBinding = try? EVY.data.draftBinding(fromParsedProps: props, scopeId: scopeId),
+    let draftRow = EVY.data.draftIfPresent(binding: draftBinding)
+  {
+    let remaining = EVYDraft.remainingPropsAfterDraftPrefix(
+      splitProps: splitProps,
+      binding: draftBinding
+    )
+    return try draftRow.decoded().parseProp(props: remaining)
+  }
 
-    let remainingProps = splitProps.count > 1 ? Array(splitProps[1...]) : []
-    let dataObj = try EVY.data.getForBinding(key: firstProp)
-    return try dataObj.decoded().parseProp(props: remainingProps)
+  let remainingProps = splitProps.count > 1 ? Array(splitProps[1...]) : []
+  let dataObj = try EVY.data.getForBinding(key: firstProp)
+  return try dataObj.decoded().parseProp(props: remainingProps)
 }
 
 @MainActor
 func _getValueFromText(_ input: String, editing: Bool = false) throws -> EVYValue {
-    let match = try parseTextFromText(input, editing)
-    return EVYValue(match.value, match.prefix, match.suffix)
+  let match = try parseTextFromText(input, editing)
+  return EVYValue(match.value, match.prefix, match.suffix)
 }
 
 @MainActor
 func _watchTarget(for text: String) -> String {
-    let unwrapped = _parsePropsFromText(text)
-    let candidates: [String] = unwrapped == text ? [text] : [unwrapped, text]
-    for candidate in candidates {
-        if let functionCall = parseFunctionCall(candidate) {
-            let parts = splitFunctionArguments(functionCall.functionArgs)
-            if let first = parts.first, !first.isEmpty {
-                return stripOptionalSurroundingQuotes(first)
-            }
-            return functionCall.functionArgs
-        }
+  let unwrapped = _parsePropsFromText(text)
+  let candidates: [String] = unwrapped == text ? [text] : [unwrapped, text]
+  for candidate in candidates {
+    if let functionCall = parseFunctionCall(candidate) {
+      let parts = splitFunctionArguments(functionCall.functionArgs)
+      if let first = parts.first, !first.isEmpty {
+        return stripOptionalSurroundingQuotes(first)
+      }
+      return functionCall.functionArgs
     }
-    if unwrapped != text {
-        return unwrapped
-    }
-    return text
+  }
+  if unwrapped != text {
+    return unwrapped
+  }
+  return text
 }
 
 @MainActor
 func _evaluateFromText(_ input: String) throws -> Bool {
-    let match = try parseTextFromText(input)
-    return match.value == "true"
+  let match = try parseTextFromText(input)
+  return match.value == "true"
 }
 
 @MainActor
 func _formatData(json: EVYJson, format: String) throws -> String {
-	if format.count < 1 { return "" }
+  if format.count < 1 { return "" }
 
-    let temporaryId = UUID().uuidString
-    let formatWithNewData = format
-        .replacingOccurrences(of: "$datum:", with: "\(temporaryId).")
+  let temporaryId = UUID().uuidString
+  let formatWithNewData =
+    format
+    .replacingOccurrences(of: "$datum:", with: "\(temporaryId).")
 
-    if formatWithNewData.isEmpty { return "" }
+  if formatWithNewData.isEmpty { return "" }
 
-    let encodedData = try JSONEncoder().encode(json)
-    try EVY.data.create(key: temporaryId, data: encodedData)
-    let returnText = try _getValueFromText(formatWithNewData)
-    try EVY.data.delete(key: temporaryId)
-    return returnText.toString()
+  let encodedData = try JSONEncoder().encode(json)
+  try EVY.data.create(key: temporaryId, data: encodedData)
+  let returnText = try _getValueFromText(formatWithNewData)
+  try EVY.data.delete(key: temporaryId)
+  return returnText.toString()
 }
 
 // MARK: - Private parsing
 
 @MainActor
-private func parseText(_ input: EVYValue,
-                       _ editing: Bool) throws -> EVYValue
-{
-    if input.value.isEmpty {
-        return input
-    }
-
-    if let (fullMatch, comparison) = parseComparisonFromText(input.value)
-    {
-        let comparisonResult = try evaluateBooleanExpression(comparison) { operand in
-            let trimmedOperand = operand.trimmingCharacters(in: .whitespacesAndNewlines)
-            let parsedOperand = try parseText(EVYValue(trimmedOperand, nil, nil),
-                                                editing)
-            if parsedOperand.value != trimmedOperand {
-                return parsedOperand.value
-            }
-            if let propsValue = try? _getDataFromText("{\(trimmedOperand)}") {
-                return propsValue.toString()
-            }
-            return parsedOperand.value
-        }
-        let parsedInput = input.value.replacingOccurrences(
-            of: fullMatch,
-            with: comparisonResult ? "true" : "false"
-        )
-        return try parseText(EVYValue(parsedInput, input.prefix, input.suffix),
-                             editing)
-    }
-
-    if let (match, funcName, funcArgs) =
-        parseFunctionFromText(input.value)
-        ?? parseFunctionInText(input.value)
-    {
-        let returnPrefix = match.startIndex == 0
-        let upperBound = match.range.upperBound.utf16Offset(in: input.value)
-        let returnSuffix = upperBound == input.value.count
-
-        let value: EVYFunctionOutput?
-
-        switch funcName {
-        case "count":
-            value = try evyCount(funcArgs)
-        case "length":
-            value = try evyLength(funcArgs)
-        case "formatCurrency":
-            value = try evyFormatCurrency(funcArgs, editing)
-        case "formatDimension":
-            value = try evyFormatDimension(funcArgs, editing)
-        case "formatWeight":
-            value = try evyFormatWeight(funcArgs, editing)
-        case "formatAddress":
-            value = try evyFormatAddress(funcArgs)
-        case "formatDecimal":
-            value = try evyFormatDecimal(funcArgs, editing)
-        case "formatMetricLength":
-            value = try evyFormatMetricLength(funcArgs, editing)
-        case "formatImperialLength":
-            value = try evyFormatImperialLength(funcArgs, editing)
-        case "formatDuration":
-            value = try evyFormatDuration(funcArgs, editing)
-        case "formatDate":
-            value = try evyFormatDate(funcArgs, editing)
-        case "buildCurrency", "buildAddress":
-            value = nil
-        default:
-            value = nil
-        }
-
-        if let value = value {
-            let returnValuesToJoin = [
-                returnPrefix ? "" : value.prefix ?? "",
-                value.value,
-                returnSuffix ? "" : value.suffix ?? ""
-            ]
-            let parsedInput = input.value.replacingOccurrences(
-                of: match.0.description,
-                with: returnValuesToJoin.joined()
-            )
-            return try parseText(EVYValue(parsedInput,
-                                          returnPrefix ? value.prefix : input.prefix,
-                                          returnSuffix ? value.suffix : input.suffix),
-                                 editing)
-        }
-    }
-
-    if let (match, props) = parseProps(input.value) {
-        let data = try _getDataFromProps(props)
-        let parsedInput = input.value.replacingOccurrences(of: match.0.description,
-                                                           with: data.toString())
-        return try parseText(EVYValue(parsedInput, input.prefix, input.suffix),
-                             editing)
-    }
-
+private func parseText(
+  _ input: EVYValue,
+  _ editing: Bool
+) throws -> EVYValue {
+  if input.value.isEmpty {
     return input
+  }
+
+  if let (fullMatch, comparison) = parseComparisonFromText(input.value) {
+    let comparisonResult = try evaluateBooleanExpression(comparison) { operand in
+      let trimmedOperand = operand.trimmingCharacters(in: .whitespacesAndNewlines)
+      let parsedOperand = try parseText(
+        EVYValue(trimmedOperand, nil, nil),
+        editing)
+      if parsedOperand.value != trimmedOperand {
+        return parsedOperand.value
+      }
+      if let propsValue = try? _getDataFromText("{\(trimmedOperand)}") {
+        return propsValue.toString()
+      }
+      return parsedOperand.value
+    }
+    let parsedInput = input.value.replacingOccurrences(
+      of: fullMatch,
+      with: comparisonResult ? "true" : "false"
+    )
+    return try parseText(
+      EVYValue(parsedInput, input.prefix, input.suffix),
+      editing)
+  }
+
+  if let (match, funcName, funcArgs) =
+    parseFunctionFromText(input.value)
+    ?? parseFunctionInText(input.value)
+  {
+    let returnPrefix = match.startIndex == 0
+    let upperBound = match.range.upperBound.utf16Offset(in: input.value)
+    let returnSuffix = upperBound == input.value.count
+
+    let value: EVYFunctionOutput?
+
+    switch funcName {
+    case "count":
+      value = try evyCount(funcArgs)
+    case "length":
+      value = try evyLength(funcArgs)
+    case "formatCurrency":
+      value = try evyFormatCurrency(funcArgs, editing)
+    case "formatDimension":
+      value = try evyFormatDimension(funcArgs, editing)
+    case "formatWeight":
+      value = try evyFormatWeight(funcArgs, editing)
+    case "formatAddress":
+      value = try evyFormatAddress(funcArgs)
+    case "formatDecimal":
+      value = try evyFormatDecimal(funcArgs, editing)
+    case "formatMetricLength":
+      value = try evyFormatMetricLength(funcArgs, editing)
+    case "formatImperialLength":
+      value = try evyFormatImperialLength(funcArgs, editing)
+    case "formatDuration":
+      value = try evyFormatDuration(funcArgs, editing)
+    case "formatDate":
+      value = try evyFormatDate(funcArgs, editing)
+    case "buildCurrency", "buildAddress":
+      value = nil
+    default:
+      value = nil
+    }
+
+    if let value = value {
+      let returnValuesToJoin = [
+        returnPrefix ? "" : value.prefix ?? "",
+        value.value,
+        returnSuffix ? "" : value.suffix ?? "",
+      ]
+      let parsedInput = input.value.replacingOccurrences(
+        of: match.0.description,
+        with: returnValuesToJoin.joined()
+      )
+      return try parseText(
+        EVYValue(
+          parsedInput,
+          returnPrefix ? value.prefix : input.prefix,
+          returnSuffix ? value.suffix : input.suffix),
+        editing)
+    }
+  }
+
+  if let (match, props) = parseProps(input.value) {
+    let data = try _getDataFromProps(props)
+    let parsedInput = input.value.replacingOccurrences(
+      of: match.0.description,
+      with: data.toString())
+    return try parseText(
+      EVYValue(parsedInput, input.prefix, input.suffix),
+      editing)
+  }
+
+  return input
 }
 
 private func parseProps(_ input: String) -> (Regex<AnyRegexOutput>.Match, String)? {
-    if let match = try? firstMatch(input, pattern: propsPattern) {
-        return (match, String(match.0.dropFirst().dropLast()))
-    }
-    return nil
+  if let match = try? firstMatch(input, pattern: propsPattern) {
+    return (match, String(match.0.dropFirst().dropLast()))
+  }
+  return nil
 }
 
-private func parseComparisonFromText(_ input: String) -> (fullMatch: String, content: String)?
-{
-    guard let regex = try? Regex(comparisonBlockPattern) else {
-        return nil
-    }
-    for match in input.matches(of: regex) {
-        let block = String(match.0)
-        let comparison = String(block.dropFirst().dropLast())
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if containsTopLevelComparisonOperator(comparison) {
-            return (block, comparison)
-        }
-    }
+private func parseComparisonFromText(_ input: String) -> (fullMatch: String, content: String)? {
+  guard let regex = try? Regex(comparisonBlockPattern) else {
     return nil
+  }
+  for match in input.matches(of: regex) {
+    let block = String(match.0)
+    let comparison = String(block.dropFirst().dropLast())
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    if containsTopLevelComparisonOperator(comparison) {
+      return (block, comparison)
+    }
+  }
+  return nil
 }
 
-private func evaluateBooleanExpression(_ input: String,
-                                       resolver: (String) throws -> String) throws -> Bool
-{
-    let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
-    let orTerms = splitRespectingParens(trimmedInput, separator: "||")
-    if orTerms.count > 1 {
-        for term in orTerms {
-            if try evaluateBooleanExpression(term, resolver: resolver) {
-                return true
-            }
-        }
-        return false
-    }
-
-    let andTerms = splitRespectingParens(trimmedInput, separator: "&&")
-    if andTerms.count > 1 {
-        for term in andTerms {
-            if try !evaluateBooleanExpression(term, resolver: resolver) {
-                return false
-            }
-        }
+private func evaluateBooleanExpression(
+  _ input: String,
+  resolver: (String) throws -> String
+) throws -> Bool {
+  let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+  let orTerms = splitRespectingParens(trimmedInput, separator: "||")
+  if orTerms.count > 1 {
+    for term in orTerms {
+      if try evaluateBooleanExpression(term, resolver: resolver) {
         return true
+      }
     }
+    return false
+  }
 
-    if isWrappedInParentheses(trimmedInput) {
-        let innerExpression = String(trimmedInput.dropFirst().dropLast())
-        return try evaluateBooleanExpression(innerExpression, resolver: resolver)
-    }
-
-    if trimmedInput == "true" {
-        return true
-    }
-    if trimmedInput == "false" {
+  let andTerms = splitRespectingParens(trimmedInput, separator: "&&")
+  if andTerms.count > 1 {
+    for term in andTerms {
+      if try !evaluateBooleanExpression(term, resolver: resolver) {
         return false
+      }
     }
+    return true
+  }
 
-    guard let (left, comparisonOperator, right) = parseAtomicComparison(trimmedInput) else {
-        throw EVYError.invalidData(context: "Invalid comparison expression: \(trimmedInput)")
-    }
+  if isWrappedInParentheses(trimmedInput) {
+    let innerExpression = String(trimmedInput.dropFirst().dropLast())
+    return try evaluateBooleanExpression(innerExpression, resolver: resolver)
+  }
 
-    let resolvedLeft = try resolver(left)
-    let resolvedRight = try resolver(right)
-    return evyComparison(comparisonOperator, left: resolvedLeft, right: resolvedRight)
+  if trimmedInput == "true" {
+    return true
+  }
+  if trimmedInput == "false" {
+    return false
+  }
+
+  guard let (left, comparisonOperator, right) = parseAtomicComparison(trimmedInput) else {
+    throw EVYError.invalidData(context: "Invalid comparison expression: \(trimmedInput)")
+  }
+
+  let resolvedLeft = try resolver(left)
+  let resolvedRight = try resolver(right)
+  return evyComparison(comparisonOperator, left: resolvedLeft, right: resolvedRight)
 }
 
 private func splitRespectingParens(_ input: String, separator: String) -> [String] {
-    guard !input.isEmpty else {
-        return [input]
+  guard !input.isEmpty else {
+    return [input]
+  }
+
+  var parts: [String] = []
+  var depth = 0
+  var currentStart = input.startIndex
+  var index = input.startIndex
+
+  while index < input.endIndex {
+    let character = input[index]
+    if character == "(" {
+      depth += 1
+    } else if character == ")" && depth > 0 {
+      depth -= 1
     }
 
-    var parts: [String] = []
-    var depth = 0
-    var currentStart = input.startIndex
-    var index = input.startIndex
-
-    while index < input.endIndex {
-        let character = input[index]
-        if character == "(" {
-            depth += 1
-        } else if character == ")" && depth > 0 {
-            depth -= 1
-        }
-
-        if depth == 0, input[index...].hasPrefix(separator) {
-            parts.append(String(input[currentStart..<index])
-                .trimmingCharacters(in: .whitespacesAndNewlines))
-            currentStart = input.index(index, offsetBy: separator.count)
-            index = currentStart
-            continue
-        }
-
-        index = input.index(after: index)
+    if depth == 0, input[index...].hasPrefix(separator) {
+      parts.append(
+        String(input[currentStart..<index])
+          .trimmingCharacters(in: .whitespacesAndNewlines))
+      currentStart = input.index(index, offsetBy: separator.count)
+      index = currentStart
+      continue
     }
 
-    parts.append(String(input[currentStart...]).trimmingCharacters(in: .whitespacesAndNewlines))
-    return parts
+    index = input.index(after: index)
+  }
+
+  parts.append(String(input[currentStart...]).trimmingCharacters(in: .whitespacesAndNewlines))
+  return parts
 }
 
 private func firstTopLevelComparison(in input: String) -> (opIndex: String.Index, op: String)? {
-    var depth = 0
-    var index = input.startIndex
+  var depth = 0
+  var index = input.startIndex
 
-    while index < input.endIndex {
-        let character = input[index]
-        if character == "(" {
-            depth += 1
-        } else if character == ")" && depth > 0 {
-            depth -= 1
-        }
-
-        if depth == 0 {
-            for comparisonOperator in comparisonOperators {
-                if input[index...].hasPrefix(comparisonOperator) {
-                    return (index, comparisonOperator)
-                }
-            }
-        }
-
-        index = input.index(after: index)
+  while index < input.endIndex {
+    let character = input[index]
+    if character == "(" {
+      depth += 1
+    } else if character == ")" && depth > 0 {
+      depth -= 1
     }
 
-    return nil
+    if depth == 0 {
+      for comparisonOperator in comparisonOperators {
+        if input[index...].hasPrefix(comparisonOperator) {
+          return (index, comparisonOperator)
+        }
+      }
+    }
+
+    index = input.index(after: index)
+  }
+
+  return nil
 }
 
-private func parseAtomicComparison(_ input: String) -> (left: String,
-                                                        comparisonOperator: String,
-                                                        right: String)?
-{
-    guard let (opIndex, comparisonOperator) = firstTopLevelComparison(in: input) else {
-        return nil
-    }
-    let left = String(input[..<opIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
-    let rightStart = input.index(opIndex, offsetBy: comparisonOperator.count)
-    let right = String(input[rightStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !left.isEmpty, !right.isEmpty else {
-        return nil
-    }
-    return (left, comparisonOperator, right)
+private func parseAtomicComparison(_ input: String) -> (
+  left: String,
+  comparisonOperator: String,
+  right: String
+)? {
+  guard let (opIndex, comparisonOperator) = firstTopLevelComparison(in: input) else {
+    return nil
+  }
+  let left = String(input[..<opIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+  let rightStart = input.index(opIndex, offsetBy: comparisonOperator.count)
+  let right = String(input[rightStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !left.isEmpty, !right.isEmpty else {
+    return nil
+  }
+  return (left, comparisonOperator, right)
 }
 
 private func containsTopLevelComparisonOperator(_ input: String) -> Bool {
-    firstTopLevelComparison(in: input) != nil
+  firstTopLevelComparison(in: input) != nil
 }
 
 private func isWrappedInParentheses(_ input: String) -> Bool {
-    guard input.first == "(", input.last == ")" else {
-        return false
-    }
-
-    var depth = 0
-    for index in input.indices {
-        let character = input[index]
-        if character == "(" {
-            depth += 1
-        } else if character == ")" {
-            depth -= 1
-            if depth == 0 {
-                return index == input.index(before: input.endIndex)
-            }
-        }
-    }
-
+  guard input.first == "(", input.last == ")" else {
     return false
+  }
+
+  var depth = 0
+  for index in input.indices {
+    let character = input[index]
+    if character == "(" {
+      depth += 1
+    } else if character == ")" {
+      depth -= 1
+      if depth == 0 {
+        return index == input.index(before: input.endIndex)
+      }
+    }
+  }
+
+  return false
 }
 
-private func parseFunctionFromText(_ input: String) -> (match: Regex<AnyRegexOutput>.Match,
-                                                        functionName: String,
-                                                        functionArgs: String)?
-{
-    guard let match = try? firstMatch(input, pattern: "\\{\(functionPattern)\\}") else {
-        return nil
-    }
+private func parseFunctionFromText(_ input: String) -> (
+  match: Regex<AnyRegexOutput>.Match,
+  functionName: String,
+  functionArgs: String
+)? {
+  guard let match = try? firstMatch(input, pattern: "\\{\(functionPattern)\\}") else {
+    return nil
+  }
 
-    guard let (_, functionName, functionArgs) = parseFunctionInText(input) else {
-        return nil
-    }
+  guard let (_, functionName, functionArgs) = parseFunctionInText(input) else {
+    return nil
+  }
 
-    return (match, functionName, functionArgs)
+  return (match, functionName, functionArgs)
 }
 
-private func parseFunctionInText(_ input: String) -> (match: Regex<AnyRegexOutput>.Match,
-                                                      functionName: String,
-                                                      functionArgs: String)?
-{
-    guard let match = try? firstMatch(input, pattern: functionPattern) else {
-        return nil
-    }
+private func parseFunctionInText(_ input: String) -> (
+  match: Regex<AnyRegexOutput>.Match,
+  functionName: String,
+  functionArgs: String
+)? {
+  guard let match = try? firstMatch(input, pattern: functionPattern) else {
+    return nil
+  }
 
-    // Remove opening { from match
-    let functionCall = match.0.description
-    guard let argsAndParenthesisMatch = try? firstMatch(functionCall,
-                                                        pattern: functionParamsPattern) else
-    {
-        return nil
-    }
+  // Remove opening { from match
+  let functionCall = match.0.description
+  guard
+    let argsAndParenthesisMatch = try? firstMatch(
+      functionCall,
+      pattern: functionParamsPattern)
+  else {
+    return nil
+  }
 
-    let parenthesisStartIndex = argsAndParenthesisMatch.range.lowerBound
-    let functionNameEndIndex = functionCall.index(before: parenthesisStartIndex)
-    let functionName = functionCall[functionCall.startIndex...functionNameEndIndex]
+  let parenthesisStartIndex = argsAndParenthesisMatch.range.lowerBound
+  let functionNameEndIndex = functionCall.index(before: parenthesisStartIndex)
+  let functionName = functionCall[functionCall.startIndex...functionNameEndIndex]
 
-    let argsAndParenthesis = argsAndParenthesisMatch.0.description
-    let functionArgs = argsAndParenthesis.dropFirst().dropLast()
+  let argsAndParenthesis = argsAndParenthesisMatch.0.description
+  let functionArgs = argsAndParenthesis.dropFirst().dropLast()
 
-    return (match, String(functionName), String(functionArgs))
+  return (match, String(functionName), String(functionArgs))
 }
 
 private var regexPatternCache: [String: Regex<AnyRegexOutput>] = [:]
 
 private func regexForPattern(_ pattern: String) throws -> Regex<AnyRegexOutput> {
-    if let cached = regexPatternCache[pattern] {
-        return cached
-    }
-    let r = try Regex(pattern)
-    regexPatternCache[pattern] = r
-    return r
+  if let cached = regexPatternCache[pattern] {
+    return cached
+  }
+  let r = try Regex(pattern)
+  regexPatternCache[pattern] = r
+  return r
 }
 
 private func firstMatch(_ input: String, pattern: String) throws -> Regex<AnyRegexOutput>.Match? {
-    let regex = try regexForPattern(pattern)
-    return input.firstMatch(of: regex)
+  let regex = try regexForPattern(pattern)
+  return input.firstMatch(of: regex)
 }
 
 private func lastMatch(_ input: String, pattern: String) throws -> Regex<AnyRegexOutput>.Match? {
-    let regex = try regexForPattern(pattern)
-    return input.matches(of: regex).last
+  let regex = try regexForPattern(pattern)
+  return input.matches(of: regex).last
 }
 
 #Preview {
-    AsyncPreview { asyncView in
-        asyncView
-    } view: {
-        try! EVY.getUserData()
-        try! await EVY.createItem()
+  AsyncPreview { asyncView in
+    asyncView
+  } view: {
+    try! EVY.getUserData()
+    try! await EVY.createItem()
 
-        let bare = "test"
-        let data = "{item.title}"
+    let bare = "test"
+    let data = "{item.title}"
 
-        let parsedData = try! parseTextFromText(data)
-        let withPrefix = try! parseTextFromText(
-            "{formatCurrency(item.price)}"
-        )
-        let withSuffix = try! parseTextFromText(
-            "{formatDimension(item.dimensions.width)}"
-        )
-        let WithSuffixAndRight = try! parseTextFromText(
-            "{formatDimension(item.dimensions.width)} - {item.title}"
-        )
-        let withComparison = try! parseTextFromText(
-            "{count(item.title) == count(selling_reasons)} v {count(item.title) == count(item.title)}"
-        )
-        let withMultiComparison = try! parseTextFromText(
-            "{count(item.title) > 0 || (1 > 2 && count(selling_reasons) > 0)}"
-        )
+    let parsedData = try! parseTextFromText(data)
+    let withPrefix = try! parseTextFromText(
+      "{formatCurrency(item.price)}"
+    )
+    let withSuffix = try! parseTextFromText(
+      "{formatDimension(item.dimensions.width)}"
+    )
+    let WithSuffixAndRight = try! parseTextFromText(
+      "{formatDimension(item.dimensions.width)} - {item.title}"
+    )
+    let withComparison = try! parseTextFromText(
+      "{count(item.title) == count(selling_reasons)} v {count(item.title) == count(item.title)}"
+    )
+    let withMultiComparison = try! parseTextFromText(
+      "{count(item.title) > 0 || (1 > 2 && count(selling_reasons) > 0)}"
+    )
 
-        let weight = try! parseTextFromText(
-            "{formatWeight(item.dimensions.weight)}"
-        )
+    let weight = try! parseTextFromText(
+      "{formatWeight(item.dimensions.weight)}"
+    )
 
-        let firstSellingReason = try! EVY.getDataFromText("{selling_reasons[0]}")
+    let firstSellingReason = try! EVY.getDataFromText("{selling_reasons[0]}")
 
-        return VStack {
-            Text("parseProps but no props: " + parsePropsFromText(bare))
-            Text("parseProps with props: " + parsePropsFromText(data))
-            Text(parsedData.toString())
-            Text(withPrefix.toString())
-            Text(withSuffix.toString())
-            Text(WithSuffixAndRight.toString())
-            Text(withComparison.toString())
-            Text(withMultiComparison.toString())
-            Text(weight.toString())
-            Text(firstSellingReason.toString())
+    return VStack {
+      Text("parseProps but no props: " + parsePropsFromText(bare))
+      Text("parseProps with props: " + parsePropsFromText(data))
+      Text(parsedData.toString())
+      Text(withPrefix.toString())
+      Text(withSuffix.toString())
+      Text(WithSuffixAndRight.toString())
+      Text(withComparison.toString())
+      Text(withMultiComparison.toString())
+      Text(weight.toString())
+      Text(firstSellingReason.toString())
 
-            EVYTextField(input: "{formatCurrency(item.price)}",
-                         destination: "{item.price}",
-                         placeholder: "Editing price")
-        }
+      EVYTextField(
+        input: "{formatCurrency(item.price)}",
+        destination: "{item.price}",
+        placeholder: "Editing price")
     }
+  }
 }

--- a/ios/evy/Utils/isNumber.swift
+++ b/ios/evy/Utils/isNumber.swift
@@ -6,8 +6,8 @@
 import Foundation
 
 extension String {
-    var isNumber: Bool {
-        let digitsCharacters = CharacterSet(charactersIn: "0123456789")
-        return CharacterSet(charactersIn: self).isSubset(of: digitsCharacters)
-    }
+  var isNumber: Bool {
+    let digitsCharacters = CharacterSet(charactersIn: "0123456789")
+    return CharacterSet(charactersIn: self).isSubset(of: digitsCharacters)
+  }
 }

--- a/ios/evy/evyApp.swift
+++ b/ios/evy/evyApp.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 @main
 struct evyApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
     }
+  }
 }

--- a/ios/evyTests/ContentViewTests.swift
+++ b/ios/evyTests/ContentViewTests.swift
@@ -4,128 +4,129 @@
 //
 
 import XCTest
+
 @testable import evy
 
 @MainActor
 final class ContentViewTests: XCTestCase {
-    func testCreateKeysToDeleteDoesNotCleanWhenEnteringCreateFlow() throws {
-        let flows = try makeFlows()
+  func testCreateKeysToDeleteDoesNotCleanWhenEnteringCreateFlow() throws {
+    let flows = try makeFlows()
 
-        let keysToDelete = ContentView.createKeysToDelete(
-            whenLeaving: "home-flow",
-            flows: flows,
-            activeDraftKeys: Set(["item"]),
-        )
+    let keysToDelete = ContentView.createKeysToDelete(
+      whenLeaving: "home-flow",
+      flows: flows,
+      activeDraftKeys: Set(["item"]),
+    )
 
-        XCTAssertEqual(keysToDelete, [])
-    }
+    XCTAssertEqual(keysToDelete, [])
+  }
 
-    func testCreateKeysToDeleteCleansCreateFlowKeysWhenLeavingCreateFlow() throws {
-        let flows = try makeFlows()
+  func testCreateKeysToDeleteCleansCreateFlowKeysWhenLeavingCreateFlow() throws {
+    let flows = try makeFlows()
 
-        let keysToDelete = ContentView.createKeysToDelete(
-            whenLeaving: "create-flow",
-            flows: flows,
-            activeDraftKeys: Set(["item"]),
-        )
+    let keysToDelete = ContentView.createKeysToDelete(
+      whenLeaving: "create-flow",
+      flows: flows,
+      activeDraftKeys: Set(["item"]),
+    )
 
-        XCTAssertEqual(keysToDelete, Set(["item"]))
-    }
+    XCTAssertEqual(keysToDelete, Set(["item"]))
+  }
 
-    func testDraftScopeIdForCreateFlowMatchesFlowAndEntityKey() throws {
-        let flows = try makeFlows()
-        let route = Route(flowId: "create-flow", pageId: "create-page")
-        XCTAssertEqual(
-            ContentView.draftScopeId(for: route, flows: flows),
-            EVYDraft.createMergeScopeId(flowId: "create-flow", entityKey: "item")
-        )
-    }
+  func testDraftScopeIdForCreateFlowMatchesFlowAndEntityKey() throws {
+    let flows = try makeFlows()
+    let route = Route(flowId: "create-flow", pageId: "create-page")
+    XCTAssertEqual(
+      ContentView.draftScopeId(for: route, flows: flows),
+      EVYDraft.createMergeScopeId(flowId: "create-flow", entityKey: "item")
+    )
+  }
 
-    func testDraftScopeIdForHomeFlowWithoutCreateUsesBrowseSuffix() throws {
-        let flows = try makeFlows()
-        let route = Route(flowId: "home-flow", pageId: "home-page")
-        XCTAssertEqual(ContentView.draftScopeId(for: route, flows: flows), "home-flow#browse")
-    }
+  func testDraftScopeIdForHomeFlowWithoutCreateUsesBrowseSuffix() throws {
+    let flows = try makeFlows()
+    let route = Route(flowId: "home-flow", pageId: "home-page")
+    XCTAssertEqual(ContentView.draftScopeId(for: route, flows: flows), "home-flow#browse")
+  }
 
-    private func makeFlows() throws -> [UI_Flow] {
-        let json: [[String: Any]] = [
-            [
-                "id": "home-flow",
-                "name": "Home",
-                "pages": [
-                    [
-                        "id": "home-page",
-                        "title": "Home",
-                        "rows": [
-                            [
-                                "id": "home-button",
-                                "type": "Button",
-                                "source": "",
-                                "view": [
-                                    "content": [
-                                        "title": "",
-                                        "label": "Create"
-                                    ]
-                                ],
-                                "actions": [
-                                    [
-                                        "condition": "",
-                                        "false": "",
-                                        "true": "navigate:create-flow:create-page"
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+  private func makeFlows() throws -> [UI_Flow] {
+    let json: [[String: Any]] = [
+      [
+        "id": "home-flow",
+        "name": "Home",
+        "pages": [
+          [
+            "id": "home-page",
+            "title": "Home",
+            "rows": [
+              [
+                "id": "home-button",
+                "type": "Button",
+                "source": "",
+                "view": [
+                  "content": [
+                    "title": "",
+                    "label": "Create",
+                  ]
+                ],
+                "actions": [
+                  [
+                    "condition": "",
+                    "false": "",
+                    "true": "navigate:create-flow:create-page",
+                  ]
+                ],
+              ]
             ],
-            [
-                "id": "create-flow",
-                "name": "Create item",
-                "pages": [
-                    [
-                        "id": "create-page",
-                        "title": "Create",
-                        "rows": [
-                            [
-                                "id": "title-row",
-                                "type": "Input",
-                                "source": "{item}",
-                                "view": [
-                                    "content": [
-                                        "title": "Title",
-                                        "value": "",
-                                        "placeholder": "Enter a title"
-                                    ]
-                                ],
-                                "destination": "{title}",
-                                "actions": []
-                            ]
-                        ],
-                        "footer": [
-                            "id": "submit-button",
-                            "type": "Button",
-                            "source": "{item}",
-                            "view": [
-                                "content": [
-                                    "title": "",
-                                    "label": "Submit"
-                                ]
-                            ],
-                            "actions": [
-                                [
-                                    "condition": "",
-                                    "false": "",
-                                    "true": "{create(item)}"
-                                ]
-                            ]
-                        ]
-                    ]
+          ]
+        ],
+      ],
+      [
+        "id": "create-flow",
+        "name": "Create item",
+        "pages": [
+          [
+            "id": "create-page",
+            "title": "Create",
+            "rows": [
+              [
+                "id": "title-row",
+                "type": "Input",
+                "source": "{item}",
+                "view": [
+                  "content": [
+                    "title": "Title",
+                    "value": "",
+                    "placeholder": "Enter a title",
+                  ]
+                ],
+                "destination": "{title}",
+                "actions": [],
+              ]
+            ],
+            "footer": [
+              "id": "submit-button",
+              "type": "Button",
+              "source": "{item}",
+              "view": [
+                "content": [
+                  "title": "",
+                  "label": "Submit",
                 ]
-            ]
-        ]
+              ],
+              "actions": [
+                [
+                  "condition": "",
+                  "false": "",
+                  "true": "{create(item)}",
+                ]
+              ],
+            ],
+          ]
+        ],
+      ],
+    ]
 
-        let data = try JSONSerialization.data(withJSONObject: json)
-        return try JSONDecoder().decode([UI_Flow].self, from: data)
-    }
+    let data = try JSONSerialization.data(withJSONObject: json)
+    return try JSONDecoder().decode([UI_Flow].self, from: data)
+  }
 }

--- a/ios/evyTests/EVYActionRunnerTests.swift
+++ b/ios/evyTests/EVYActionRunnerTests.swift
@@ -4,96 +4,97 @@
 //
 
 import XCTest
+
 @testable import evy
 
 @MainActor
 final class EVYActionRunnerTests: XCTestCase {
-    func testCloseAction() {
-        var received: NavOperation?
-        let action = UI_RowAction(condition: "", false: "", true: "{close()}")
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        XCTAssertEqual(received, .close)
-    }
+  func testCloseAction() {
+    var received: NavOperation?
+    let action = UI_RowAction(condition: "", false: "", true: "{close()}")
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    XCTAssertEqual(received, .close)
+  }
 
-    func testBareCloseActionIsInert() {
-        var received: NavOperation?
-        let action = UI_RowAction(condition: "", false: "", true: "close")
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        XCTAssertNil(received)
-    }
+  func testBareCloseActionIsInert() {
+    var received: NavOperation?
+    let action = UI_RowAction(condition: "", false: "", true: "close")
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    XCTAssertNil(received)
+  }
 
-    func testUnwrappedCloseFunctionIsInert() {
-        var received: NavOperation?
-        let action = UI_RowAction(condition: "", false: "", true: "close()")
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        XCTAssertNil(received)
-    }
+  func testUnwrappedCloseFunctionIsInert() {
+    var received: NavOperation?
+    let action = UI_RowAction(condition: "", false: "", true: "close()")
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    XCTAssertNil(received)
+  }
 
-    func testCreateAction() {
-        var received: NavOperation?
-        let action = UI_RowAction(condition: "", false: "", true: "{create(item)}")
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        XCTAssertEqual(received, .create("item"))
-    }
+  func testCreateAction() {
+    var received: NavOperation?
+    let action = UI_RowAction(condition: "", false: "", true: "{create(item)}")
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    XCTAssertEqual(received, .create("item"))
+  }
 
-    func testNavigateWithBraceFunction() {
-        var received: NavOperation?
-        let action = UI_RowAction(
-            condition: "",
-            false: "",
-            true: "{navigate(flow-1,page-2)}",
-        )
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        guard case let .navigate(route) = received else {
-            XCTFail("Expected navigate, got \(String(describing: received))")
-            return
-        }
-        XCTAssertEqual(route.flowId, "flow-1")
-        XCTAssertEqual(route.pageId, "page-2")
+  func testNavigateWithBraceFunction() {
+    var received: NavOperation?
+    let action = UI_RowAction(
+      condition: "",
+      false: "",
+      true: "{navigate(flow-1,page-2)}",
+    )
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    guard case .navigate(let route) = received else {
+      XCTFail("Expected navigate, got \(String(describing: received))")
+      return
     }
+    XCTAssertEqual(route.flowId, "flow-1")
+    XCTAssertEqual(route.pageId, "page-2")
+  }
 
-    func testNavigateColonFormat() {
-        var received: NavOperation?
-        let action = UI_RowAction(
-            condition: "",
-            false: "",
-            true: "navigate:flowX:pageY",
-        )
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        guard case let .navigate(route) = received else {
-            XCTFail("Expected navigate")
-            return
-        }
-        XCTAssertEqual(route.flowId, "flowX")
-        XCTAssertEqual(route.pageId, "pageY")
+  func testNavigateColonFormat() {
+    var received: NavOperation?
+    let action = UI_RowAction(
+      condition: "",
+      false: "",
+      true: "navigate:flowX:pageY",
+    )
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    guard case .navigate(let route) = received else {
+      XCTFail("Expected navigate")
+      return
     }
+    XCTAssertEqual(route.flowId, "flowX")
+    XCTAssertEqual(route.pageId, "pageY")
+  }
 
-    func testHighlightRequiredFormatsFieldLabel() {
-        var received: NavOperation?
-        let action = UI_RowAction(
-            condition: "",
-            false: "",
-            true: "{highlight_required(unit_price)}",
-        )
-        EVYActionRunner.run(actions: [action]) { received = $0 }
-        guard case let .highlightRequired(label) = received else {
-            XCTFail("Expected highlightRequired")
-            return
-        }
-        XCTAssertTrue(label.contains("unit") || label.contains("Unit"))
+  func testHighlightRequiredFormatsFieldLabel() {
+    var received: NavOperation?
+    let action = UI_RowAction(
+      condition: "",
+      false: "",
+      true: "{highlight_required(unit_price)}",
+    )
+    EVYActionRunner.run(actions: [action]) { received = $0 }
+    guard case .highlightRequired(let label) = received else {
+      XCTFail("Expected highlightRequired")
+      return
     }
+    XCTAssertTrue(label.contains("unit") || label.contains("Unit"))
+  }
 
-    func testUnsupportedFunctionPostsErrorNotification() {
-        let expectation = expectation(
-            forNotification: Notification.Name.evyErrorOccurred,
-            object: nil,
-        )
-        let action = UI_RowAction(
-            condition: "",
-            false: "",
-            true: "{notARealEvyFunction()}",
-        )
-        EVYActionRunner.run(actions: [action]) { _ in }
-        wait(for: [expectation], timeout: 2)
-    }
+  func testUnsupportedFunctionPostsErrorNotification() {
+    let expectation = expectation(
+      forNotification: Notification.Name.evyErrorOccurred,
+      object: nil,
+    )
+    let action = UI_RowAction(
+      condition: "",
+      false: "",
+      true: "{notARealEvyFunction()}",
+    )
+    EVYActionRunner.run(actions: [action]) { _ in }
+    wait(for: [expectation], timeout: 2)
+  }
 }

--- a/ios/evyTests/EVYDraftBindingsTests.swift
+++ b/ios/evyTests/EVYDraftBindingsTests.swift
@@ -4,41 +4,42 @@
 //
 
 import XCTest
+
 @testable import evy
 
 @MainActor
 final class EVYDraftBindingTests: XCTestCase {
-    func testBindingSingleUUIDUsesEphemeralScope() throws {
-        let uuid = "00000000-0000-4000-8000-000000000001"
-        let binding = try EVYDraft.binding(parsedProps: uuid, scopeId: nil)
-        XCTAssertEqual(binding.scopeId, "ephemeral:\(uuid)")
-        XCTAssertEqual(binding.pathSegments, [uuid])
-        guard case .aliasFlat(let segs) = binding.mergeMode else {
-            XCTFail("expected aliasFlat merge mode")
-            return
-        }
-        XCTAssertEqual(segs, [uuid])
+  func testBindingSingleUUIDUsesEphemeralScope() throws {
+    let uuid = "00000000-0000-4000-8000-000000000001"
+    let binding = try EVYDraft.binding(parsedProps: uuid, scopeId: nil)
+    XCTAssertEqual(binding.scopeId, "ephemeral:\(uuid)")
+    XCTAssertEqual(binding.pathSegments, [uuid])
+    guard case .aliasFlat(let segs) = binding.mergeMode else {
+      XCTFail("expected aliasFlat merge mode")
+      return
     }
+    XCTAssertEqual(segs, [uuid])
+  }
 
-    func testBindingTitleDoesNotUseEphemeralScope() throws {
-        let binding = try EVYDraft.binding(parsedProps: "title", scopeId: "flow#item")
-        XCTAssertEqual(binding.scopeId, "flow#item")
-        XCTAssertFalse(binding.scopeId.hasPrefix("ephemeral:"))
-    }
+  func testBindingTitleDoesNotUseEphemeralScope() throws {
+    let binding = try EVYDraft.binding(parsedProps: "title", scopeId: "flow#item")
+    XCTAssertEqual(binding.scopeId, "flow#item")
+    XCTAssertFalse(binding.scopeId.hasPrefix("ephemeral:"))
+  }
 
-    func testBindingUUIDWithMoreSegmentsIsNotEphemeralShortcut() throws {
-        let uuid = "00000000-0000-4000-8000-000000000001"
-        let binding = try EVYDraft.binding(
-            parsedProps: "\(uuid).foo",
-            scopeId: nil
-        )
-        XCTAssertNotEqual(binding.scopeId, "ephemeral:\(uuid)")
-        XCTAssertEqual(binding.scopeId, EVYDraft.Scope.fallbackUnscoped)
-        XCTAssertEqual(binding.pathSegments, [uuid, "foo"])
-        guard case .explicitPath(let segs) = binding.mergeMode else {
-            XCTFail("expected explicitPath merge mode")
-            return
-        }
-        XCTAssertEqual(segs, [uuid, "foo"])
+  func testBindingUUIDWithMoreSegmentsIsNotEphemeralShortcut() throws {
+    let uuid = "00000000-0000-4000-8000-000000000001"
+    let binding = try EVYDraft.binding(
+      parsedProps: "\(uuid).foo",
+      scopeId: nil
+    )
+    XCTAssertNotEqual(binding.scopeId, "ephemeral:\(uuid)")
+    XCTAssertEqual(binding.scopeId, EVYDraft.Scope.fallbackUnscoped)
+    XCTAssertEqual(binding.pathSegments, [uuid, "foo"])
+    guard case .explicitPath(let segs) = binding.mergeMode else {
+      XCTFail("expected explicitPath merge mode")
+      return
     }
+    XCTAssertEqual(segs, [uuid, "foo"])
+  }
 }

--- a/ios/evyTests/EVYDraftMergesTests.swift
+++ b/ios/evyTests/EVYDraftMergesTests.swift
@@ -4,220 +4,221 @@
 //
 
 import XCTest
+
 @testable import evy
 
 @MainActor
 final class EVYCreateMergesDraftsTests: XCTestCase {
-    private let testDraftScope = "__test__#item"
+  private let testDraftScope = "__test__#item"
 
-    override func setUp() async throws {
-        try await super.setUp()
-        try? EVY.data.delete(key: "item")
-        EVY.data.deleteAllDraftsForTestIsolation()
-        EVY.data.activeDraftScopeId = testDraftScope
+  override func setUp() async throws {
+    try await super.setUp()
+    try? EVY.data.delete(key: "item")
+    EVY.data.deleteAllDraftsForTestIsolation()
+    EVY.data.activeDraftScopeId = testDraftScope
+  }
+
+  override func tearDown() async throws {
+    try? EVY.data.delete(key: "item")
+    EVY.data.deleteAllDraftsForTestIsolation()
+    EVY.data.activeDraftScopeId = nil
+    try await super.tearDown()
+  }
+
+  func testCreateMergesScalarTitleFromDraft() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("Seed Title"),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
+
+    EVY.ensureDraftExists(variableName: "title")
+    try EVY.updateValue("User Title", at: "{title}")
+
+    try EVY.create(key: "item", draftScopeId: testDraftScope)
+
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
     }
+    XCTAssertEqual(dict["title"], .string("User Title"))
+  }
 
-    override func tearDown() async throws {
-        try? EVY.data.delete(key: "item")
-        EVY.data.deleteAllDraftsForTestIsolation()
-        EVY.data.activeDraftScopeId = nil
-        try await super.tearDown()
+  func testCreateMergesStructuredPriceFromDraft() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("X"),
+      "price": .dictionary([
+        "currency": .string("AUD"),
+        "value": .decimal(250),
+      ]),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
+
+    EVY.ensureDraftExists(variableName: "price")
+    let newPrice = EVYJson.dictionary([
+      "currency": .string("AUD"),
+      "value": .decimal(99),
+    ])
+    let priceBinding = try EVY.data.draftBinding(fromParsedProps: "price")
+    try EVY.data.updateDraft(binding: priceBinding, data: try JSONEncoder().encode(newPrice))
+
+    try EVY.create(key: "item", draftScopeId: testDraftScope)
+
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
     }
-
-    func testCreateMergesScalarTitleFromDraft() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("Seed Title"),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
-
-        EVY.ensureDraftExists(variableName: "title")
-        try EVY.updateValue("User Title", at: "{title}")
-
-        try EVY.create(key: "item", draftScopeId: testDraftScope)
-
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        XCTAssertEqual(dict["title"], .string("User Title"))
+    guard case .dictionary(let mergedPrice)? = dict["price"] else {
+      XCTFail("expected price dictionary")
+      return
     }
+    XCTAssertEqual(mergedPrice["currency"], .string("AUD"))
+    let value = mergedPrice["value"]
+    XCTAssertTrue(
+      value == .decimal(99) || value == .int(99),
+      "expected price value 99, got \(String(describing: value))"
+    )
+  }
 
-    func testCreateMergesStructuredPriceFromDraft() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("X"),
-            "price": .dictionary([
-                "currency": .string("AUD"),
-                "value": .decimal(250),
-            ]),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
+  func testCreateSkipsEmptyBootstrapDraftSoSeedTitleRemains() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("Seed Title"),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
 
-        EVY.ensureDraftExists(variableName: "price")
-        let newPrice = EVYJson.dictionary([
-            "currency": .string("AUD"),
-            "value": .decimal(99),
-        ])
-        let priceBinding = try EVY.data.draftBinding(fromParsedProps: "price")
-        try EVY.data.updateDraft(binding: priceBinding, data: try JSONEncoder().encode(newPrice))
+    EVY.ensureDraftExists(variableName: "title")
 
-        try EVY.create(key: "item", draftScopeId: testDraftScope)
+    try EVY.create(key: "item", draftScopeId: testDraftScope)
 
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        guard case .dictionary(let mergedPrice)? = dict["price"] else {
-            XCTFail("expected price dictionary")
-            return
-        }
-        XCTAssertEqual(mergedPrice["currency"], .string("AUD"))
-        let value = mergedPrice["value"]
-        XCTAssertTrue(
-            value == .decimal(99) || value == .int(99),
-            "expected price value 99, got \(String(describing: value))"
-        )
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
     }
+    XCTAssertEqual(dict["title"], .string("Seed Title"))
+  }
 
-    func testCreateSkipsEmptyBootstrapDraftSoSeedTitleRemains() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("Seed Title"),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
+  func testCreateMergesWidthDraftIntoUniqueNestedField() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("T"),
+      "dimensions": .dictionary([
+        "width": .int(500),
+        "height": .int(1600),
+      ]),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
 
-        EVY.ensureDraftExists(variableName: "title")
+    EVY.ensureDraftExists(variableName: "width")
+    try EVY.updateValue("50", at: "{width}")
 
-        try EVY.create(key: "item", draftScopeId: testDraftScope)
+    try EVY.create(key: "item", draftScopeId: testDraftScope)
 
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        XCTAssertEqual(dict["title"], .string("Seed Title"))
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
     }
-
-    func testCreateMergesWidthDraftIntoUniqueNestedField() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("T"),
-            "dimensions": .dictionary([
-                "width": .int(500),
-                "height": .int(1600),
-            ]),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
-
-        EVY.ensureDraftExists(variableName: "width")
-        try EVY.updateValue("50", at: "{width}")
-
-        try EVY.create(key: "item", draftScopeId: testDraftScope)
-
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        guard case .dictionary(let dimensions)? = dict["dimensions"] else {
-            XCTFail("expected dimensions dictionary")
-            return
-        }
-        XCTAssertEqual(dimensions["width"], .string("50"))
+    guard case .dictionary(let dimensions)? = dict["dimensions"] else {
+      XCTFail("expected dimensions dictionary")
+      return
     }
+    XCTAssertEqual(dimensions["width"], .string("50"))
+  }
 
-    func testCreateAddsWidthFieldFromDraftWhenMissingFromSeed() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("T"),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
+  func testCreateAddsWidthFieldFromDraftWhenMissingFromSeed() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("T"),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
 
-        EVY.ensureDraftExists(variableName: "width")
-        try EVY.updateValue("50", at: "{width}")
+    EVY.ensureDraftExists(variableName: "width")
+    try EVY.updateValue("50", at: "{width}")
 
-        try EVY.create(key: "item", draftScopeId: testDraftScope)
+    try EVY.create(key: "item", draftScopeId: testDraftScope)
 
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        XCTAssertEqual(dict["width"], .string("50"))
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
     }
+    XCTAssertEqual(dict["width"], .string("50"))
+  }
 
-    func testCreateMergesExplicitNestedPathFromDraft() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("T"),
-            "dimensions": .dictionary([
-                "width": .int(1),
-                "height": .int(2),
-            ]),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
+  func testCreateMergesExplicitNestedPathFromDraft() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("T"),
+      "dimensions": .dictionary([
+        "width": .int(1),
+        "height": .int(2),
+      ]),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
 
-        let binding = try EVYDraft.binding(
-            parsedProps: "dimensions.width",
-            scopeId: testDraftScope
-        )
-        try EVY.data.upsertDraft(
-            binding: binding,
-            data: try JSONEncoder().encode(EVYJson.string("99"))
-        )
+    let binding = try EVYDraft.binding(
+      parsedProps: "dimensions.width",
+      scopeId: testDraftScope
+    )
+    try EVY.data.upsertDraft(
+      binding: binding,
+      data: try JSONEncoder().encode(EVYJson.string("99"))
+    )
 
-        try EVY.create(key: "item", draftScopeId: testDraftScope)
+    try EVY.create(key: "item", draftScopeId: testDraftScope)
 
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        guard case .dictionary(let dimensions)? = dict["dimensions"] else {
-            XCTFail("expected dimensions dictionary")
-            return
-        }
-        XCTAssertEqual(dimensions["width"], .string("99"))
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
     }
-
-    func testCreateMergesOnlyDraftsForRequestedScope() throws {
-        let seed: [String: EVYJson] = [
-            "id": .string("00000000-0000-0000-0000-000000000001"),
-            "title": .string("Seed"),
-        ]
-        try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
-        let row = try EVY.data.get(key: "item")
-
-        let scopeA = "flow-a#item"
-        let scopeB = "flow-b#item"
-
-        let titleA = try EVYDraft.binding(parsedProps: "title", scopeId: scopeA)
-        try EVY.data.upsertDraft(
-            binding: titleA,
-            data: try JSONEncoder().encode(EVYJson.string("From A"))
-        )
-        let titleB = try EVYDraft.binding(parsedProps: "title", scopeId: scopeB)
-        try EVY.data.upsertDraft(
-            binding: titleB,
-            data: try JSONEncoder().encode(EVYJson.string("From B"))
-        )
-
-        try EVY.create(key: "item", draftScopeId: scopeA)
-
-        let merged = try row.decoded()
-        guard case .dictionary(let dict) = merged else {
-            XCTFail("expected dictionary")
-            return
-        }
-        XCTAssertEqual(dict["title"], .string("From A"))
+    guard case .dictionary(let dimensions)? = dict["dimensions"] else {
+      XCTFail("expected dimensions dictionary")
+      return
     }
+    XCTAssertEqual(dimensions["width"], .string("99"))
+  }
+
+  func testCreateMergesOnlyDraftsForRequestedScope() throws {
+    let seed: [String: EVYJson] = [
+      "id": .string("00000000-0000-0000-0000-000000000001"),
+      "title": .string("Seed"),
+    ]
+    try EVY.data.create(key: "item", data: try JSONEncoder().encode(EVYJson.dictionary(seed)))
+    let row = try EVY.data.get(key: "item")
+
+    let scopeA = "flow-a#item"
+    let scopeB = "flow-b#item"
+
+    let titleA = try EVYDraft.binding(parsedProps: "title", scopeId: scopeA)
+    try EVY.data.upsertDraft(
+      binding: titleA,
+      data: try JSONEncoder().encode(EVYJson.string("From A"))
+    )
+    let titleB = try EVYDraft.binding(parsedProps: "title", scopeId: scopeB)
+    try EVY.data.upsertDraft(
+      binding: titleB,
+      data: try JSONEncoder().encode(EVYJson.string("From B"))
+    )
+
+    try EVY.create(key: "item", draftScopeId: scopeA)
+
+    let merged = try row.decoded()
+    guard case .dictionary(let dict) = merged else {
+      XCTFail("expected dictionary")
+      return
+    }
+    XCTAssertEqual(dict["title"], .string("From A"))
+  }
 }

--- a/ios/evyTests/interpreterTests.swift
+++ b/ios/evyTests/interpreterTests.swift
@@ -4,119 +4,123 @@
 //
 
 import XCTest
+
 @testable import evy
 
 @MainActor
 final class InterpreterTests: XCTestCase {
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        try EVY.getUserData()
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    try EVY.getUserData()
+  }
+
+  func testEvaluatesLogicalOperatorsWithLiterals() throws {
+    XCTAssertTrue(try EVY.evaluateFromText("{0 > 1 || 1 > 0}"))
+    XCTAssertFalse(try EVY.evaluateFromText("{0 > 1 || 0 > 2}"))
+    XCTAssertTrue(try EVY.evaluateFromText("{1 > 0 && 2 > 1}"))
+    XCTAssertFalse(try EVY.evaluateFromText("{1 > 0 && 0 > 1}"))
+  }
+
+  func testEvaluatesFunctionOperands() throws {
+    let titleKey = uniqueKey("title")
+    let reasonsKey = uniqueKey("reasons")
+
+    try store(.string("Hello"), at: titleKey)
+    try store(.array([.string("One"), .string("Two")]), at: reasonsKey)
+
+    XCTAssertTrue(try EVY.evaluateFromText("{count(\(titleKey)) > 0 || count(\(reasonsKey)) > 3}"))
+    XCTAssertFalse(
+      try EVY.evaluateFromText("{count(\(titleKey)) > 10 && count(\(reasonsKey)) > 3}"))
+  }
+
+  func testEvaluatesBarePropsInsideComparison() throws {
+    let paymentCashKey = uniqueKey("payment_cash")
+    let paymentAppKey = uniqueKey("payment_app")
+
+    try store(.bool(false), at: paymentCashKey)
+    try store(.bool(true), at: paymentAppKey)
+
+    XCTAssertTrue(
+      try EVY.evaluateFromText("{\(paymentCashKey) == true || \(paymentAppKey) == true}"))
+    XCTAssertFalse(
+      try EVY.evaluateFromText("{\(paymentCashKey) == true && \(paymentAppKey) == false}"))
+  }
+
+  func testWatchTargetUnwrapsCountToUnderlyingDataKey() {
+    let key = uniqueKey("photo_ids")
+    XCTAssertEqual(
+      EVY.watchTarget(for: "Photos: {count(\(key))}/10 - more text"),
+      key
+    )
+  }
+
+  func testWatchTargetUsesFirstArgumentForMultiArgFunction() {
+    XCTAssertEqual(
+      EVY.watchTarget(for: "{formatDecimal(item.price, 2)}"),
+      "item.price"
+    )
+  }
+
+  func testCountReflectsArrayAfterStoreUpdate() throws {
+    let key = uniqueKey("photos")
+    try store(.array([.string("a")]), at: key)
+    let one = try parseTextFromText("n: {count(\(key))}")
+    XCTAssertEqual(one.value, "n: 1")
+
+    let encoded = try JSONEncoder().encode(EVYJson.array([.string("a"), .string("b")]))
+    try EVY.data.update(props: [key], data: encoded)
+
+    let two = try parseTextFromText("n: {count(\(key))}")
+    XCTAssertEqual(two.value, "n: 2")
+  }
+
+  func testFormatDecimalRoundsToPlaces() throws {
+    let key = uniqueKey("amount")
+    try store(.string("20.0423"), at: key)
+    let out = try parseTextFromText("{formatDecimal(\(key), 2)}")
+    XCTAssertEqual(out.value, "20.04")
+  }
+
+  func testFormatMetricLengthUsesTwoDecimalMetres() throws {
+    let key = uniqueKey("mm")
+    try store(.int(23240), at: key)
+    let out = try parseTextFromText("{formatMetricLength(\(key))}")
+    XCTAssertEqual(out.toString(), "23.24m")
+  }
+
+  func testFormatImperialLengthConvertsMillimetresToFeet() throws {
+    let key = uniqueKey("mm")
+    try store(.int(4231), at: key)
+    let out = try parseTextFromText("{formatImperialLength(\(key))}")
+    XCTAssertEqual(out.toString(), "13.88ft")
+  }
+
+  func testFormatDurationHumanizesMilliseconds() throws {
+    let key = uniqueKey("ms")
+    try store(.int(900_000), at: key)
+    let out = try parseTextFromText("{formatDuration(\(key))}")
+    XCTAssertEqual(out.value, "15 minutes")
+  }
+
+  func testFormatDateFormatsIsoStringWithPattern() throws {
+    let key = uniqueKey("created")
+    try store(.string("2024-01-19T12:42:52.000Z"), at: key)
+    let out = try parseTextFromText(
+      "{formatDate(\(key), \"MM/dd/yyyy\")}"
+    )
+    XCTAssertEqual(out.value, "01/19/2024")
+  }
+
+  private func store(_ value: EVYJson, at key: String) throws {
+    if EVY.data.exists(key: key) {
+      try EVY.data.delete(key: key)
     }
+    let encodedValue = try JSONEncoder().encode(value)
+    try EVY.data.create(key: key, data: encodedValue)
+  }
 
-    func testEvaluatesLogicalOperatorsWithLiterals() throws {
-        XCTAssertTrue(try EVY.evaluateFromText("{0 > 1 || 1 > 0}"))
-        XCTAssertFalse(try EVY.evaluateFromText("{0 > 1 || 0 > 2}"))
-        XCTAssertTrue(try EVY.evaluateFromText("{1 > 0 && 2 > 1}"))
-        XCTAssertFalse(try EVY.evaluateFromText("{1 > 0 && 0 > 1}"))
-    }
-
-    func testEvaluatesFunctionOperands() throws {
-        let titleKey = uniqueKey("title")
-        let reasonsKey = uniqueKey("reasons")
-
-        try store(.string("Hello"), at: titleKey)
-        try store(.array([.string("One"), .string("Two")]), at: reasonsKey)
-
-        XCTAssertTrue(try EVY.evaluateFromText("{count(\(titleKey)) > 0 || count(\(reasonsKey)) > 3}"))
-        XCTAssertFalse(try EVY.evaluateFromText("{count(\(titleKey)) > 10 && count(\(reasonsKey)) > 3}"))
-    }
-
-    func testEvaluatesBarePropsInsideComparison() throws {
-        let paymentCashKey = uniqueKey("payment_cash")
-        let paymentAppKey = uniqueKey("payment_app")
-
-        try store(.bool(false), at: paymentCashKey)
-        try store(.bool(true), at: paymentAppKey)
-
-        XCTAssertTrue(try EVY.evaluateFromText("{\(paymentCashKey) == true || \(paymentAppKey) == true}"))
-        XCTAssertFalse(try EVY.evaluateFromText("{\(paymentCashKey) == true && \(paymentAppKey) == false}"))
-    }
-
-    func testWatchTargetUnwrapsCountToUnderlyingDataKey() {
-        let key = uniqueKey("photo_ids")
-        XCTAssertEqual(
-            EVY.watchTarget(for: "Photos: {count(\(key))}/10 - more text"),
-            key
-        )
-    }
-
-    func testWatchTargetUsesFirstArgumentForMultiArgFunction() {
-        XCTAssertEqual(
-            EVY.watchTarget(for: "{formatDecimal(item.price, 2)}"),
-            "item.price"
-        )
-    }
-
-    func testCountReflectsArrayAfterStoreUpdate() throws {
-        let key = uniqueKey("photos")
-        try store(.array([.string("a")]), at: key)
-        let one = try parseTextFromText("n: {count(\(key))}")
-        XCTAssertEqual(one.value, "n: 1")
-
-        let encoded = try JSONEncoder().encode(EVYJson.array([.string("a"), .string("b")]))
-        try EVY.data.update(props: [key], data: encoded)
-
-        let two = try parseTextFromText("n: {count(\(key))}")
-        XCTAssertEqual(two.value, "n: 2")
-    }
-
-    func testFormatDecimalRoundsToPlaces() throws {
-        let key = uniqueKey("amount")
-        try store(.string("20.0423"), at: key)
-        let out = try parseTextFromText("{formatDecimal(\(key), 2)}")
-        XCTAssertEqual(out.value, "20.04")
-    }
-
-    func testFormatMetricLengthUsesTwoDecimalMetres() throws {
-        let key = uniqueKey("mm")
-        try store(.int(23240), at: key)
-        let out = try parseTextFromText("{formatMetricLength(\(key))}")
-        XCTAssertEqual(out.toString(), "23.24m")
-    }
-
-    func testFormatImperialLengthConvertsMillimetresToFeet() throws {
-        let key = uniqueKey("mm")
-        try store(.int(4231), at: key)
-        let out = try parseTextFromText("{formatImperialLength(\(key))}")
-        XCTAssertEqual(out.toString(), "13.88ft")
-    }
-
-    func testFormatDurationHumanizesMilliseconds() throws {
-        let key = uniqueKey("ms")
-        try store(.int(900_000), at: key)
-        let out = try parseTextFromText("{formatDuration(\(key))}")
-        XCTAssertEqual(out.value, "15 minutes")
-    }
-
-    func testFormatDateFormatsIsoStringWithPattern() throws {
-        let key = uniqueKey("created")
-        try store(.string("2024-01-19T12:42:52.000Z"), at: key)
-        let out = try parseTextFromText(
-            "{formatDate(\(key), \"MM/dd/yyyy\")}"
-        )
-        XCTAssertEqual(out.value, "01/19/2024")
-    }
-
-    private func store(_ value: EVYJson, at key: String) throws {
-        if EVY.data.exists(key: key) {
-            try EVY.data.delete(key: key)
-        }
-        let encodedValue = try JSONEncoder().encode(value)
-        try EVY.data.create(key: key, data: encodedValue)
-    }
-
-    private func uniqueKey(_ suffix: String) -> String {
-        let randomId = UUID().uuidString.replacingOccurrences(of: "-", with: "_")
-        return "evy_interpreter_tests_\(suffix)_\(randomId)"
-    }
+  private func uniqueKey(_ suffix: String) -> String {
+    let randomId = UUID().uuidString.replacingOccurrences(of: "-", with: "_")
+    return "evy_interpreter_tests_\(suffix)_\(randomId)"
+  }
 }


### PR DESCRIPTION
JIRA: 
Figma: 
Stream video: 

## Summary
- Moves EVY error handling into a dedicated iOS EVYError source file.
- Applies Xcode formatting across the iOS Swift codebase.

## Major changes
- Adds ios/evy/Data/EVYError.swift and wires it into the Xcode project.
- Keeps existing iOS behavior while standardizing Swift formatting after moving the error type.
- Updates Swift tests and e2e helper formatting consistently with the app code.

## Tests ran
- xcodebuild -quiet -project ios/evy.xcodeproj -scheme evy -destination platform=iOS Simulator,name=iPhone 17,OS=26.4.1 build: passed
- xcodebuild -quiet -project ios/evy.xcodeproj -scheme evy -destination platform=iOS Simulator,name=iPhone 17,OS=26.4.1 test -only-testing:evyTests: passed
- ./run-e2e.sh --skip-ios: passed
- xcodebuild -quiet -project ios/evy.xcodeproj -scheme evy -destination platform=iOS Simulator,name=iPhone 17,OS=26.4.1 test: attempted; unit tests passed, UI/e2e tests failed outside the dedicated e2e service runner with simulator launch and backend-dependent failures

## Risks / suggestions
- Large Swift formatting-only diff can make review noisier.
- If needed, rerun the full iOS e2e suite with services already running to validate UI flows separately.
