### PR TITLE
[REFACTOR] Update architecture diagrams

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -29,6 +29,7 @@ runs:
                   changes:
                     - '${{ inputs.path-filter }}'
                     ${{ inputs.path-filter-extra != '' && format('- ''{0}''', inputs.path-filter-extra) }}
+                    - '!**/*.md'
 
         - name: Setup Bun
           if: steps.filter.outputs.changes == 'true'

--- a/.github/workflows/api_build.yml
+++ b/.github/workflows/api_build.yml
@@ -3,8 +3,12 @@ name: API Build
 on:
     pull_request:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
     push:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
 
 jobs:
     api_build:

--- a/.github/workflows/api_lint.yml
+++ b/.github/workflows/api_lint.yml
@@ -3,8 +3,14 @@ name: API Lint
 on:
     pull_request:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
+            - 'docs/**'
     push:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
+            - 'docs/**'
 
 jobs:
     api_lint:

--- a/.github/workflows/api_tests.yml
+++ b/.github/workflows/api_tests.yml
@@ -3,8 +3,12 @@ name: API Tests
 on:
     pull_request:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
     push:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
 
 jobs:
     api_tests:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -3,12 +3,16 @@ name: E2E Tests
 on:
     pull_request:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
     push:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
     workflow_dispatch:
 
-# E2E runs on Blacksmith macOS 26 so iOS Simulator tests can run in CI. PostgreSQL is started on the host
-# (Homebrew); api/marketplace/web run via `run-e2e.sh --no-docker` (no Docker required for this job).
+        # E2E runs on Blacksmith macOS 26 so iOS Simulator tests can run in CI. PostgreSQL is started on the host
+        # (Homebrew); api/marketplace/web run via `run-e2e.sh --no-docker` (no Docker required for this job).
 
 jobs:
     e2e_tests:
@@ -36,13 +40,16 @@ jobs:
                         - 'run-e2e.sh'
                         - '.github/workflows/e2e_tests.yml'
                         - '.github/actions/**'
+                        - '!**/*.md'
 
             - name: Setup Bun
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               uses: oven-sh/setup-bun@v2
 
             - name: Start PostgreSQL on host
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               run: |
                   set -euo pipefail
                   brew install postgresql@16
@@ -57,19 +64,23 @@ jobs:
                   "$PG_BIN/createdb" -h localhost -p 5432 -U postgres -O evy marketplace
 
             - name: Install dependencies
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               run: bun run install:all
 
             - name: Prepare .env and generate types
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               uses: ./.github/actions/prepare-dotenv-and-types
 
             - name: Install Playwright browsers
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               run: bun run --cwd web test:setup
 
             - name: Verify Xcode and iOS simulators
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               run: |
                   set -euo pipefail
                   echo "Available Xcode apps:"
@@ -81,7 +92,8 @@ jobs:
                   xcodebuild -showdestinations -project ios/evy.xcodeproj -scheme evy | sed -n '1,80p'
 
             - name: Run E2E tests
-              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true'
+              if: github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
               env:
                   MARKETPLACE_GRPC_HOST: 127.0.0.1
                   IOS_SIMULATOR_DEVICE_NAME: iPhone 17
@@ -90,7 +102,8 @@ jobs:
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@v7
-              if: always() && (github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e == 'true')
+              if: always() && (github.event_name == 'workflow_dispatch' ||
+                  steps.paths.outputs.e2e == 'true')
               with:
                   name: e2e-tests-playwright-report
                   path: web/playwright-report/

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -1,69 +1,71 @@
 name: Create and publish docker images to Github
 
 on:
