### PR TITLE
[FEAT] Add -- option to clear action branches in action editor modal

### DIFF
--- a/web/app/components/actionPopup/BranchEditor.tsx
+++ b/web/app/components/actionPopup/BranchEditor.tsx
@@ -12,7 +12,7 @@ import {
 	toVariableOptions,
 } from "../../utils/actionFlowOptions";
 import { PopoverSelect, type PopoverOption } from "../PopoverSelect";
-import { FUNCTION_OPTIONS } from "./actionPopupConstants";
+import { BRANCH_FUNCTION_OPTIONS } from "./actionPopupConstants";
 
 type BranchEditorProps = {
 	branchId: string;
@@ -122,7 +122,7 @@ export function BranchEditor({
 		<div className="evy-flex evy-flex-col evy-gap-1">
 			<PopoverSelect
 				ariaLabel={`${branchId}-function`}
-				options={FUNCTION_OPTIONS}
+				options={BRANCH_FUNCTION_OPTIONS}
 				value={selectedFunction}
 				onChange={handleFunctionChange}
 			/>

--- a/web/app/components/actionPopup/actionPopupConstants.ts
+++ b/web/app/components/actionPopup/actionPopupConstants.ts
@@ -17,6 +17,11 @@ export const FUNCTION_OPTIONS: PopoverOption[] = ACTION_FUNCTIONS.map((fn) => ({
 	label: FUNCTION_LABELS[fn],
 }));
 
+export const BRANCH_FUNCTION_OPTIONS: PopoverOption[] = [
+	{ value: "", label: "--" },
+	...FUNCTION_OPTIONS,
+];
+
 export const BOOLEAN_OPTIONS: PopoverOption[] = [
 	{ value: "true", label: "true" },
 	{ value: "false", label: "false" },

--- a/web/tests/configuration.spec.ts
+++ b/web/tests/configuration.spec.ts
@@ -1205,4 +1205,126 @@ test.describe("Row configuration", () => {
 			"Nest level 7",
 		);
 	});
+
+	test("should clear a branch by selecting -- and persist on save", async ({
+		page,
+	}) => {
+		await openAppWithTestFlows(page, [
+			{
+				id: "step_1",
+				title: "Test Page",
+				rows: [
+					{
+						type: "Button",
+						view: {
+							content: { title: "", label: "Clear Branch" },
+						},
+						actions: [{ condition: "", false: "", true: "{close()}" }],
+					},
+				],
+			},
+		]);
+		const buttonRow = page.getByText("Clear Branch", { exact: true }).first();
+		await expect(buttonRow).toBeVisible();
+		await buttonRow.click();
+
+		const configPanel = getConfigPanel(page);
+
+		// Verify the existing true branch is shown
+		await expect(configPanel.getByText("If true")).toBeVisible();
+		await expect(configPanel.getByText("Close")).toBeVisible();
+
+		await configPanel.getByLabel("Edit action 1").click();
+
+		const popup = page.getByRole("dialog", { name: "Edit action 1" });
+		await expect(popup).toBeVisible();
+
+		// Verify true branch is set to close
+		const trueFunctionSelect = popup.getByLabel("true-0-function");
+		await expect(trueFunctionSelect).toHaveAttribute("data-value", "close");
+
+		// Select -- to clear the true branch
+		await popoverSelect(page, trueFunctionSelect, "--");
+		await expect(trueFunctionSelect).toHaveAttribute("data-value", "");
+
+		// Nested controls should be gone
+		await expect(popup.getByLabel("true-0-arg-0")).not.toBeVisible();
+
+		await popup.getByRole("button", { name: "Save" }).click();
+		await expect(popup).not.toBeVisible();
+
+		// After save, the true branch summary should be gone
+		await expect(configPanel.getByText("If true")).not.toBeVisible();
+		await expect(configPanel.getByText("Close")).not.toBeVisible();
+
+		// Reopen and verify the branch is still empty
+		await configPanel.getByLabel("Edit action 1").click();
+		const reopenedPopup = page.getByRole("dialog", {
+			name: "Edit action 1",
+		});
+		await expect(reopenedPopup).toBeVisible();
+		await expect(reopenedPopup.getByLabel("true-0-function")).toHaveAttribute(
+			"data-value",
+			"",
+		);
+	});
+
+	test("should not persist branch clear when cancel is clicked after selecting --", async ({
+		page,
+	}) => {
+		await openAppWithTestFlows(page, [
+			{
+				id: "step_1",
+				title: "Test Page",
+				rows: [
+					{
+						type: "Button",
+						view: {
+							content: { title: "", label: "Cancel Clear" },
+						},
+						actions: [{ condition: "", false: "", true: "{close()}" }],
+					},
+				],
+			},
+		]);
+		const buttonRow = page.getByText("Cancel Clear", { exact: true }).first();
+		await expect(buttonRow).toBeVisible();
+		await buttonRow.click();
+
+		const configPanel = getConfigPanel(page);
+
+		await expect(configPanel.getByText("If true")).toBeVisible();
+		await expect(configPanel.getByText("Close")).toBeVisible();
+
+		await configPanel.getByLabel("Edit action 1").click();
+
+		const popup = page.getByRole("dialog", { name: "Edit action 1" });
+		await expect(popup).toBeVisible();
+
+		const trueFunctionSelect = popup.getByLabel("true-0-function");
+		await expect(trueFunctionSelect).toHaveAttribute("data-value", "close");
+
+		// Select -- to clear the true branch
+		await popoverSelect(page, trueFunctionSelect, "--");
+		await expect(trueFunctionSelect).toHaveAttribute("data-value", "");
+
+		// Cancel the popup
+		await popup.getByRole("button", { name: "Cancel" }).click();
+		await expect(popup).not.toBeVisible();
+
+		// The original branch should still be shown in the summary
+		await expect(configPanel.getByText("If true")).toBeVisible();
+		await expect(configPanel.getByText("Close")).toBeVisible();
+
+		// Reopen and verify the original branch is preserved
+		await configPanel.getByLabel("Edit action 1").click();
+		const reopenedPopup = page.getByRole("dialog", {
+			name: "Edit action 1",
+		});
+		await expect(reopenedPopup).toBeVisible();
+		await expect(reopenedPopup.getByLabel("true-0-function")).toHaveAttribute(
+			"data-value",
+			"close",
+		);
+	});
 });


### PR DESCRIPTION
## Summary

On the web builder, once you select an action for the true or false branch of a row action, there was no way to undo/remove it from the modal. This change adds a `--` option to the action function dropdowns, which clears the branch (and all its nested/child configuration) upon saving.

## Major changes

- **web/app/components/actionPopup/actionPopupConstants.ts** — Added `BRANCH_FUNCTION_OPTIONS` export that prepends `{ value: "", label: "--" }` to the existing function options list.
- **web/app/components/actionPopup/BranchEditor.tsx** — Switched the action function `PopoverSelect` to use `BRANCH_FUNCTION_OPTIONS` instead of `FUNCTION_OPTIONS`. The existing `handleFunctionChange` already handles the clearing logic (calls `onChange("")
` for an empty function name).
- **web/tests/configuration.spec.ts** — Two new Playwright tests:
  - `should clear a branch by selecting -- and persist on save`: verifies that selecting `--` clears the branch, nested controls disappear, and the change persists after Save.
  - `should not persist branch clear when cancel is clicked after selecting --`: verifies that selecting `--` then Cancel preserves the original branch configuration.

## Key design decisions

- The deletion only commits on **Save** — the modal-local state holds the change until then. Cancel reverts the branch to its previous value.
- No database/persistence calls from `BranchEditor` — it only calls the local `onChange` prop, keeping the change local to `ActionPopup`.
- The existing `buildArgDropdowns` function already returns an empty array when `functionName` is empty, so all nested arg dropdowns and the navigate query textarea disappear automatically when `--` is selected.

## Risks

Low risk. The change is purely additive (new dropdown option) and relies on existing clearing/rendering logic already in place. The `FUNCTION_OPTIONS` export was left untouched to avoid affecting the condition editor's operand dropdowns.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->