### PR TITLE
[FEAT] Improve drag-and-drop page and footer targets

### DIFF
--- a/web/app/components/AppPage.tsx
+++ b/web/app/components/AppPage.tsx
@@ -2,9 +2,15 @@ import { useCallback, useMemo, useRef, type CSSProperties } from "react";
 
 import { useDragContext, useFlowsContext } from "../state";
 import { usePageDropTarget } from "../hooks/usePageDropTarget";
+import { usePageEdgeIndicators } from "../hooks/usePageEdgeIndicators";
 import { canvasPageInteriorDomProps } from "../utils/canvasPageInterior";
 import { findFlowById } from "../utils/flowHelpers";
+import { BlankPageDropIndicator } from "./BlankPageDropIndicator";
 import { buildRowElements } from "./buildRowElements";
+import { DraggableRowContainer } from "./DraggableRowContainer";
+import { FooterPlaceholderDropIndicator } from "./FooterPlaceholderDropIndicator";
+import { PageEdgeDropZone } from "./PageEdgeDropZone";
+
 import { baseTitleStyle, rounded24Style } from "./pageStyles";
 
 const pageTitleStyle: CSSProperties = {
@@ -14,16 +20,12 @@ const pageTitleStyle: CSSProperties = {
 	border: "none",
 };
 
-const roundedBottom24Style: CSSProperties = {
-	borderBottomLeftRadius: "var(--radius-2-4)",
-	borderBottomRightRadius: "var(--radius-2-4)",
-};
-
 export default function AppPage({ pageId }: { pageId: string }) {
 	const { flows, activeFlowId, dispatchRow } = useFlowsContext();
-	const { dispatchDropIndicator } = useDragContext();
+	const { dispatchDropIndicator, dragging } = useDragContext();
 
 	const scrollableRef = useRef<HTMLDivElement | null>(null);
+	const pageWrapperRef = useRef<HTMLDivElement | null>(null);
 
 	const selectRow = useCallback(
 		(rowId: string) => dispatchRow({ type: "SET_ACTIVE_ROW", rowId }),
@@ -39,11 +41,17 @@ export default function AppPage({ pageId }: { pageId: string }) {
 		[pageId, dispatchRow],
 	);
 
+	const selectPageDirect = useCallback(
+		() => dispatchRow({ type: "SET_ACTIVE_PAGE", pageId }),
+		[pageId, dispatchRow],
+	);
+
 	usePageDropTarget({
 		scrollableRef,
 		pageId,
 		dispatchDropIndicator,
 		onClickBackground: selectPage,
+		dropTargetRef: pageWrapperRef,
 	});
 
 	const page = useMemo(
@@ -51,10 +59,17 @@ export default function AppPage({ pageId }: { pageId: string }) {
 		[flows, activeFlowId, pageId],
 	);
 
+	const pageRows = page?.rows ?? [];
+	const pageHasRows = pageRows.length > 0;
+	const lastRowId = pageHasRows ? pageRows[pageRows.length - 1].id : undefined;
+
+	const { forcedIndicators, showBlankPageIndicator, edgePosition } =
+		usePageEdgeIndicators(pageId, lastRowId, pageHasRows);
+
 	const rowElements = useMemo(() => {
 		if (!page) return [];
-		return buildRowElements(page.rows, selectRow);
-	}, [page, selectRow]);
+		return buildRowElements(page.rows, selectRow, forcedIndicators);
+	}, [page, selectRow, forcedIndicators]);
 
 	const titleElement = page?.title ? (
 		<button
@@ -76,35 +91,53 @@ export default function AppPage({ pageId }: { pageId: string }) {
 		>
 			{footer ? (
 				<div
+					ref={pageWrapperRef}
 					className="evy-flex evy-flex-col evy-h-full evy-bg-white"
 					style={rounded24Style}
 				>
 					{titleElement}
+					{showBlankPageIndicator && <BlankPageDropIndicator />}
 					<div
-						className="evy-overflow-scroll evy-flex-1 evy-pt-4"
+						className="evy-overflow-scroll evy-flex evy-flex-col evy-flex-1 evy-pt-4"
 						{...canvasPageInteriorDomProps}
 						ref={scrollableRef}
 					>
 						{rowElements}
+						<PageEdgeDropZone
+							pageId={pageId}
+							position={edgePosition}
+							dispatchDropIndicator={dispatchDropIndicator}
+							className="evy-flex-1"
+							style={{ minHeight: "var(--size-8)" }}
+							onClick={selectPageDirect}
+						/>
 					</div>
-					<button
-						type="button"
-						className="evy-border-none evy-hover:bg-gray-light evy-cursor-pointer evy-w-full evy-bg-white evy-p-0"
-						style={roundedBottom24Style}
-						onClick={() => selectRow(footer.id)}
+					<DraggableRowContainer
+						rowId={footer.id}
+						selectRow={() => selectRow(footer.id)}
 					>
 						{footer.row}
-					</button>
+					</DraggableRowContainer>
 				</div>
 			) : (
 				<div
-					className="evy-overflow-scroll evy-h-full evy-pt-4 evy-bg-white"
+					className="evy-overflow-scroll evy-flex evy-flex-col evy-h-full evy-pt-4 evy-bg-white"
 					style={rounded24Style}
 					{...canvasPageInteriorDomProps}
 					ref={scrollableRef}
 				>
 					{titleElement}
+					{showBlankPageIndicator && <BlankPageDropIndicator />}
 					{rowElements}
+					<PageEdgeDropZone
+						pageId={pageId}
+						position={edgePosition}
+						dispatchDropIndicator={dispatchDropIndicator}
+						className="evy-flex-1"
+						style={{ minHeight: "var(--size-8)" }}
+						onClick={selectPageDirect}
+					/>
+					{dragging && <FooterPlaceholderDropIndicator pageId={pageId} />}
 				</div>
 			)}
 		</div>

--- a/web/app/components/BlankPageDropIndicator.tsx
+++ b/web/app/components/BlankPageDropIndicator.tsx
@@ -1,0 +1,13 @@
+export function BlankPageDropIndicator() {
+	return (
+		<div
+			className="evy-w-full"
+			style={{
+				height: "2px",
+				marginTop: "var(--size-2)",
+				backgroundColor: "var(--color-evy-blue)",
+				flexShrink: 0,
+			}}
+		/>
+	);
+}

--- a/web/app/components/ContainerChildren.tsx
+++ b/web/app/components/ContainerChildren.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import type { Row } from "../types/row";
+import type { Row, ContainerType } from "../types/row";
 import { useFlowsContext } from "../state";
 import { DraggableRowContainer } from "./DraggableRowContainer";
 import { PlaceholderDropIndicator } from "./PlaceholderDropIndicator";
@@ -9,12 +9,16 @@ export function ContainerChildren({
 	rows,
 	orientation = "vertical",
 	showIndicators = false,
-	showPlaceholder,
+	containerRowId,
+	containerType,
+	showPlaceholder = true,
 }: {
 	rows: Row[] | undefined;
 	orientation?: "horizontal" | "vertical";
 	showIndicators?: boolean;
-	showPlaceholder: boolean;
+	containerRowId: string;
+	containerType: ContainerType;
+	showPlaceholder?: boolean;
 }) {
 	const { dispatchRow } = useFlowsContext();
 
@@ -27,23 +31,23 @@ export function ContainerChildren({
 
 	if (!rows?.length) {
 		return showPlaceholder ? (
-			<PlaceholderDropIndicator key="placeholder" />
+			<PlaceholderDropIndicator
+				key="placeholder"
+				containerRowId={containerRowId}
+				containerType={containerType}
+			/>
 		) : null;
 	}
 
-	const lastIndex = rows.length - 1;
-
 	return (
 		<>
-			{rows.map((child, index) => (
+			{rows.map((child) => (
 				<DraggableRowContainer
 					key={child.id}
 					rowId={child.id}
 					selectRow={() => selectNestedRow(child.id)}
 					orientation={orientation}
 					showIndicators={showIndicators}
-					previousRowId={index > 0 ? rows[index - 1].id : undefined}
-					nextRowId={index < lastIndex ? rows[index + 1].id : undefined}
 				>
 					{child.row}
 				</DraggableRowContainer>

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { Fragment } from "react";
+import { Fragment, useMemo } from "react";
 import ReactDOM from "react-dom";
 
 import { useDraggable, idleState } from "../hooks/useDraggable";
@@ -11,27 +11,34 @@ export function DraggableRowContainer({
 	selectRow,
 	orientation,
 	showIndicators = false,
-	previousRowId,
-	nextRowId,
 	isDraggable = true,
+	forcedIndicators,
 }: {
 	rowId: string;
 	children: React.ReactNode;
 	selectRow?: () => void;
 	orientation?: "horizontal" | "vertical";
 	showIndicators?: boolean;
-	previousRowId?: string;
-	nextRowId?: string;
 	isDraggable?: boolean;
+	forcedIndicators?: Array<"before" | "after">;
 }) {
-	const { ref, state, indicators, dropzones } = useDraggable({
+	const {
+		ref,
+		state,
+		indicators: hookIndicators,
+	} = useDraggable({
 		rowId,
 		orientation,
 		showIndicators,
-		previousRowId,
-		nextRowId,
 		isDraggable,
 	});
+
+	const mergedIndicators = useMemo(() => {
+		if (forcedIndicators?.length) {
+			return forcedIndicators;
+		}
+		return hookIndicators;
+	}, [forcedIndicators, hookIndicators]);
 
 	return (
 		<Fragment>
@@ -39,8 +46,7 @@ export function DraggableRowContainer({
 				ref={ref}
 				state={state}
 				selectRow={selectRow}
-				indicators={indicators}
-				dropzones={dropzones}
+				indicators={mergedIndicators}
 				orientation={orientation}
 			>
 				{children}

--- a/web/app/components/DropPlaceholderShell.tsx
+++ b/web/app/components/DropPlaceholderShell.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type CSSProperties, type ReactNode } from "react";
+
+type DropPlaceholderShellProps = {
+	children: ReactNode;
+	isDraggedOver: boolean;
+	className?: string;
+	style?: CSSProperties;
+};
+
+export const DropPlaceholderShell = forwardRef<
+	HTMLDivElement,
+	DropPlaceholderShellProps
+>(function DropPlaceholderShell(
+	{ children, isDraggedOver, className, style },
+	ref,
+) {
+	return (
+		<div
+			ref={ref}
+			className={`evy-flex evy-items-center evy-justify-center evy-w-full evy-rounded-sm${className ? ` ${className}` : ""}`}
+			style={{
+				minHeight: "var(--size-8)",
+				border: "2px dashed var(--color-evy-blue)",
+				backgroundColor: isDraggedOver ? "var(--color-evy-blue)" : undefined,
+				opacity: isDraggedOver ? 1 : 0.8,
+				transition: "background-color 0.1s ease, opacity 0.1s ease",
+				...style,
+			}}
+		>
+			<span
+				className="evy-text-sm"
+				style={{ color: isDraggedOver ? "white" : "var(--color-evy-blue)" }}
+			>
+				{children}
+			</span>
+		</div>
+	);
+});

--- a/web/app/components/FooterPlaceholderDropIndicator.tsx
+++ b/web/app/components/FooterPlaceholderDropIndicator.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react";
+import invariant from "tiny-invariant";
+
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+import { DropPlaceholderShell } from "./DropPlaceholderShell";
+
+export function FooterPlaceholderDropIndicator({ pageId }: { pageId: string }) {
+	const ref = useRef<HTMLDivElement | null>(null);
+	const [isDraggedOver, setIsDraggedOver] = useState(false);
+
+	useEffect(() => {
+		const element = ref.current;
+		invariant(
+			element,
+			"FooterPlaceholderDropIndicator: ref.current is not defined",
+		);
+
+		return dropTargetForElements({
+			element,
+			canDrop: () => true,
+			getData: () => ({
+				destinationIsFooter: true,
+				pageId,
+			}),
+			onDragEnter: () => setIsDraggedOver(true),
+			onDragLeave: () => setIsDraggedOver(false),
+			onDrop: () => setIsDraggedOver(false),
+		});
+	}, [pageId]);
+
+	return (
+		<DropPlaceholderShell
+			ref={ref}
+			isDraggedOver={isDraggedOver}
+			style={{ flexShrink: 0 }}
+		>
+			Add footer row
+		</DropPlaceholderShell>
+	);
+}

--- a/web/app/components/PageEdgeDropZone.tsx
+++ b/web/app/components/PageEdgeDropZone.tsx
@@ -1,0 +1,73 @@
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	type CSSProperties,
+	type Dispatch,
+} from "react";
+import invariant from "tiny-invariant";
+
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+import type { DropIndicatorAction } from "../types/actions";
+
+export function PageEdgeDropZone({
+	pageId,
+	position,
+	dispatchDropIndicator,
+	style,
+	className,
+	onClick,
+}: {
+	pageId: string;
+	position: "start" | "end";
+	dispatchDropIndicator: Dispatch<DropIndicatorAction>;
+	style?: CSSProperties;
+	className?: string;
+	onClick?: () => void;
+}) {
+	const ref = useRef<HTMLDivElement | null>(null);
+
+	const setIndicatorPosition = useCallback(() => {
+		dispatchDropIndicator({
+			type: "SET_INDICATOR_PAGE_POSITION",
+			pageId,
+			position,
+		});
+	}, [dispatchDropIndicator, pageId, position]);
+
+	const clearIndicatorPosition = useCallback(() => {
+		dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE_POSITION" });
+	}, [dispatchDropIndicator]);
+
+	useEffect(() => {
+		const element = ref.current;
+		invariant(element, "PageEdgeDropZone: ref.current is not defined");
+
+		return dropTargetForElements({
+			element,
+			getData: () => ({
+				pageId,
+				pageDropPosition: position,
+			}),
+			canDrop: () => true,
+			onDragEnter: setIndicatorPosition,
+			onDrag: setIndicatorPosition,
+			onDragLeave: clearIndicatorPosition,
+			onDrop: clearIndicatorPosition,
+		});
+	}, [clearIndicatorPosition, pageId, position, setIndicatorPosition]);
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: drop target background area
+		<div
+			ref={ref}
+			className={className}
+			style={style}
+			onClick={onClick}
+			onKeyDown={onClick ? (e) => e.key === "Enter" && onClick() : undefined}
+			role={onClick ? "button" : undefined}
+			tabIndex={onClick ? 0 : undefined}
+		/>
+	);
+}

--- a/web/app/components/PlaceholderDropIndicator.tsx
+++ b/web/app/components/PlaceholderDropIndicator.tsx
@@ -1,20 +1,52 @@
-import { DraggableRowContainer } from "./DraggableRowContainer";
-import { containerDropindicatorId } from "../rows/EVYRow";
-import {
-	verticalDropIndicator,
-	dropIndicatorExpansionBefore,
-} from "../rows/design-system/dropIndicator";
+import { useEffect, useRef, useState } from "react";
+import invariant from "tiny-invariant";
 
-export function PlaceholderDropIndicator() {
+import { attachClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+import { containerDropindicatorId } from "../rows/EVYRow";
+import { DropPlaceholderShell } from "./DropPlaceholderShell";
+import type { ContainerType } from "../types/row";
+
+export function PlaceholderDropIndicator({
+	containerRowId,
+	containerType,
+}: {
+	containerRowId: string;
+	containerType: ContainerType;
+}) {
+	const ref = useRef<HTMLDivElement | null>(null);
+	const [isDraggedOver, setIsDraggedOver] = useState(false);
+
+	useEffect(() => {
+		const element = ref.current;
+		invariant(element, "PlaceholderDropIndicator: ref.current is not defined");
+
+		return dropTargetForElements({
+			element,
+			canDrop: () => true,
+			getData: ({ input, element: targetElement }) =>
+				attachClosestEdge(
+					{
+						rowId: containerDropindicatorId,
+						destinationContainerRowId: containerRowId,
+						destinationContainerType: containerType,
+					},
+					{
+						input,
+						element: targetElement,
+						allowedEdges: ["top", "bottom"],
+					},
+				),
+			onDragEnter: () => setIsDraggedOver(true),
+			onDragLeave: () => setIsDraggedOver(false),
+			onDrop: () => setIsDraggedOver(false),
+		});
+	}, [containerRowId, containerType]);
+
 	return (
-		<DraggableRowContainer
-			rowId={containerDropindicatorId}
-			orientation="horizontal"
-			isDraggable={false}
-		>
-			<div
-				className={`${verticalDropIndicator} ${dropIndicatorExpansionBefore}`}
-			/>
-		</DraggableRowContainer>
+		<DropPlaceholderShell ref={ref} isDraggedOver={isDraggedOver}>
+			Drop row here
+		</DropPlaceholderShell>
 	);
 }

--- a/web/app/components/RowPrimitive.tsx
+++ b/web/app/components/RowPrimitive.tsx
@@ -1,32 +1,23 @@
 import type React from "react";
-import { forwardRef, useMemo } from "react";
+import { forwardRef } from "react";
 
 import {
-	dropIndicatorExpansionBefore,
-	dropIndicatorExpansionAfter,
-	horizontalDropIndicator,
-	verticalDropIndicator,
+	verticalDropIndicatorBefore,
+	verticalDropIndicatorAfter,
+	horizontalDropIndicatorBefore,
+	horizontalDropIndicatorAfter,
 } from "../rows/design-system/dropIndicator";
 
-import {
-	idleState,
-	draggingState,
-	type DraggableState,
-} from "../hooks/useDraggable";
-
-const previewState: DraggableState = {
-	type: "preview",
-	container: null,
-	rect: null,
-};
+import { idleState, type DraggableState } from "../hooks/useDraggable";
 
 type RowPrimitiveProps = {
 	children: React.ReactNode;
 	state: DraggableState;
 	selectRow?: () => void;
 	indicators?: Array<"before" | "after">;
-	dropzones?: Array<"before" | "after">;
 	orientation?: "horizontal" | "vertical";
+	className?: string;
+	style?: React.CSSProperties;
 };
 
 export const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
@@ -36,63 +27,40 @@ export const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 			state,
 			selectRow,
 			indicators = [],
-			dropzones = [],
 			orientation = "vertical",
+			className,
+			style,
 		},
 		ref,
 	) {
-		const cursor = useMemo(() => {
-			return {
-				[previewState.type]: "pointer",
-				[draggingState.type]: "pointer",
-				[idleState.type]: "grab",
-			}[state.type];
-		}, [state.type]);
+		const cursor = state.type === idleState.type ? "grab" : "pointer";
+		const beforeClass =
+			orientation === "vertical"
+				? verticalDropIndicatorBefore
+				: horizontalDropIndicatorBefore;
+		const afterClass =
+			orientation === "vertical"
+				? verticalDropIndicatorAfter
+				: horizontalDropIndicatorAfter;
 
-		const indicatorClass = useMemo(() => {
-			return orientation === "vertical"
-				? verticalDropIndicator
-				: horizontalDropIndicator;
-		}, [orientation]);
-
-		const showBefore = useMemo(
-			() => dropzones.includes("before") || indicators.includes("before"),
-			[dropzones, indicators],
-		);
-		const showAfter = useMemo(
-			() => dropzones.includes("after") || indicators.includes("after"),
-			[dropzones, indicators],
-		);
+		const showBefore = indicators.includes("before");
+		const showAfter = indicators.includes("after");
 
 		return (
-			<>
-				{showBefore && (
-					<div
-						className={`${indicatorClass} ${
-							indicators.includes("before") ? dropIndicatorExpansionBefore : ""
-						}`}
-					/>
-				)}
-				{/* biome-ignore lint/a11y/useSemanticElements: This is a drag-and-drop container that requires a div for proper layout */}
-				<div
-					className="evy-flex evy-flex-col evy-w-full evy-relative evy-hover:bg-gray-light"
-					style={{ cursor }}
-					ref={ref}
-					onClick={selectRow}
-					onKeyDown={(e) => e.key === "Enter" && selectRow?.()}
-					role="button"
-					tabIndex={0}
-				>
-					{children}
-				</div>
-				{showAfter && (
-					<div
-						className={`${indicatorClass} ${
-							indicators.includes("after") ? dropIndicatorExpansionAfter : ""
-						}`}
-					/>
-				)}
-			</>
+			// biome-ignore lint/a11y/useSemanticElements: This is a drag-and-drop container that requires a div for proper layout
+			<div
+				className={`evy-flex evy-flex-col evy-w-full evy-relative evy-hover:bg-gray-light${className ? ` ${className}` : ""}`}
+				style={{ cursor, ...style }}
+				ref={ref}
+				onClick={selectRow}
+				onKeyDown={(e) => e.key === "Enter" && selectRow?.()}
+				role="button"
+				tabIndex={0}
+			>
+				{showBefore && <div className={beforeClass} />}
+				{children}
+				{showAfter && <div className={afterClass} />}
+			</div>
 		);
 	},
 );

--- a/web/app/components/SecondarySheetPage.tsx
+++ b/web/app/components/SecondarySheetPage.tsx
@@ -2,7 +2,11 @@ import { useCallback, useMemo, useRef } from "react";
 
 import { useDragContext, useFlowsContext } from "../state";
 import { usePageDropTarget } from "../hooks/usePageDropTarget";
+import { usePageEdgeIndicators } from "../hooks/usePageEdgeIndicators";
+import { BlankPageDropIndicator } from "./BlankPageDropIndicator";
 import { buildRowElements } from "./buildRowElements";
+import { PageEdgeDropZone } from "./PageEdgeDropZone";
+
 import { baseTitleStyle, rounded24Style } from "./pageStyles";
 import { canvasPageInteriorDomProps } from "../utils/canvasPageInterior";
 import { findFlowById } from "../utils/flowHelpers";
@@ -42,11 +46,19 @@ export default function SecondarySheetPage({
 		extraData,
 	});
 
+	const pageHasRows = childRows.length > 0;
+	const lastChildRowId = pageHasRows
+		? childRows[childRows.length - 1].id
+		: undefined;
+
+	const { forcedIndicators, showBlankPageIndicator, edgePosition } =
+		usePageEdgeIndicators(pageId, lastChildRowId, pageHasRows);
+
 	const childRowIds = childRows.map((r) => r.id).join(",");
 	// biome-ignore lint/correctness/useExhaustiveDependencies: childRowIds detects in-place array mutations that childRows reference misses
 	const rowElements = useMemo(
-		() => buildRowElements(childRows, selectRow),
-		[childRows, childRowIds, selectRow],
+		() => buildRowElements(childRows, selectRow, forcedIndicators),
+		[childRows, childRowIds, selectRow, forcedIndicators],
 	);
 
 	return (
@@ -55,13 +67,21 @@ export default function SecondarySheetPage({
 			style={{ padding: "var(--size-30px)" }}
 		>
 			<div
-				className="evy-overflow-scroll evy-h-full evy-pt-4 evy-bg-white"
+				className="evy-overflow-scroll evy-flex evy-flex-col evy-h-full evy-pt-4 evy-bg-white"
 				style={rounded24Style}
 				{...canvasPageInteriorDomProps}
 				ref={scrollableRef}
 			>
 				<div style={baseTitleStyle}>{title}</div>
+				{showBlankPageIndicator && <BlankPageDropIndicator />}
 				{rowElements}
+				<PageEdgeDropZone
+					pageId={pageId}
+					position={edgePosition}
+					dispatchDropIndicator={dispatchDropIndicator}
+					className="evy-flex-1"
+					style={{ minHeight: "var(--size-8)" }}
+				/>
 			</div>
 		</div>
 	);

--- a/web/app/components/buildRowElements.tsx
+++ b/web/app/components/buildRowElements.tsx
@@ -4,18 +4,26 @@ import { DraggableRowContainer } from "./DraggableRowContainer";
 export function buildRowElements(
 	rows: Row[],
 	selectRow: (rowId: string) => void,
+	forcedIndicators?: {
+		rowId: string;
+		indicators: Array<"before" | "after">;
+	},
 ) {
-	const lastIndex = rows.length - 1;
-	return rows.map((row, index) => (
-		<DraggableRowContainer
-			key={row.id}
-			rowId={row.id}
-			selectRow={() => selectRow(row.id)}
-			showIndicators
-			previousRowId={index > 0 ? rows[index - 1].id : undefined}
-			nextRowId={index < lastIndex ? rows[index + 1].id : undefined}
-		>
-			{row.row}
-		</DraggableRowContainer>
-	));
+	return rows.map((row) => {
+		const rowForcedIndicators =
+			forcedIndicators && forcedIndicators.rowId === row.id
+				? forcedIndicators.indicators
+				: undefined;
+		return (
+			<DraggableRowContainer
+				key={row.id}
+				rowId={row.id}
+				selectRow={() => selectRow(row.id)}
+				showIndicators
+				forcedIndicators={rowForcedIndicators}
+			>
+				{row.row}
+			</DraggableRowContainer>
+		);
+	});
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -12,30 +12,45 @@
 	--color-gray-border: oklch(85% 0 0);
 
 	/* Sizes */
-	--size-1: 0.25rem; /* 4px */
-	--size-2: 0.5rem; /* 8px */
-	--size-3: 0.75rem; /* 12px */
-	--size-4: 1rem; /* 16px */
-	--size-8: 2rem; /* 32px */
+	--size-1: 0.25rem;
+	/* 4px */
+	--size-2: 0.5rem;
+	/* 8px */
+	--size-3: 0.75rem;
+	/* 12px */
+	--size-4: 1rem;
+	/* 16px */
+	--size-8: 2rem;
+	/* 32px */
 	--size-30px: 30px;
-	--size-32: 8rem; /* 128px */
-	--size-48: 12rem; /* 192px */
+	--size-32: 8rem;
+	/* 128px */
+	--size-48: 12rem;
+	/* 192px */
 	--size-nav-bar: 50px;
 	--size-nav-control: 34px;
 	--size-336: 336px;
 	--size-662: 662px;
 
 	/* Border radius */
-	--radius-sm: 0.25rem; /* 4px */
-	--radius-md: 0.5rem; /* 8px */
-	--radius-2-4: 2.4rem; /* 38.4px */
+	--radius-sm: 0.25rem;
+	/* 4px */
+	--radius-md: 0.5rem;
+	/* 8px */
+	--radius-2-4: 2.4rem;
+	/* 38.4px */
 
 	/* Font sizes */
-	--text-xs: 0.5rem; /* 8px */
-	--text-sm: 0.75rem; /* 12px */
-	--text-md: 0.875rem; /* 14px */
-	--text-l: 0.9375rem; /* 15px */
-	--text-xl: 1rem; /* 16px */
+	--text-xs: 0.5rem;
+	/* 8px */
+	--text-sm: 0.75rem;
+	/* 12px */
+	--text-md: 0.875rem;
+	/* 14px */
+	--text-l: 0.9375rem;
+	/* 15px */
+	--text-xl: 1rem;
+	/* 16px */
 
 	/* Font weights */
 	--font-medium: 500;
@@ -71,33 +86,43 @@ body {
 .evy-flex {
 	display: flex;
 }
+
 .evy-block {
 	display: block;
 }
+
 .evy-flex-col {
 	flex-direction: column;
 }
+
 .evy-flex-1 {
 	flex: 1 1 0%;
 }
+
 .evy-box-sizing-border {
 	box-sizing: border-box;
 }
+
 .evy-relative {
 	position: relative;
 }
+
 .evy-absolute {
 	position: absolute;
 }
+
 .evy-overflow-hidden {
 	overflow: hidden;
 }
+
 .evy-overflow-y-auto {
 	overflow-y: auto;
 }
+
 .evy-overflow-scroll {
 	overflow: scroll;
 }
+
 .evy-flex-shrink-0 {
 	flex-shrink: 0;
 }
@@ -106,15 +131,19 @@ body {
 .evy-justify-between {
 	justify-content: space-between;
 }
+
 .evy-justify-center {
 	justify-content: center;
 }
+
 .evy-items-center {
 	align-items: center;
 }
+
 .evy-text-center {
 	text-align: center;
 }
+
 .evy-text-left {
 	text-align: left;
 }
@@ -123,33 +152,42 @@ body {
 .evy-p-0 {
 	padding: 0;
 }
+
 .evy-p-2 {
 	padding: var(--size-2);
 }
+
 .evy-px-2 {
 	padding-left: var(--size-2);
 	padding-right: var(--size-2);
 }
+
 .evy-p-3 {
 	padding: var(--size-3);
 }
+
 .evy-p-4 {
 	padding: var(--size-4);
 }
+
 .evy-pl-4 {
 	padding-left: var(--size-4);
 }
+
 .evy-px-4 {
 	padding-left: var(--size-4);
 	padding-right: var(--size-4);
 }
+
 .evy-py-2 {
 	padding-top: var(--size-2);
 	padding-bottom: var(--size-2);
 }
+
 .evy-pr-8 {
 	padding-right: var(--size-8);
 }
+
 .evy-pt-4 {
 	padding-top: var(--size-4);
 }
@@ -158,27 +196,35 @@ body {
 .evy-gap-1 {
 	gap: var(--size-1);
 }
+
 .evy-gap-2 {
 	gap: var(--size-2);
 }
+
 .evy-gap-3 {
 	gap: var(--size-3);
 }
+
 .evy-gap-4 {
 	gap: var(--size-4);
 }
+
 .evy-mt-2 {
 	margin-top: var(--size-2);
 }
+
 .evy-mt-8 {
 	margin-top: var(--size-8);
 }
+
 .evy-mb-1 {
 	margin-bottom: var(--size-1);
 }
+
 .evy-mb-2 {
 	margin-bottom: var(--size-2);
 }
+
 .evy-mb-4 {
 	margin-bottom: var(--size-4);
 }
@@ -187,9 +233,11 @@ body {
 .evy-w-4 {
 	width: var(--size-4);
 }
+
 .evy-w-full {
 	width: 100%;
 }
+
 .evy-w-300 {
 	width: 300px;
 }
@@ -198,15 +246,19 @@ body {
 .evy-h-4 {
 	height: var(--size-4);
 }
+
 .evy-h-full {
 	height: 100%;
 }
+
 .evy-h-screen {
 	height: 100vh;
 }
+
 .evy-min-h-nav-bar {
 	min-height: var(--size-nav-bar);
 }
+
 .evy-min-h-full {
 	min-height: 100%;
 }
@@ -215,12 +267,15 @@ body {
 .evy-bg-gray-light {
 	background-color: var(--color-evy-gray-light);
 }
+
 .evy-bg-gray-dark {
 	background-color: var(--color-evy-gray-dark);
 }
+
 .evy-bg-white {
 	background-color: var(--color-white);
 }
+
 .evy-bg-transparent {
 	background-color: transparent;
 }
@@ -229,36 +284,47 @@ body {
 .evy-text-sm {
 	font-size: var(--text-sm);
 }
+
 .evy-text-md {
 	font-size: var(--text-md);
 }
+
 .evy-text-lg {
 	font-size: var(--text-l);
 }
+
 .evy-text-xl {
 	font-size: var(--text-xl);
 }
+
 .evy-text-white {
 	color: var(--color-white);
 }
+
 .evy-text-blue {
 	color: var(--color-evy-blue);
 }
+
 .evy-text-red {
 	color: var(--color-evy-red);
 }
+
 .evy-text-black {
 	color: var(--color-black);
 }
+
 .evy-text-gray {
 	color: var(--color-evy-gray);
 }
+
 .evy-text-gray-dark {
 	color: var(--color-evy-gray-dark);
 }
+
 .evy-font-medium {
 	font-weight: var(--font-medium);
 }
+
 .evy-font-semibold {
 	font-weight: var(--font-semibold);
 }
@@ -267,17 +333,21 @@ body {
 .evy-border-none {
 	border: none;
 }
+
 .evy-border {
 	border-width: 1px;
 	border-style: solid;
 }
+
 .evy-border-b {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
 }
+
 .evy-border-gray {
 	border-color: var(--color-gray-border);
 }
+
 .evy-border-gray-light {
 	border-color: var(--color-evy-gray-light);
 }
@@ -286,6 +356,7 @@ body {
 .evy-rounded-sm {
 	border-radius: var(--radius-sm);
 }
+
 .evy-rounded-md {
 	border-radius: var(--radius-md);
 }
@@ -294,15 +365,33 @@ body {
 .evy-inset-0 {
 	inset: 0;
 }
+
 .evy-inset-y-0 {
 	top: 0;
 	bottom: 0;
+}
+
+.evy-top-0 {
+	top: 0;
+}
+
+.evy-bottom-0 {
+	bottom: 0;
+}
+
+.evy-left-0 {
+	left: 0;
+}
+
+.evy-right-0 {
+	right: 0;
 }
 
 /* Pointer events */
 .evy-cursor-pointer {
 	cursor: pointer;
 }
+
 .evy-pointer-events-none {
 	pointer-events: none;
 }
@@ -316,9 +405,11 @@ body {
 .evy-hover\:bg-gray:hover {
 	background-color: var(--color-evy-gray);
 }
+
 .evy-hover\:bg-gray-light:hover {
 	background-color: var(--color-evy-gray-light);
 }
+
 .evy-hover\:text-black:hover {
 	color: var(--color-black);
 }
@@ -383,10 +474,12 @@ label {
 		hue-rotate(355deg) brightness(88%) contrast(95%);
 	transition: all var(--transition);
 }
+
 .evy-bin-button img {
 	width: 14px;
 	height: 14px;
 }
+
 .evy-bin-button:hover {
 	opacity: 1;
 	filter: brightness(0) saturate(100%) invert(23%) sepia(95%) saturate(5000%)
@@ -395,19 +488,21 @@ label {
 }
 
 .evy-v-dropzone {
-	transition: height 0.2s ease-in-out;
+	position: absolute;
+	left: 0;
+	right: 0;
+	height: 2px;
 	background-color: var(--color-evy-blue);
-	height: 0px;
-}
-.evy-v-dropzone.expanded {
-	height: var(--size-8);
+	pointer-events: none;
+	z-index: 10;
 }
 
 .evy-h-dropzone {
-	transition: width 0.2s ease-in-out;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 2px;
 	background-color: var(--color-evy-blue);
-	width: 0px;
-}
-.evy-h-dropzone.expanded {
-	width: var(--size-8);
+	pointer-events: none;
+	z-index: 10;
 }

--- a/web/app/hooks/useDraggable.ts
+++ b/web/app/hooks/useDraggable.ts
@@ -52,8 +52,6 @@ type UseDraggableOptions = {
 	rowId: string;
 	orientation?: "horizontal" | "vertical";
 	showIndicators?: boolean;
-	previousRowId?: string;
-	nextRowId?: string;
 	isDraggable?: boolean;
 };
 
@@ -61,15 +59,12 @@ type UseDraggableResult = {
 	ref: React.RefObject<HTMLDivElement | null>;
 	state: DraggableState;
 	indicators: Array<"before" | "after"> | undefined;
-	dropzones: Array<"before" | "after"> | undefined;
 };
 
 export function useDraggable({
 	rowId,
 	orientation = "vertical",
 	showIndicators = false,
-	previousRowId,
-	nextRowId,
 	isDraggable = true,
 }: UseDraggableOptions): UseDraggableResult {
 	const { dragging, dropIndicator, dispatchDropIndicator } = useDragContext();
@@ -101,26 +96,6 @@ export function useDraggable({
 			["bottom", "right"].includes(edge) ? "after" : undefined,
 		].filter((x): x is "before" | "after" => x !== undefined);
 	}, [dropIndicator, dragging, rowId, showIndicators]);
-
-	const dropzones = useMemo(() => {
-		if (dragging !== "rows" || !dropIndicator || !showIndicators) return;
-
-		const hideBefore =
-			(previousRowId && !dropIndicator.rowId) ||
-			(previousRowId &&
-				dropIndicator.rowId === previousRowId &&
-				dropIndicator.edge !== "bottom");
-		const hideAfter =
-			(nextRowId && dropIndicator.rowId && dropIndicator.rowId !== nextRowId) ||
-			(nextRowId &&
-				dropIndicator.rowId === nextRowId &&
-				dropIndicator.edge !== "top");
-
-		return [
-			hideBefore ? undefined : "before",
-			hideAfter ? undefined : "after",
-		].filter((x): x is "before" | "after" => x !== undefined);
-	}, [dragging, dropIndicator, previousRowId, nextRowId, showIndicators]);
 
 	const onDragEvent = useCallback(
 		(args: DragEvent) => {
@@ -236,6 +211,5 @@ export function useDraggable({
 		ref,
 		state,
 		indicators,
-		dropzones,
 	};
 }

--- a/web/app/hooks/usePageDropTarget.ts
+++ b/web/app/hooks/usePageDropTarget.ts
@@ -13,27 +13,29 @@ export function usePageDropTarget({
 	dispatchDropIndicator,
 	extraData,
 	onClickBackground,
+	dropTargetRef,
 }: {
 	scrollableRef: RefObject<HTMLDivElement | null>;
 	pageId: string;
 	dispatchDropIndicator: Dispatch<DropIndicatorAction>;
 	extraData?: Record<string, string>;
 	onClickBackground?: (e: MouseEvent) => void;
+	/** Optional separate element for the page-level drop target. Falls back to scrollableRef. */
+	dropTargetRef?: RefObject<HTMLDivElement | null>;
 }) {
 	useEffect(() => {
-		invariant(
-			scrollableRef.current,
-			"usePageDropTarget: scrollableRef.current is not defined",
-		);
-		const element = scrollableRef.current;
+		const pageElement = dropTargetRef?.current ?? scrollableRef.current;
+		invariant(pageElement, "usePageDropTarget: page element is not defined");
 
 		if (onClickBackground) {
-			element.addEventListener("click", onClickBackground);
+			pageElement.addEventListener("click", onClickBackground);
 		}
 
-		const cleanup = combine(
+		const autoScrollElement = scrollableRef.current;
+
+		const cleanups: Array<() => void> = [
 			dropTargetForElements({
-				element,
+				element: pageElement,
 				getData: () => ({ pageId, ...extraData }),
 				canDrop: () => true,
 				onDrop: () => {
@@ -44,15 +46,22 @@ export function usePageDropTarget({
 				onDragLeave: () =>
 					dispatchDropIndicator({ type: "UNSET_INDICATOR_PAGE" }),
 			}),
-			autoScrollForElements({
-				element,
-				canScroll: () => true,
-			}),
-		);
+		];
+
+		if (autoScrollElement) {
+			cleanups.push(
+				autoScrollForElements({
+					element: autoScrollElement,
+					canScroll: () => true,
+				}),
+			);
+		}
+
+		const cleanup = combine(...cleanups);
 
 		return () => {
 			if (onClickBackground) {
-				element.removeEventListener("click", onClickBackground);
+				pageElement.removeEventListener("click", onClickBackground);
 			}
 			cleanup();
 		};
@@ -62,5 +71,6 @@ export function usePageDropTarget({
 		dispatchDropIndicator,
 		extraData,
 		onClickBackground,
+		dropTargetRef,
 	]);
 }

--- a/web/app/hooks/usePageEdgeIndicators.ts
+++ b/web/app/hooks/usePageEdgeIndicators.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+
+import { useDragContext } from "../state";
+
+type ForcedIndicators = {
+	rowId: string;
+	indicators: Array<"before" | "after">;
+};
+
+/**
+ * Shared logic for computing page-edge drop indicator state.
+ *
+ * Used by both AppPage and SecondarySheetPage to avoid duplicating
+ * the indicator derivation logic.
+ */
+export function usePageEdgeIndicators(
+	pageId: string,
+	lastRowId: string | undefined,
+	pageHasRows: boolean,
+) {
+	const { dropIndicator, dragging } = useDragContext();
+
+	const isPageEdgeActive =
+		dragging === "rows" && dropIndicator?.pageId === pageId;
+
+	const isPageEdgeEndActive =
+		isPageEdgeActive && dropIndicator?.pageDropPosition === "end";
+
+	const showBlankPageIndicator =
+		!pageHasRows &&
+		isPageEdgeActive &&
+		dropIndicator?.pageDropPosition === "start";
+
+	const edgePosition: "start" | "end" = pageHasRows ? "end" : "start";
+
+	const forcedIndicators = useMemo((): ForcedIndicators | undefined => {
+		if (isPageEdgeEndActive && lastRowId) {
+			return { rowId: lastRowId, indicators: ["after"] };
+		}
+		return undefined;
+	}, [isPageEdgeEndActive, lastRowId]);
+
+	return { forcedIndicators, showBlankPageIndicator, edgePosition };
+}

--- a/web/app/rows/container/ColumnContainerRow.tsx
+++ b/web/app/rows/container/ColumnContainerRow.tsx
@@ -24,7 +24,8 @@ export default defineRow(typeName, {
 					rows={row.config.view.content.children}
 					orientation="horizontal"
 					showIndicators
-					showPlaceholder={row.id !== typeName}
+					containerRowId={row.id}
+					containerType="children"
 				/>
 			</div>
 		</RowLayout>

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -39,7 +39,9 @@ export default defineRow(typeName, {
 					rows={row.config.view.content.children}
 					orientation="vertical"
 					showIndicators
-					showPlaceholder={row.id !== typeName && !dynamicChildTemplate}
+					containerRowId={row.id}
+					containerType="children"
+					showPlaceholder={!dynamicChildTemplate}
 				/>
 			</div>
 		);

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -92,7 +92,8 @@ export default defineRow(typeName, {
 				</div>
 				<ContainerChildren
 					rows={rowsToShow}
-					showPlaceholder={row.id !== typeName}
+					containerRowId={rowId}
+					containerType="children"
 				/>
 			</>
 		);

--- a/web/app/rows/container/SheetContainerRow.tsx
+++ b/web/app/rows/container/SheetContainerRow.tsx
@@ -27,7 +27,8 @@ export default defineRow(typeName, {
 				<div className="evy-flex evy-gap-2">
 					<ContainerChildren
 						rows={rows}
-						showPlaceholder={row.id !== typeName}
+						containerRowId={row.id}
+						containerType="child"
 					/>
 				</div>
 			</RowLayout>

--- a/web/app/rows/design-system/dropIndicator.ts
+++ b/web/app/rows/design-system/dropIndicator.ts
@@ -1,7 +1,7 @@
-export const verticalDropIndicator = "evy-v-dropzone evy-w-full evy-rounded-sm";
+export const verticalDropIndicatorBefore = "evy-v-dropzone evy-top-0";
 
-export const horizontalDropIndicator =
-	"evy-h-dropzone evy-min-h-full evy-mt-2 evy-mb-2 evy-rounded-sm";
+export const verticalDropIndicatorAfter = "evy-v-dropzone evy-bottom-0";
 
-export const dropIndicatorExpansionBefore = "expanded evy-mt-2";
-export const dropIndicatorExpansionAfter = "expanded evy-mb-2";
+export const horizontalDropIndicatorBefore = "evy-h-dropzone evy-left-0";
+
+export const horizontalDropIndicatorAfter = "evy-h-dropzone evy-right-0";

--- a/web/app/state/reducers/dropIndicatorReducer.test.ts
+++ b/web/app/state/reducers/dropIndicatorReducer.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+
+import type { DropIndicatorState } from "../../types/actions";
+import { dropIndicatorReducer } from "./dropIndicatorReducer";
+
+describe("dropIndicatorReducer", () => {
+	it("tracks page edge indicator state", () => {
+		const state = dropIndicatorReducer(null, {
+			type: "SET_INDICATOR_PAGE_POSITION",
+			pageId: "page-1",
+			position: "end",
+		});
+
+		expect(state).toEqual({ pageId: "page-1", pageDropPosition: "end" });
+	});
+
+	it("clears page edge position without clearing the page target", () => {
+		const result = dropIndicatorReducer(
+			{ pageId: "page-1", pageDropPosition: "start" },
+			{ type: "UNSET_INDICATOR_PAGE_POSITION" },
+		);
+
+		expect(result).toEqual({
+			pageId: "page-1",
+			pageDropPosition: undefined,
+		});
+	});
+
+	it("clears page target and page edge position together", () => {
+		const state: DropIndicatorState = {
+			rowId: "row-1",
+			edge: "bottom" as Edge,
+			pageId: "page-1",
+			pageDropPosition: "end",
+		};
+
+		const result = dropIndicatorReducer(state, {
+			type: "UNSET_INDICATOR_PAGE",
+		});
+
+		expect(result).toEqual({
+			rowId: "row-1",
+			edge: "bottom",
+			pageId: undefined,
+			pageDropPosition: undefined,
+		});
+	});
+
+	it("tracks row indicators without clearing page indicators", () => {
+		const result = dropIndicatorReducer(
+			{ pageId: "page-1", pageDropPosition: "start" },
+			{ type: "SET_INDICATOR_ROW", rowId: "row-1", edge: "top" as Edge },
+		);
+
+		expect(result).toEqual({
+			pageId: "page-1",
+			pageDropPosition: "start",
+			rowId: "row-1",
+			edge: "top",
+		});
+	});
+
+	it("clears row indicators without clearing page indicators", () => {
+		const result = dropIndicatorReducer(
+			{
+				rowId: "row-1",
+				edge: "top" as Edge,
+				pageId: "page-1",
+				pageDropPosition: "end",
+			},
+			{ type: "UNSET_INDICATOR_ROW" },
+		);
+
+		expect(result).toEqual({
+			rowId: undefined,
+			edge: undefined,
+			pageId: "page-1",
+			pageDropPosition: "end",
+		});
+	});
+});

--- a/web/app/state/reducers/dropIndicatorReducer.ts
+++ b/web/app/state/reducers/dropIndicatorReducer.ts
@@ -29,6 +29,18 @@ export const dropIndicatorReducer = (
 			return {
 				...state,
 				pageId: undefined,
+				pageDropPosition: undefined,
+			};
+		case "SET_INDICATOR_PAGE_POSITION":
+			return {
+				...state,
+				pageId: action.pageId,
+				pageDropPosition: action.position,
+			};
+		case "UNSET_INDICATOR_PAGE_POSITION":
+			return {
+				...state,
+				pageDropPosition: undefined,
 			};
 		default:
 			return state;

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -473,4 +473,231 @@ describe("pageReducer", () => {
 		expect(closed.secondarySheetRowId).toBeUndefined();
 		expect(closed.configStack).toEqual([]);
 	});
+
+	it("REMOVE_ROW removes footer root", () => {
+		const foot = textRow("footer-row");
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [textRow("row-1")],
+							footer: foot,
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const next = pageReducer(state, {
+			type: "REMOVE_ROW",
+			pageId: "page-1",
+			rowId: "footer-row",
+		});
+		expect(next.flows[0].pages[0].footer).toBeUndefined();
+		expect(next.flows[0].pages[0].rows.length).toBe(1);
+	});
+
+	it("REMOVE_ROW removes nested footer child", () => {
+		const inner = textRow("foot-inner");
+		const foot = sheetRow("footer-row", inner);
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [],
+							footer: foot,
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const next = pageReducer(state, {
+			type: "REMOVE_ROW",
+			pageId: "page-1",
+			rowId: "foot-inner",
+		});
+		expect(
+			next.flows[0].pages[0].footer?.config.view.content.child,
+		).toBeUndefined();
+		expect(next.flows[0].pages[0].rows.length).toBe(0);
+	});
+
+	it("MOVE_ROW moves footer root into page rows", () => {
+		const foot = textRow("footer-row");
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [textRow("row-1")],
+							footer: foot,
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const next = pageReducer(state, {
+			type: "MOVE_ROW",
+			rowId: "footer-row",
+			originPageId: "page-1",
+			destinationPageId: "page-1",
+			destinationIndex: 0,
+		});
+		expect(next.flows[0].pages[0].footer).toBeUndefined();
+		expect(next.flows[0].pages[0].rows[0].id).toBe("footer-row");
+		expect(next.flows[0].pages[0].rows[1].id).toBe("row-1");
+	});
+
+	it("ADD_ROW inserts palette row into footer container", () => {
+		const foot = sheetRow("footer-sheet", textRow("dummy"), []);
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [],
+							footer: foot,
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const newId = "new-in-footer";
+		const next = pageReducer(state, {
+			type: "ADD_ROW",
+			newRowId: newId,
+			oldRowId: "TextRow",
+			destinationPageId: "page-1",
+			destinationIndex: 0,
+			destinationContainer: { rowId: "footer-sheet", type: "children" },
+		});
+		const footAfter = next.flows[0].pages[0].footer;
+		expect(footAfter?.config.view.content.children?.[0].id).toBe(newId);
+	});
+
+	it("ADD_ROW_AS_FOOTER adds palette row as page footer", () => {
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [textRow("row-1")],
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const newId = "new-footer";
+		const next = pageReducer(state, {
+			type: "ADD_ROW_AS_FOOTER",
+			newRowId: newId,
+			oldRowId: "TextRow",
+			destinationPageId: "page-1",
+		});
+		expect(next.flows[0].pages[0].footer).toBeDefined();
+		expect(next.flows[0].pages[0].footer?.id).toBe(newId);
+		expect(next.flows[0].pages[0].rows.length).toBe(1);
+		expect(next.activeRowId).toBe(newId);
+	});
+
+	it("ADD_ROW_AS_FOOTER no-ops when base row not found", () => {
+		const state = initialState();
+		const next = pageReducer(state, {
+			type: "ADD_ROW_AS_FOOTER",
+			newRowId: "new-footer",
+			oldRowId: "NonExistentRow",
+			destinationPageId: "page-1",
+		});
+		expect(next).toBe(state);
+	});
+
+	it("MOVE_ROW_TO_FOOTER moves row from page rows to footer", () => {
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [textRow("row-1"), textRow("row-2")],
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const next = pageReducer(state, {
+			type: "MOVE_ROW_TO_FOOTER",
+			rowId: "row-2",
+			originPageId: "page-1",
+			destinationPageId: "page-1",
+		});
+		expect(next.flows[0].pages[0].footer).toBeDefined();
+		expect(next.flows[0].pages[0].footer?.id).toBe("row-2");
+		expect(next.flows[0].pages[0].rows.length).toBe(1);
+		expect(next.flows[0].pages[0].rows[0].id).toBe("row-1");
+		expect(next.activeRowId).toBe("row-2");
+	});
+
+	it("MOVE_ROW_TO_FOOTER moves row across pages", () => {
+		const state = initialState({
+			flows: [
+				{
+					id: "flow-1",
+					name: "Flow",
+					pages: [
+						{
+							id: "page-1",
+							title: "Page",
+							rows: [textRow("row-1")],
+						},
+						{
+							id: "page-2",
+							title: "Second",
+							rows: [textRow("row-2")],
+						},
+					],
+				},
+			],
+			activePageId: "page-1",
+		});
+		const next = pageReducer(state, {
+			type: "MOVE_ROW_TO_FOOTER",
+			rowId: "row-1",
+			originPageId: "page-1",
+			destinationPageId: "page-2",
+		});
+		expect(next.flows[0].pages[0].rows.length).toBe(0);
+		expect(next.flows[0].pages[1].footer).toBeDefined();
+		expect(next.flows[0].pages[1].footer?.id).toBe("row-1");
+		expect(next.activeRowId).toBe("row-1");
+	});
 });

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -6,12 +6,12 @@ import type { Row } from "../../types/row";
 import { baseRows } from "../../rows/baseRows";
 import { buildRowForNewPageFromBase } from "../../utils/decodeFlow";
 import {
-	removeRowFromTree,
 	updateRowInTree,
 	findRowInPages,
 	findRowIdPathFromPageRoot,
 	findRowInSinglePage,
-	insertRowIntoTree,
+	removeRowFromPage,
+	insertRowIntoPage,
 } from "../../utils/rowTree";
 import { deriveSheetAndFocusFromRowChain } from "../../utils/urlUtils";
 import {
@@ -30,6 +30,21 @@ function mapRowAcrossPages(
 		rows: updateRowInTree(page.rows, rowId, updater),
 		footer: page.footer?.id === rowId ? updater(page.footer) : page.footer,
 	}));
+}
+
+function rowNameEquals(row: unknown, name: string): boolean {
+	if (row === null) return false;
+	const n = (row as Record<string, unknown>).name;
+	return typeof n === "string" && n === name;
+}
+
+function buildPaletteRow(oldRowId: string, newRowId: string): Row | undefined {
+	const baseRow = baseRows.find((row) => {
+		if (!row || typeof row !== "function") return false;
+		return rowNameEquals(row, oldRowId);
+	});
+	if (!baseRow) return undefined;
+	return buildRowForNewPageFromBase(baseRow, newRowId);
 }
 
 export const pageReducer = (state: AppState, action: RowAction): AppState => {
@@ -111,51 +126,77 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 		};
 	};
 
-	function rowNameEquals(row: unknown, name: string): boolean {
-		if (row === null) return false;
-		const n = (row as Record<string, unknown>).name;
-		return typeof n === "string" && n === name;
-	}
-
 	switch (action.type) {
 		case "ADD_ROW": {
-			const baseRow = baseRows.find((row) => {
-				if (!row || typeof row !== "function") return false;
-				return rowNameEquals(row, action.oldRowId);
-			});
-			if (!baseRow) return state;
-
-			const rowDataAdd: Row = buildRowForNewPageFromBase(
-				baseRow,
-				action.newRowId,
-			);
+			const newRow = buildPaletteRow(action.oldRowId, action.newRowId);
+			if (!newRow) return state;
 
 			const page = flow.pages.find((p) => p.id === action.destinationPageId);
 			if (!page) return state;
 
-			const insertionResult = insertRowIntoTree(
-				page.rows,
-				rowDataAdd,
+			const updatedPage = insertRowIntoPage(
+				page,
+				newRow,
 				action.destinationIndex,
 				action.destinationContainer,
 			);
-			invariant(
-				insertionResult.inserted,
-				"PageReducer addRow: destination container not found in tree",
-			);
 
 			const updatedPages = flow.pages.map((p) =>
-				p.id === action.destinationPageId
-					? {
-							...p,
-							rows: insertionResult.rows,
-						}
-					: p,
+				p.id === action.destinationPageId ? updatedPage : p,
 			);
 
 			return updateState({
 				updatedPages,
 				activeRowId: action.newRowId,
+				configStack: [],
+			});
+		}
+		case "ADD_ROW_AS_FOOTER": {
+			const footerRow = buildPaletteRow(action.oldRowId, action.newRowId);
+			if (!footerRow) return state;
+
+			const pageExists = flow.pages.some(
+				(page) => page.id === action.destinationPageId,
+			);
+			if (!pageExists) return state;
+
+			const updatedPages = flow.pages.map((page) =>
+				page.id === action.destinationPageId
+					? { ...page, footer: footerRow }
+					: page,
+			);
+
+			return updateState({
+				updatedPages,
+				activeRowId: action.newRowId,
+				configStack: [],
+			});
+		}
+		case "MOVE_ROW_TO_FOOTER": {
+			const moveFooterOriginPage = flow.pages.find(
+				(page) => page.id === action.originPageId,
+			);
+			if (!moveFooterOriginPage) return state;
+
+			const moveFooterRow = findRowInPages(action.rowId, [
+				moveFooterOriginPage,
+			]);
+			if (!moveFooterRow) return state;
+
+			const cleanedPagesForFooter = flow.pages.map((page) =>
+				page.id === action.originPageId
+					? removeRowFromPage(page, action.rowId)
+					: page,
+			);
+			const finalPagesFooter = cleanedPagesForFooter.map((page) =>
+				page.id === action.destinationPageId
+					? { ...page, footer: moveFooterRow }
+					: page,
+			);
+
+			return updateState({
+				updatedPages: finalPagesFooter,
+				activeRowId: action.rowId,
 				configStack: [],
 			});
 		}
@@ -168,53 +209,34 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			const row = findRowInPages(action.rowId, [originPage]);
 			invariant(row, "PageReducer moveRow: row is not defined");
 
-			const originRowsWithoutRow = removeRowFromTree(
-				originPage.rows,
-				action.rowId,
-			);
+			const cleanedOriginPage = removeRowFromPage(originPage, action.rowId);
 
 			const newPages = flow.pages.map((page) => {
 				if (
 					page.id === action.originPageId &&
 					page.id === action.destinationPageId
 				) {
-					const insertionResult = insertRowIntoTree(
-						originRowsWithoutRow,
+					// Same-page move: remove first, then insert into the result.
+					const result = insertRowIntoPage(
+						cleanedOriginPage,
 						row,
 						action.destinationIndex,
 						action.destinationContainer,
 					);
-					// Removing the dragged row can drop the destination container from the
-					// tree (e.g. invalid same-page drop into a descendant). No-op is expected.
-					if (!insertionResult.inserted) return page;
-
-					return {
-						...page,
-						rows: insertionResult.rows,
-					};
+					// If the destination container was a descendant of the dragged row,
+					// insertion will fail because the container was removed. No-op.
+					return result;
 				}
 				if (page.id === action.originPageId) {
-					return {
-						...page,
-						rows: originRowsWithoutRow,
-					};
+					return cleanedOriginPage;
 				}
 				if (page.id === action.destinationPageId) {
-					const insertionResult = insertRowIntoTree(
-						page.rows,
+					return insertRowIntoPage(
+						page,
 						row,
 						action.destinationIndex,
 						action.destinationContainer,
 					);
-					invariant(
-						insertionResult.inserted,
-						"PageReducer moveRow: destination container not found in tree",
-					);
-
-					return {
-						...page,
-						rows: insertionResult.rows,
-					};
 				}
 				return page;
 			});
@@ -229,10 +251,7 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 			return updateState({
 				updatedPages: flow.pages.map((page) =>
 					page.id === action.pageId
-						? {
-								...page,
-								rows: removeRowFromTree(page.rows, action.rowId),
-							}
+						? removeRowFromPage(page, action.rowId)
 						: page,
 				),
 			});

--- a/web/app/types/actions.ts
+++ b/web/app/types/actions.ts
@@ -13,12 +13,24 @@ export type RowAction =
 			destinationContainer?: { rowId: string; type: ContainerType };
 	  }
 	| {
+			type: "ADD_ROW_AS_FOOTER";
+			newRowId: string;
+			oldRowId: string;
+			destinationPageId: string;
+	  }
+	| {
 			type: "MOVE_ROW";
 			rowId: string;
 			originPageId: string;
 			destinationPageId: string;
 			destinationIndex: number;
 			destinationContainer?: { rowId: string; type: ContainerType };
+	  }
+	| {
+			type: "MOVE_ROW_TO_FOOTER";
+			rowId: string;
+			originPageId: string;
+			destinationPageId: string;
 	  }
 	| {
 			type: "REMOVE_ROW";
@@ -99,6 +111,7 @@ export type DropIndicatorState = {
 	rowId?: string;
 	pageId?: string;
 	edge?: Edge;
+	pageDropPosition?: "start" | "end";
 } | null;
 
 export type DropIndicatorAction =
@@ -116,6 +129,14 @@ export type DropIndicatorAction =
 	  }
 	| {
 			type: "UNSET_INDICATOR_PAGE";
+	  }
+	| {
+			type: "SET_INDICATOR_PAGE_POSITION";
+			pageId: string;
+			position: "start" | "end";
+	  }
+	| {
+			type: "UNSET_INDICATOR_PAGE_POSITION";
 	  };
 
 export type AppState = {

--- a/web/app/utils/dropHandler.ts
+++ b/web/app/utils/dropHandler.ts
@@ -14,8 +14,8 @@ import type { ContainerType } from "../types/row";
 import type { RowAction } from "../types/actions";
 import { containerDropindicatorId } from "../rows/EVYRow";
 import {
-	findContainerById,
-	findContainerOfRow,
+	findContainerByIdInPage,
+	findContainerOfRowInPage,
 	resolveDestinationPageFromRawPageId,
 	resolveSourcePageIdFromRaw,
 } from "../utils/rowTree";
@@ -28,6 +28,12 @@ type DropDispatchOptions = {
 		type: ContainerType;
 	};
 };
+
+type DropTargetRecord = {
+	data: Record<string | symbol, unknown>;
+};
+
+type PageDropPosition = "start" | "end";
 
 function getDefaultAppendIndexForPageDrop(
 	destinationPage: UI_Page,
@@ -65,6 +71,94 @@ function buildInitialDropDispatchOptions(
 	return dispatchOptions;
 }
 
+function getPageDropPosition(
+	dropTarget: DropTargetRecord | undefined,
+): PageDropPosition | undefined {
+	const pageDropPosition = dropTarget?.data.pageDropPosition;
+	return pageDropPosition === "start" || pageDropPosition === "end"
+		? pageDropPosition
+		: undefined;
+}
+
+function applyPageDropPosition(
+	dispatchOptions: DropDispatchOptions,
+	destinationPage: UI_Page,
+	secondarySheetRowId: string | undefined,
+	pageDropPosition: PageDropPosition | undefined,
+): void {
+	if (pageDropPosition === "start") {
+		dispatchOptions.destinationIndex = 0;
+		return;
+	}
+
+	if (pageDropPosition === "end") {
+		dispatchOptions.destinationIndex = getDefaultAppendIndexForPageDrop(
+			destinationPage,
+			secondarySheetRowId,
+		);
+	}
+}
+
+function findFooterDropTarget(
+	dropTargets: DropTargetRecord[],
+): DropTargetRecord | undefined {
+	return dropTargets.find((target) => target.data.destinationIsFooter === true);
+}
+
+function dispatchFooterDrop(
+	footerDropTarget: DropTargetRecord,
+	sourcePageId: string,
+	rowId: string,
+	dispatchRow: Dispatch<RowAction>,
+): void {
+	const footerPageId = footerDropTarget.data.pageId;
+	invariant(
+		typeof footerPageId === "string",
+		"handleDrop: footer placeholder pageId is not a string",
+	);
+
+	if (sourcePageId === "rows") {
+		dispatchRow({
+			type: "ADD_ROW_AS_FOOTER",
+			newRowId: crypto.randomUUID(),
+			oldRowId: rowId,
+			destinationPageId: footerPageId,
+		});
+		return;
+	}
+
+	dispatchRow({
+		type: "MOVE_ROW_TO_FOOTER",
+		rowId,
+		originPageId: sourcePageId,
+		destinationPageId: footerPageId,
+	});
+}
+
+function dispatchStandardDrop(
+	sourcePageId: string,
+	rowId: string,
+	dispatchOptions: DropDispatchOptions,
+	dispatchRow: Dispatch<RowAction>,
+): void {
+	if (sourcePageId === "rows") {
+		dispatchRow({
+			type: "ADD_ROW",
+			newRowId: crypto.randomUUID(),
+			oldRowId: rowId,
+			...dispatchOptions,
+		});
+		return;
+	}
+
+	dispatchRow({
+		type: "MOVE_ROW",
+		rowId,
+		originPageId: sourcePageId,
+		...dispatchOptions,
+	});
+}
+
 export function handleDrop(
 	args: BaseEventPayload<ElementDragType>,
 	pages: UI_Page[],
@@ -85,6 +179,12 @@ export function handleDrop(
 	);
 
 	const sourcePageId = resolveSourcePageIdFromRaw(rawSourcePageId, pages);
+
+	const footerDropTarget = findFooterDropTarget(location.current.dropTargets);
+	if (footerDropTarget) {
+		dispatchFooterDrop(footerDropTarget, sourcePageId, rowId, dispatchRow);
+		return;
+	}
 
 	// If the row was dropped on top of another row,
 	// dropTargets is an array with [row, ..., page]
@@ -129,14 +229,23 @@ export function handleDrop(
 		resolvedSecondarySheetRowId,
 	);
 
+	const firstDropTarget = location.current.dropTargets[0];
+	const pageDropPosition = getPageDropPosition(firstDropTarget);
+	applyPageDropPosition(
+		dispatchOptions,
+		destinationPage,
+		resolvedSecondarySheetRowId,
+		pageDropPosition,
+	);
+
 	// If the row was dropped on top of another row,
 	// dropTargets is an array with [row, ..., page]
 	// Otherwise it is [page]
-	const firstDropTarget = location.current.dropTargets[0];
-	const destinationRow =
-		location.current.dropTargets.length > 1 && !!firstDropTarget?.data.rowId
-			? firstDropTarget
-			: null;
+	const hasDestinationRow =
+		!pageDropPosition &&
+		location.current.dropTargets.length > 1 &&
+		!!firstDropTarget?.data.rowId;
+	const destinationRow = hasDestinationRow ? firstDropTarget : null;
 
 	const closestEdgeOfTarget: Edge | null = destinationRow
 		? extractClosestEdge(destinationRow.data)
@@ -148,8 +257,28 @@ export function handleDrop(
 			typeof destinationRowId === "string",
 			"handleDrop: destination rowId is not a string",
 		);
-		const destinationContainer =
-			destinationRowId === containerDropindicatorId
+
+		// Placeholder drop targets carry explicit destination container metadata.
+		const isPlaceholderDrop = destinationRowId === containerDropindicatorId;
+		const placeholderContainerRowId =
+			destinationRow.data.destinationContainerRowId;
+		const placeholderContainerType =
+			destinationRow.data.destinationContainerType;
+
+		if (
+			isPlaceholderDrop &&
+			typeof placeholderContainerRowId === "string" &&
+			(placeholderContainerType === "child" ||
+				placeholderContainerType === "children")
+		) {
+			// Drop into an empty container placeholder - use explicit metadata.
+			dispatchOptions.destinationContainer = {
+				rowId: placeholderContainerRowId,
+				type: placeholderContainerType,
+			};
+			dispatchOptions.destinationIndex = 0;
+		} else {
+			const destinationContainer = isPlaceholderDrop
 				? (() => {
 						const secondTargetRowId =
 							location.current.dropTargets[1]?.data.rowId;
@@ -157,38 +286,41 @@ export function handleDrop(
 							typeof secondTargetRowId === "string",
 							"handleDrop: dropTargets[1].rowId is not a string",
 						);
-						return findContainerById(secondTargetRowId, destinationPage.rows);
+						return findContainerByIdInPage(destinationPage, secondTargetRowId);
 					})()
-				: findContainerOfRow(destinationRowId, destinationPage.rows);
+				: findContainerOfRowInPage(destinationPage, destinationRowId);
 
-		// Need to support dropping into nested containers...
-		// right now the destinationContainer is 1 layer deep only,
-		// we need to be able to tell the indexes of every container down
-		if (
-			destinationContainer?.type === "children" &&
-			destinationContainer.container.config.view.content.children?.length
-		) {
-			dispatchOptions.destinationIndex =
-				destinationContainer.container.config.view.content.children.findIndex(
+			if (
+				destinationContainer?.type === "children" &&
+				destinationContainer.container.config.view.content.children?.length
+			) {
+				dispatchOptions.destinationIndex =
+					destinationContainer.container.config.view.content.children.findIndex(
+						(r) => r.id === destinationRow.data.rowId,
+					);
+			} else if (
+				destinationContainer?.type === "child" &&
+				destinationContainer.container.config.view.content.child?.id
+			) {
+				dispatchOptions.destinationIndex = 0;
+			} else if (closestEdgeOfTarget && !destinationContainer) {
+				const destinationRowIndex = destinationPage.rows.findIndex(
 					(r) => r.id === destinationRow.data.rowId,
 				);
-		} else if (
-			destinationContainer?.type === "child" &&
-			destinationContainer.container.config.view.content.child?.id
-		) {
-			dispatchOptions.destinationIndex = 0;
-		} else if (closestEdgeOfTarget && !destinationContainer) {
-			const destinationRowIndex = destinationPage.rows.findIndex(
-				(r) => r.id === destinationRow.data.rowId,
-			);
-			dispatchOptions.destinationIndex = destinationRowIndex;
-		}
+				// If the destination row is the footer root (or otherwise not in page.rows),
+				// default to appending at the end of the page rows.
+				dispatchOptions.destinationIndex =
+					destinationRowIndex >= 0
+						? destinationRowIndex
+						: destinationPage.rows.length;
+			}
 
-		if (destinationContainer) {
-			dispatchOptions.destinationContainer = {
-				rowId: destinationContainer.container.id,
-				type: destinationContainer.type,
-			};
+			if (destinationContainer) {
+				dispatchOptions.destinationContainer = {
+					rowId: destinationContainer.container.id,
+					type: destinationContainer.type,
+				};
+			}
 		}
 	}
 
@@ -204,19 +336,5 @@ export function handleDrop(
 			dispatchOptions.destinationIndex ?? destinationPage.rows.length;
 	}
 
-	if (sourcePageId === "rows") {
-		dispatchRow({
-			type: "ADD_ROW",
-			newRowId: crypto.randomUUID(),
-			oldRowId: rowId,
-			...dispatchOptions,
-		});
-	} else {
-		dispatchRow({
-			type: "MOVE_ROW",
-			rowId,
-			originPageId: sourcePageId,
-			...dispatchOptions,
-		});
-	}
+	dispatchStandardDrop(sourcePageId, rowId, dispatchOptions, dispatchRow);
 }

--- a/web/app/utils/flowFactory.ts
+++ b/web/app/utils/flowFactory.ts
@@ -1,12 +1,12 @@
 import type { UI_Flow as ServerFlow, UI_Page as ServerPage } from "evy-types";
 
-import type { UI_Flow } from "../types/flow";
+import type { UI_Flow, UI_Page } from "../types/flow";
 import { decodeFlows } from "./decodeFlow";
 
 /**
  * Builds a minimal valid blank page for the builder UI and API validation.
  */
-export function buildNewClientPage(): ServerPage {
+export function buildNewClientPage(): UI_Page {
 	return {
 		id: crypto.randomUUID(),
 		title: "",
@@ -19,10 +19,15 @@ export function buildNewClientPage(): ServerPage {
  */
 export function buildNewClientFlow(name: string): UI_Flow {
 	const flowId = crypto.randomUUID();
+	const serverPage: ServerPage = {
+		id: crypto.randomUUID(),
+		title: "",
+		rows: [],
+	};
 	const serverFlow: ServerFlow = {
 		id: flowId,
 		name,
-		pages: [buildNewClientPage()],
+		pages: [serverPage],
 	};
 	return decodeFlows([serverFlow])[0];
 }

--- a/web/app/utils/rowTree.test.ts
+++ b/web/app/utils/rowTree.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it } from "bun:test";
 import type { UI_Page } from "../types/flow";
 import type { Row } from "../types/row";
 import {
-	findContainerById,
-	findContainerOfRow,
+	findContainerByIdInPage,
+	findContainerOfRowInPage,
 	findRowIdPathFromPageRoot,
 	findRowInPages,
 	getRowsRecursive,
-	insertRowIntoTree,
-	removeRowFromTree,
+	insertRowIntoPage,
+	removeRowFromPage,
 	resolveDestinationPageFromRawPageId,
 	resolveSourcePageIdFromRaw,
 	updateRowInTree,
@@ -24,6 +24,7 @@ function makeRow(
 		row: null,
 		config: {
 			type: "Text",
+			source: "",
 			actions: [],
 			view: {
 				content: {
@@ -36,225 +37,128 @@ function makeRow(
 	};
 }
 
-function page(id: string, rows: Row[]): UI_Page {
-	return { id, title: "T", rows };
+function page(id: string, rows: Row[], footer?: Row): UI_Page {
+	return { id, title: "T", rows, footer };
 }
 
-describe("resolveSourcePageIdFromRaw", () => {
-	it("returns raw id when not a secondary pseudo page", () => {
-		const pages = [page("p1", [makeRow("a")])];
-		expect(resolveSourcePageIdFromRaw("p1", pages)).toBe("p1");
-	});
+describe("secondary sheet page ids", () => {
+	it("resolves secondary pseudo ids to the page containing the sheet row", () => {
+		const pages = [page("main", [makeRow("sheet-host")])];
 
-	it("maps secondary:hostRowId to the page that contains the host row at top level", () => {
-		const host = makeRow("sheet-host");
-		const pages = [page("main", [host])];
 		expect(resolveSourcePageIdFromRaw("secondary:sheet-host", pages)).toBe(
 			"main",
 		);
+
+		const destination = resolveDestinationPageFromRawPageId(
+			"secondary:sheet-host",
+			pages,
+		);
+		expect(destination.resolvedPageId).toBe("main");
+		expect(destination.secondarySheetRowId).toBe("sheet-host");
 	});
 
-	it("falls back to raw id when host row is not found", () => {
-		const pages = [page("main", [makeRow("a")])];
-		expect(resolveSourcePageIdFromRaw("secondary:missing", pages)).toBe(
+	it("falls back to the raw source id when the sheet row is missing", () => {
+		expect(resolveSourcePageIdFromRaw("secondary:missing", [])).toBe(
 			"secondary:missing",
 		);
 	});
 });
 
-describe("resolveDestinationPageFromRawPageId", () => {
-	it("resolves normal page id", () => {
-		const pages = [page("p1", [])];
-		const res = resolveDestinationPageFromRawPageId("p1", pages);
-		expect(res.page.id).toBe("p1");
-		expect(res.resolvedPageId).toBe("p1");
-		expect(res.secondarySheetRowId).toBeUndefined();
+describe("row tree traversal", () => {
+	it("finds nested rows and root-to-leaf paths including footer descendants", () => {
+		const bodyLeaf = makeRow("body-leaf");
+		const footerLeaf = makeRow("footer-leaf");
+		const bodyRoot = makeRow("body-root", { children: [bodyLeaf] });
+		const footerRoot = makeRow("footer-root", { child: footerLeaf });
+		const p = page("p", [bodyRoot], footerRoot);
+
+		expect(findRowInPages("body-leaf", [p])).toBe(bodyLeaf);
+		expect(findRowInPages("footer-leaf", [p])).toBe(footerLeaf);
+		expect(findRowIdPathFromPageRoot(p, "footer-leaf")).toEqual([
+			"footer-root",
+			"footer-leaf",
+		]);
 	});
 
-	it("resolves secondary sheet to host page", () => {
-		const host = makeRow("host");
-		const pages = [page("p1", [host])];
-		const res = resolveDestinationPageFromRawPageId("secondary:host", pages);
-		expect(res.page.id).toBe("p1");
-		expect(res.resolvedPageId).toBe("p1");
-		expect(res.secondarySheetRowId).toBe("host");
-	});
-});
-
-describe("findRowInPages", () => {
-	it("finds top-level row", () => {
-		const a = makeRow("a");
-		expect(findRowInPages("a", [page("p", [a])])).toBe(a);
-	});
-
-	it("finds nested child", () => {
-		const inner = makeRow("inner");
-		const outer = makeRow("outer", { child: inner });
-		expect(findRowInPages("inner", [page("p", [outer])])).toBe(inner);
-	});
-
-	it("finds nested children", () => {
-		const c = makeRow("c");
-		const outer = makeRow("outer", { children: [c] });
-		expect(findRowInPages("c", [page("p", [outer])])).toBe(c);
-	});
-
-	it("returns undefined when missing", () => {
-		expect(findRowInPages("x", [page("p", [makeRow("a")])])).toBeUndefined();
-	});
-
-	it("finds row nested under footer", () => {
-		const inner = makeRow("foot-inner");
-		const foot = makeRow("foot", { child: inner });
-		const p: UI_Page = { id: "p", title: "T", rows: [], footer: foot };
-		expect(findRowInPages("foot-inner", [p])).toBe(inner);
-	});
-});
-
-describe("findRowIdPathFromPageRoot", () => {
-	it("returns path from top-level row to nested leaf", () => {
+	it("flattens a row subtree", () => {
 		const leaf = makeRow("leaf");
-		const mid = makeRow("mid", { child: leaf });
-		const p = page("p1", [makeRow("root", { children: [mid] })]);
-		expect(findRowIdPathFromPageRoot(p, "leaf")).toEqual([
+		const mid = makeRow("mid", { children: [leaf] });
+		const root = makeRow("root", { child: mid });
+
+		expect(getRowsRecursive(root).map((row) => row.id)).toEqual([
 			"root",
 			"mid",
 			"leaf",
 		]);
 	});
 
-	it("works when leaf is under footer", () => {
-		const inner = makeRow("f-in");
-		const foot = makeRow("foot", { child: inner });
-		const p: UI_Page = { id: "p", title: "T", rows: [], footer: foot };
-		expect(findRowIdPathFromPageRoot(p, "f-in")).toEqual(["foot", "f-in"]);
-	});
-});
-
-describe("getRowsRecursive", () => {
-	it("includes self and descendants", () => {
-		const leaf = makeRow("leaf");
-		const mid = makeRow("mid", { children: [leaf] });
-		const root = makeRow("root", { child: mid });
-		const flat = getRowsRecursive(root).map((r) => r.id);
-		expect(flat).toEqual(["root", "mid", "leaf"]);
-	});
-});
-
-describe("findContainerOfRow", () => {
-	it("returns null for top-level row", () => {
-		const rows = [makeRow("a")];
-		expect(findContainerOfRow("a", rows)).toBeNull();
-	});
-
-	it("finds child container", () => {
-		const inner = makeRow("inner");
-		const outer = makeRow("outer", { child: inner });
-		const res = findContainerOfRow("inner", [outer]);
-		expect(res?.container.id).toBe("outer");
-		expect(res?.type).toBe("child");
-	});
-
-	it("finds children container", () => {
-		const c = makeRow("c");
-		const outer = makeRow("outer", { children: [c] });
-		const res = findContainerOfRow("c", [outer]);
-		expect(res?.container.id).toBe("outer");
-		expect(res?.type).toBe("children");
-	});
-});
-
-describe("findContainerById", () => {
-	it("finds row that is a child slot container", () => {
-		const inner = makeRow("inner");
-		const outer = makeRow("outer", { child: inner });
-		const res = findContainerById("outer", [outer]);
-		expect(res?.type).toBe("child");
-	});
-
-	it("finds row that is a children slot container", () => {
-		const c = makeRow("c");
-		const outer = makeRow("outer", { children: [c] });
-		const res = findContainerById("outer", [outer]);
-		expect(res?.type).toBe("children");
-	});
-});
-
-describe("removeRowFromTree", () => {
-	it("removes top-level row", () => {
-		const a = makeRow("a");
-		const b = makeRow("b");
-		const out = removeRowFromTree([a, b], "a");
-		expect(out.map((r) => r.id)).toEqual(["b"]);
-	});
-
-	it("removes nested child", () => {
-		const inner = makeRow("inner");
-		const outer = makeRow("outer", { child: inner });
-		const out = removeRowFromTree([outer], "inner");
-		expect(out[0].config.view.content.child).toBeUndefined();
-	});
-
-	it("removes from children array", () => {
-		const c1 = makeRow("c1");
-		const c2 = makeRow("c2");
-		const outer = makeRow("outer", { children: [c1, c2] });
-		const out = removeRowFromTree([outer], "c1");
-		const children = out[0].config.view.content.children ?? [];
-		expect(children.map((r) => r.id)).toEqual(["c2"]);
-	});
-});
-
-describe("insertRowIntoTree", () => {
-	it("inserts at page root index", () => {
-		const a = makeRow("a");
-		const b = makeRow("b");
-		const res = insertRowIntoTree([a], b, 0);
-		expect(res.inserted).toBe(true);
-		expect(res.rows.map((r) => r.id)).toEqual(["b", "a"]);
-	});
-
-	it("inserts into child container", () => {
-		const outer = makeRow("outer", {});
-		const insert = makeRow("new");
-		const res = insertRowIntoTree([outer], insert, 0, {
-			rowId: "outer",
-			type: "child",
-		});
-		expect(res.inserted).toBe(true);
-		expect(res.rows[0].config.view.content.child?.id).toBe("new");
-	});
-
-	it("inserts into children container at index", () => {
-		const outer = makeRow("outer", { children: [] });
-		const insert = makeRow("new");
-		const res = insertRowIntoTree([outer], insert, 0, {
-			rowId: "outer",
-			type: "children",
-		});
-		expect(res.inserted).toBe(true);
-		expect(res.rows[0].config.view.content.children?.map((r) => r.id)).toEqual([
-			"new",
-		]);
-	});
-
-	it("returns inserted false when container missing", () => {
-		const res = insertRowIntoTree([makeRow("a")], makeRow("b"), 0, {
-			rowId: "nope",
-			type: "children",
-		});
-		expect(res.inserted).toBe(false);
-	});
-});
-
-describe("updateRowInTree", () => {
-	it("updates matching row at depth", () => {
+	it("updates nested rows immutably", () => {
 		const inner = makeRow("inner", { text: "old" });
 		const outer = makeRow("outer", { child: inner });
 		const out = updateRowInTree([outer], "inner", (row) =>
 			makeRow(row.id, { ...row.config.view.content, text: "new" }),
 		);
+
+		expect(out[0]).not.toBe(outer);
 		expect(out[0].config.view.content.child?.config.view.content.text).toBe(
+			"new",
+		);
+	});
+});
+
+describe("page-level row tree helpers", () => {
+	it("finds containers in page rows and footer subtrees", () => {
+		const bodyChild = makeRow("body-child");
+		const footerChild = makeRow("footer-child");
+		const bodyContainer = makeRow("body-container", { children: [bodyChild] });
+		const footerContainer = makeRow("footer-container", { child: footerChild });
+		const p = page("p", [bodyContainer], footerContainer);
+
+		expect(findContainerOfRowInPage(p, "body-child")?.container.id).toBe(
+			"body-container",
+		);
+		expect(findContainerOfRowInPage(p, "footer-child")?.container.id).toBe(
+			"footer-container",
+		);
+		expect(findContainerByIdInPage(p, "footer-container")?.type).toBe("child");
+		expect(findContainerOfRowInPage(p, "footer-container")).toBeNull();
+	});
+
+	it("removes rows from page roots, footer roots, and nested footer content", () => {
+		const footerChild = makeRow("footer-child");
+		const footer = makeRow("footer", { child: footerChild });
+		const withoutBody = removeRowFromPage(
+			page("p", [makeRow("body")], footer),
+			"body",
+		);
+		const withoutFooterChild = removeRowFromPage(
+			page("p", [], footer),
+			"footer-child",
+		);
+		const withoutFooter = removeRowFromPage(page("p", [], footer), "footer");
+
+		expect(withoutBody.rows).toEqual([]);
+		expect(
+			withoutFooterChild.footer?.config.view.content.child,
+		).toBeUndefined();
+		expect(withoutFooter.footer).toBeUndefined();
+	});
+
+	it("inserts rows at page root and inside footer containers", () => {
+		const pageInsert = insertRowIntoPage(
+			page("p", [makeRow("a")]),
+			makeRow("b"),
+			0,
+		);
+		const footerInsert = insertRowIntoPage(
+			page("p", [], makeRow("footer", { children: [] })),
+			makeRow("new"),
+			0,
+			{ rowId: "footer", type: "children" },
+		);
+
+		expect(pageInsert.rows.map((row) => row.id)).toEqual(["b", "a"]);
+		expect(footerInsert.footer?.config.view.content.children?.[0].id).toBe(
 			"new",
 		);
 	});

--- a/web/app/utils/rowTree.ts
+++ b/web/app/utils/rowTree.ts
@@ -5,17 +5,12 @@ import type { Row, ContainerType } from "../types/row";
 
 const SECONDARY_PAGE_ID_PREFIX = "secondary:";
 
-/** If `pageId` is a secondary-sheet pseudo id, returns the host row id; otherwise `undefined`. */
 function parseSecondarySheetRowId(pageId: string): string | undefined {
 	return pageId.startsWith(SECONDARY_PAGE_ID_PREFIX)
 		? pageId.slice(SECONDARY_PAGE_ID_PREFIX.length)
 		: undefined;
 }
 
-/**
- * Maps a drag `pageId` from initial drop targets to the real page id
- * (secondary pseudo ids resolve via the sheet host row).
- */
 export function resolveSourcePageIdFromRaw(
 	rawSourcePageId: string,
 	pages: UI_Page[],
@@ -32,7 +27,6 @@ type ResolvedDropDestinationPage = {
 	secondarySheetRowId: string | undefined;
 };
 
-/** Resolves destination drop target `pageId` (including `secondary:*`) to a real page. */
 export function resolveDestinationPageFromRawPageId(
 	rawDestinationPageId: string,
 	pages: UI_Page[],
@@ -64,12 +58,11 @@ export function resolveDestinationPageFromRawPageId(
 	};
 }
 
-/** Page whose top-level `rows` contains the given row id (not recursive). */
 function findPageContainingRow(
 	pages: UI_Page[],
 	rowId: string,
 ): UI_Page | undefined {
-	return pages.find((page) => page.rows.some((r) => r.id === rowId));
+	return pages.find((page) => findRowInSinglePage(page, rowId));
 }
 
 export function findRowInPages(
@@ -83,7 +76,6 @@ export function findRowInPages(
 	return undefined;
 }
 
-/** Resolves a row anywhere on a single page (main `rows` or `footer`). */
 export function findRowInSinglePage(
 	page: { rows: Row[]; footer?: Row },
 	rowId: string,
@@ -98,10 +90,6 @@ export function findRowInSinglePage(
 	return undefined;
 }
 
-/**
- * Path of row ids from a top-level page row (or footer root) down to `leafRowId`.
- * Used to derive `activeRowId` + `configStack` when selecting a nested row on the canvas.
- */
 export function findRowIdPathFromPageRoot(
 	page: UI_Page,
 	leafRowId: string,
@@ -227,7 +215,6 @@ export function findContainerById(
 	return null;
 }
 
-/** Immutable shallow merge of `row.config.view.content` (child/children updates). */
 function withContentUpdate(
 	row: Row,
 	contentPatch: Partial<Row["config"]["view"]["content"]>,
@@ -262,9 +249,6 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 		}
 	}
 
-	// Some container rows expose both `children` and a single `child`.
-	// We must keep traversing after the `children` pass so moves/removals from
-	// sheet-like containers do not leave the nested `child` behind.
 	if (nextRow.config.view.content.child?.id === targetRowId) {
 		return withContentUpdate(nextRow, { child: undefined });
 	}
@@ -317,9 +301,6 @@ function insertRowIntoSubtree(
 	destinationType: ContainerType,
 ): InsertRowResult {
 	if (row.id === targetRowId) {
-		// Drag/drop destinations can point at either a single-slot `child`
-		// container or an ordered `children` collection, so insertion needs to
-		// preserve both shapes instead of assuming top-level page rows only.
 		if (destinationType === "child") {
 			return {
 				row: withContentUpdate(row, { child: rowToInsert }),
@@ -386,7 +367,6 @@ export function insertRowIntoTree(
 	destinationIndex: number,
 	destinationContainer?: { rowId: string; type: ContainerType },
 ): InsertRowsResult {
-	// Shared by ADD_ROW and MOVE_ROW so both code paths support nested drop targets.
 	if (!destinationContainer) {
 		return {
 			rows: insertRowAtIndex(rows, rowToInsert, destinationIndex),
@@ -452,4 +432,92 @@ export function updateRowInTree(
 	return rows.map(
 		(row) => updateRowInSubtree(row, targetRowId, updater) ?? row,
 	);
+}
+
+export function findContainerOfRowInPage(
+	page: UI_Page,
+	rowId: string,
+): { container: Row; type: ContainerType } | null {
+	const fromRows = findContainerOfRow(rowId, page.rows);
+	if (fromRows) return fromRows;
+	if (page.footer) {
+		if (page.footer.id === rowId) {
+			return null;
+		}
+		return findContainerOfRow(rowId, [page.footer]);
+	}
+	return null;
+}
+
+export function findContainerByIdInPage(
+	page: UI_Page,
+	rowId: string,
+): { container: Row; type: ContainerType } | null {
+	const fromRows = findContainerById(rowId, page.rows);
+	if (fromRows) return fromRows;
+	if (page.footer) {
+		return findContainerById(rowId, [page.footer]);
+	}
+	return null;
+}
+
+export function removeRowFromPage(page: UI_Page, targetRowId: string): UI_Page {
+	if (page.footer?.id === targetRowId) {
+		return { ...page, footer: undefined };
+	}
+
+	if (page.footer) {
+		const cleanedFooter = removeRowInSubtree(page.footer, targetRowId);
+		if (cleanedFooter !== page.footer) {
+			return { ...page, footer: cleanedFooter };
+		}
+	}
+
+	return {
+		...page,
+		rows: removeRowFromTree(page.rows, targetRowId),
+	};
+}
+
+export function insertRowIntoPage(
+	page: UI_Page,
+	rowToInsert: Row,
+	destinationIndex: number,
+	destinationContainer?: { rowId: string; type: ContainerType },
+): UI_Page {
+	if (!destinationContainer) {
+		return {
+			...page,
+			rows: insertRowAtIndex(page.rows, rowToInsert, destinationIndex),
+		};
+	}
+
+	for (const [index, row] of page.rows.entries()) {
+		const result = insertRowIntoSubtree(
+			row,
+			destinationContainer.rowId,
+			rowToInsert,
+			destinationIndex,
+			destinationContainer.type,
+		);
+		if (!result.inserted) continue;
+		const updatedRows = [...page.rows];
+		updatedRows[index] = result.row;
+		return { ...page, rows: updatedRows };
+	}
+
+	if (page.footer) {
+		const result = insertRowIntoSubtree(
+			page.footer,
+			destinationContainer.rowId,
+			rowToInsert,
+			destinationIndex,
+			destinationContainer.type,
+		);
+		if (result.inserted) {
+			return { ...page, footer: result.row };
+		}
+	}
+
+	return page;
 }

--- a/web/integration/utils.tsx
+++ b/web/integration/utils.tsx
@@ -8,10 +8,9 @@ export const SELECTORS = {
 	rowContainer:
 		'div[class*="evy-flex"][class*="evy-flex-col"][class*="evy-w-full"]',
 	draggableRow: 'div[data-row-id]:not([data-row-id="placeholder"])',
-	dropIndicator: ".evy-v-dropzone.expanded, .evy-h-dropzone.expanded",
-	topIndicator: ".evy-v-dropzone.expanded.evy-mt-2, .evy-h-dropzone.expanded",
-	bottomIndicator:
-		".evy-v-dropzone.expanded.evy-mb-2, .evy-h-dropzone.expanded",
+	dropIndicator: ".evy-v-dropzone, .evy-h-dropzone",
+	topIndicator: ".evy-v-dropzone.evy-top-0, .evy-h-dropzone.evy-left-0",
+	bottomIndicator: ".evy-v-dropzone.evy-bottom-0, .evy-h-dropzone.evy-right-0",
 	flowSelector: "#flow-select",
 	secondarySheetPage: '[data-testid="secondary-sheet-page"]',
 };


### PR DESCRIPTION
## Summary
- Improve web builder drag-and-drop behavior for page edge drops, empty containers, secondary sheets, and footer targets.
- Add reusable drop indicator/placeholder components and simplify drag container APIs.
- Make row tree and page reducer helpers footer-aware while trimming redundant tests and comments.

## Major changes
- Added page edge and footer drop zones for clearer row placement.
- Added shared blank-page and placeholder drop indicator components.
- Refactored drop handling into smaller helpers for page-edge, footer, and standard row drops.
- Updated row tree helpers to resolve secondary sheet IDs, traverse footers, and insert/remove nested rows.
- Reduced excessive reducer/tree test coverage to focused behavioral cases.

## Tests ran
- bun run --cwd web build
- bun run --cwd web lint
- bun run --cwd web test:unit
- bun run --cwd web test:integration
- WEB_PORT=3001 ./run-e2e.sh --skip-ios

## Risks / follow-ups
- iOS e2e was skipped per the command flag; CI can cover full validation if configured.
- Drag-and-drop UX is interaction-heavy, so any edge cases should be verified against CI/browser tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->