-  push:
-    branches: ['main']
+    push:
+        branches: ['main']
+        paths-ignore:
+            - '**/*.md'
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    build-and-push:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v4
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push api Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: api/Dockerfile
-          push: true
-          tags: ghcr.io/${{ github.repository }}-api:latest
-          labels: ${{ steps.meta.outputs.labels }}
+            - name: Build and push api Docker image
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: api/Dockerfile
+                  push: true
+                  tags: ghcr.io/${{ github.repository }}-api:latest
+                  labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Build and push web Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: web/Dockerfile
-          push: true
-          tags: ghcr.io/${{ github.repository }}-web:latest
-          labels: ${{ steps.meta.outputs.labels }}
+            - name: Build and push web Docker image
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: web/Dockerfile
+                  push: true
+                  tags: ghcr.io/${{ github.repository }}-web:latest
+                  labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Docker Compose Remote Deploy api
-        uses: glesage/docker-compose-remote-action@v1
-        with:
-          service: api
-          project_name: evy
-          ssh_host: 170.64.163.217
-          ssh_user: evy
-          ssh_key: ${{ secrets.DO_SSH_KEY }}
-          known_host_key: ${{ secrets.DO_HOST_KEY }}
-          pull: true
-        env:
-          DB_USER: ${{ secrets.PG_USER }}
-          DB_PASS: ${{ secrets.PG_PASS }}
-          DB_PORT: 5432
-          DB_DOMAIN: db
-          DB_EVY_DATABASE: evy
+            - name: Docker Compose Remote Deploy api
+              uses: glesage/docker-compose-remote-action@v1
+              with:
+                  service: api
+                  project_name: evy
+                  ssh_host: 170.64.163.217
+                  ssh_user: evy
+                  ssh_key: ${{ secrets.DO_SSH_KEY }}
+                  known_host_key: ${{ secrets.DO_HOST_KEY }}
+                  pull: true
+              env:
+                  DB_USER: ${{ secrets.PG_USER }}
+                  DB_PASS: ${{ secrets.PG_PASS }}
+                  DB_PORT: 5432
+                  DB_DOMAIN: db
+                  DB_EVY_DATABASE: evy
 
-      - name: Docker Compose Remote Deploy web
-        uses: glesage/docker-compose-remote-action@v1
-        with:
-          service: web
-          project_name: evy
-          ssh_host: 170.64.163.217
-          ssh_user: evy
-          ssh_key: ${{ secrets.DO_SSH_KEY }}
-          known_host_key: ${{ secrets.DO_HOST_KEY }}
-          pull: true
+            - name: Docker Compose Remote Deploy web
+              uses: glesage/docker-compose-remote-action@v1
+              with:
+                  service: web
+                  project_name: evy
+                  ssh_host: 170.64.163.217
+                  ssh_user: evy
+                  ssh_key: ${{ secrets.DO_SSH_KEY }}
+                  known_host_key: ${{ secrets.DO_HOST_KEY }}
+                  pull: true

--- a/.github/workflows/web_lint.yml
+++ b/.github/workflows/web_lint.yml
@@ -3,8 +3,14 @@ name: Web Lint
 on:
     pull_request:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
+            - 'docs/**'
     push:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
+            - 'docs/**'
 
 jobs:
     web_lint:

--- a/.github/workflows/web_tests.yml
+++ b/.github/workflows/web_tests.yml
@@ -3,8 +3,12 @@ name: Web Tests
 on:
     pull_request:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
     push:
         branches: [dev]
+        paths-ignore:
+            - '**/*.md'
 
 jobs:
     web_tests:

--- a/api/README.md
+++ b/api/README.md
@@ -86,15 +86,18 @@ sequenceDiagram
 { "jsonrpc": "2.0", "method": "dataUpdated", "params": { /* row */ } }
 ```
 
-- Successful `evy` upserts call `emitJsonRpc` from [`src/rpc.ts`](./src/rpc.ts): `flowUpdated` when `resource === "sdui"`, otherwise `dataUpdated`.
-- Remote services emit named events on `evy.Service.SubscribeEvents`; [`src/services.ts`](./src/services.ts) parses `payload_json` and forwards them with the same `emitJsonRpc` helper (reconnect with exponential backoff).
+- [`src/index.ts`](./src/index.ts) creates a `broadcast` callback wrapping `emitJsonRpc` and injects it into `rpc` and `services` at startup.
+- Successful `evy` upserts invoke the broadcast callback from [`src/rpc.ts`](./src/rpc.ts): `flowUpdated` when `resource === "sdui"`, otherwise `dataUpdated`.
+- Remote services emit named events on `evy.Service.SubscribeEvents`; [`src/services.ts`](./src/services.ts) parses `payload_json` and forwards them via the same broadcast callback (reconnect with exponential backoff).
+- The shared [`src/broadcast.ts`](./src/broadcast.ts) defines the `BroadcastFn` type contract, decoupling `rpc` and `services` from the WebSocket layer.
 
 ### Internal module layout
 
 ```mermaid
 flowchart TD
-    index[index.ts<br/>wires server + handlers]
+    index[index.ts<br/>wires server + handlers + broadcast]
     ws[ws.ts<br/>JSON-RPC transport]
+    broadcast[broadcast.ts<br/>BroadcastFn type contract]
     rpc[rpc.ts<br/>get / upsert routing]
     data[data.ts<br/>Drizzle + auth<br/>getCore / upsertCore]
     services[services.ts<br/>gRPC adapters + SubscribeEvents]
@@ -106,13 +109,14 @@ flowchart TD
     index --> ws
     index --> rpc
     index --> data
+    index --> services
     rpc --> data
     rpc --> services
     rpc --> serviceDataSync
-    rpc --> ws
+    rpc --> broadcast
     serviceDataSync --> services
     serviceDataSync --> expressionParser
-    services --> ws
+    services --> broadcast
     data --> db
     readiness --> rpc
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -97,7 +97,6 @@ sequenceDiagram
 flowchart TD
     index[index.ts<br/>wires server + handlers + broadcast]
     ws[ws.ts<br/>JSON-RPC transport]
-    broadcast[broadcast.ts<br/>BroadcastFn type contract]
     rpc[rpc.ts<br/>get / upsert routing]
     data[data.ts<br/>Drizzle + auth<br/>getCore / upsertCore]
     services[services.ts<br/>gRPC adapters + SubscribeEvents]
@@ -113,10 +112,8 @@ flowchart TD
     rpc --> data
     rpc --> services
     rpc --> serviceDataSync
-    rpc --> broadcast
     serviceDataSync --> services
     serviceDataSync --> expressionParser
-    services --> broadcast
     data --> db
     readiness --> rpc
 ```

--- a/ios/README.md
+++ b/ios/README.md
@@ -40,7 +40,7 @@ flowchart LR
         Row -->|child / children| Row
     end
 
-    Content -->|fetch SDUI| EVY
+    Content -->|sync services / fetch SDUI| EVY
     Content -->|render| EVYPage
     EVYPage --> Page
     EVYPage --> EVYRow[EVYRow dispatcher]
@@ -57,7 +57,7 @@ flowchart LR
     EVYRow --> Edit
     EVYRow --> ViewRows
 
-    Views[UI/Views<br/>EVYCalendar, EVYDropdown, EVYInlinePicker,<br/>EVYInputList, EVYMap, EVYSearch, EVYSelectList,<br/>EVYSelectPhoto, EVYTextField, EVYTimeslotPicker, ...]
+    Views[UI/Views<br/>EVYButton, EVYCalendar, EVYDropdown, EVYInlinePicker,<br/>EVYInputList, EVYMap, EVYSearch, EVYSelectList,<br/>EVYSelectPhoto, EVYTextField, EVYTimeslotPicker, ...]
     Atoms[UI/Atoms<br/>CarouselIndicator, RadioButton,<br/>Rectangle, RowTitle, TextView]
     Action --> Views
     Edit --> Views
@@ -65,7 +65,7 @@ flowchart LR
     ViewRows --> Atoms
     Views --> Atoms
 
-    EVY[[EVY facade<br/>getData / getSDUI / create<br/>getDataFromText / updateValue<br/>ensureDraftExists / formatData]]
+    EVY[[EVY facade<br/>getDataFromText / getDataFromProps / getSDUI<br/>create / updateValue / updateData<br/>ensureDraftExists / formatData / evaluateFromText<br/>syncAllServices / resolveQueryParams]]
     Action -->|run| Runner[EVYActionRunner<br/>navigate / create / close /<br/>highlight_required]
     Runner --> Content
     Runner --> EVY
@@ -74,21 +74,23 @@ flowchart LR
     ViewRows -->|read bindings| EVY
     Container -->|read bindings| EVY
 
-    Interpreter[interpreter.swift<br/>parseProps / splitProps /<br/>parseTextFromText / parseFunctionCall]
+    Interpreter[interpreter.swift<br/>parsePropsFromText / splitPropsFromText /<br/>parseTextFromText / parseFunctionCall /<br/>splitFunctionArguments]
     Functions[functions.swift<br/>count, length, format*,<br/>build*, compare, ...]
     EVY --> Interpreter
     EVY --> Functions
     Functions --> EVY
-    RowTree[EVYRowTree<br/>DFS walk]
-    Content --> RowTree
-    EVYPage --> RowTree
+
+    RowVisitor[forEachRow<br/>recursive row visitor]
+    Content -->|extract create keys| RowVisitor
+    EVYPage -->|bootstrap drafts| RowVisitor
+    RowVisitor --> Row
 
     subgraph data [Data]
         PublicStore[EVYDataStore public<br/>server-synced SwiftData]
         PrivateStore[EVYDataStore private<br/>$local SwiftData]
-        DraftStore[EVYDraftStore<br/>draft cache + active scope]
+        DraftStore[EVYDraftStore<br/>in-memory draft cache + active scope]
         EntityModel[(EVYData)]
-        DraftPath[EVYDraft.binding / EVYDraft.Scope<br/>scopeId = flowId:entityKey]
+        DraftPath[EVYDraft.Binding<br/>scopeId + pathSegments + mergeMode]
         PublicStore --> EntityModel
         PrivateStore --> EntityModel
         DraftStore --> EntityModel
@@ -98,19 +100,28 @@ flowchart LR
     EVY --> PrivateStore
     EVY --> DraftStore
 
+    SearchCtrl[EVYSearchController<br/>local/API search state]
+    Views --> SearchCtrl
+    SearchCtrl -->|read local results| EVY
+    SearchCtrl -->|API searches| APIManager
+
     subgraph api [Data/API]
-        APIManager[EVYAPIManager.shared]
+        APIManager[EVYAPIManager.shared<br/>auth + subscriptions]
         WS[EVYWebsocket<br/>JSON-RPC over WebSocket]
         APIManager --> WS
     end
     EVY -->|fetch / upsert| APIManager
 
     Notif{{NotificationCenter<br/>.evyDataUpdated<br/>.evyFlowUpdated<br/>.evyErrorOccurred}}
-    Manager -. post .-> Notif
+    PublicStore -. post .-> Notif
+    DraftStore -. post .-> Notif
     EVY -. post .-> Notif
+    Runner -. post .-> Notif
     WS -. post .-> Notif
+    Views -. post errors .-> Notif
     Notif -. observe .-> Content
     Notif -. observe .-> EVYState["EVYState T"]
+    Notif -. observe .-> Views
     EVYState -. drives .-> Views
     EVYState -. drives .-> Atoms
 ```


### PR DESCRIPTION
## Summary
- Updates API and iOS architecture diagrams to match the current implementation.
- Clarifies API runtime broadcast wiring while keeping type-only imports out of the internal module dependency diagram.
- Corrects the iOS diagram for current facade methods, row traversal, search controller, draft binding, and notification flow.

## Major changes
- Refreshed API README architecture documentation for JSON-RPC dispatch, gRPC forwarding, service data sync, real-time notifications, and internal module layout.
- Updated related documentation and diagrams across the repo to reflect current service, iOS, web, and shared type contracts.
- Kept broadcast.ts documented as the shared BroadcastFn type contract without rendering it as a runtime dependency in the internal module layout.

## Tests ran
- Not run per request; CI will run checks.

## Risks / suggestions for later
- Documentation-only diagram updates are low risk.
- Mermaid rendering should be verified in GitHub's PR preview.