### PR TITLE
[FEAT] Remove container drop indicators from rows panel, only show on phone pages

### DIFF
--- a/web/app/components/ContainerChildren.tsx
+++ b/web/app/components/ContainerChildren.tsx
@@ -4,6 +4,7 @@ import type { Row, ContainerType } from "../types/row";
 import { useFlowsContext } from "../state";
 import { DraggableRowContainer } from "./DraggableRowContainer";
 import { PlaceholderDropIndicator } from "./PlaceholderDropIndicator";
+import { useIsInRowsPanel } from "./RowRenderLocationContext";
 
 export function ContainerChildren({
 	rows,
@@ -21,6 +22,8 @@ export function ContainerChildren({
 	showPlaceholder?: boolean;
 }) {
 	const { dispatchRow } = useFlowsContext();
+	const isInRowsPanel = useIsInRowsPanel();
+	const shouldShowIndicators = showIndicators && !isInRowsPanel;
 
 	const selectNestedRow = useCallback(
 		(nestedRowId: string) => {
@@ -30,7 +33,7 @@ export function ContainerChildren({
 	);
 
 	if (!rows?.length) {
-		return showPlaceholder ? (
+		return showPlaceholder && !isInRowsPanel ? (
 			<PlaceholderDropIndicator
 				key="placeholder"
 				containerRowId={containerRowId}
@@ -47,7 +50,7 @@ export function ContainerChildren({
 					rowId={child.id}
 					selectRow={() => selectNestedRow(child.id)}
 					orientation={orientation}
-					showIndicators={showIndicators}
+					showIndicators={shouldShowIndicators}
 				>
 					{child.row}
 				</DraggableRowContainer>

--- a/web/app/components/DraggableRowContainer.tsx
+++ b/web/app/components/DraggableRowContainer.tsx
@@ -48,6 +48,7 @@ export function DraggableRowContainer({
 				selectRow={selectRow}
 				indicators={mergedIndicators}
 				orientation={orientation}
+				isDraggable={isDraggable}
 			>
 				{children}
 			</RowPrimitive>

--- a/web/app/components/RowPrimitive.tsx
+++ b/web/app/components/RowPrimitive.tsx
@@ -18,6 +18,7 @@ type RowPrimitiveProps = {
 	orientation?: "horizontal" | "vertical";
 	className?: string;
 	style?: React.CSSProperties;
+	isDraggable?: boolean;
 };
 
 export const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
@@ -30,10 +31,15 @@ export const RowPrimitive = forwardRef<HTMLDivElement, RowPrimitiveProps>(
 			orientation = "vertical",
 			className,
 			style,
+			isDraggable = true,
 		},
 		ref,
 	) {
-		const cursor = state.type === idleState.type ? "grab" : "pointer";
+		const cursor = isDraggable
+			? state.type === idleState.type
+				? "grab"
+				: "pointer"
+			: "default";
 		const beforeClass =
 			orientation === "vertical"
 				? verticalDropIndicatorBefore

--- a/web/app/components/RowRenderLocationContext.tsx
+++ b/web/app/components/RowRenderLocationContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+const IsRowsPanelContext = createContext(false);
+
+export function RowsPanelProvider({ children }: { children: ReactNode }) {
+	return (
+		<IsRowsPanelContext.Provider value={true}>
+			{children}
+		</IsRowsPanelContext.Provider>
+	);
+}
+
+export function useIsInRowsPanel(): boolean {
+	return useContext(IsRowsPanelContext);
+}

--- a/web/app/components/RowsPanel.tsx
+++ b/web/app/components/RowsPanel.tsx
@@ -7,6 +7,7 @@ import invariant from "tiny-invariant";
 import { useDragContext, useFlowsContext } from "../state";
 import { CancelOverlay } from "./CancelOverlay";
 import { DraggableRowContainer } from "./DraggableRowContainer";
+import { RowsPanelProvider } from "./RowRenderLocationContext";
 import { SearchInput } from "./SearchInput";
 
 export function RowsPanel() {
@@ -56,7 +57,7 @@ export function RowsPanel() {
 			>
 				{filteredRows.map((row) => (
 					<DraggableRowContainer key={row.id} rowId={row.id}>
-						{row.row}
+						<RowsPanelProvider>{row.row}</RowsPanelProvider>
 					</DraggableRowContainer>
 				))}
 				{filteredRows.length === 0 && searchQuery && (


### PR DESCRIPTION
## Summary

Hide container drag-and-drop indicators (both the "Drop row here" placeholder and the before/after edge indicators) when rows are rendered in the left Rows Panel sidebar. These indicators only make sense on the phone page canvas, where users reorder and nest rows.

## Major changes

- **New `RowRenderLocationContext`** — A simple boolean React context that tracks whether a row subtree is being rendered inside the rows panel.
- **`RowsPanel`** — Wraps each palette row in `RowsPanelProvider` to signal the render location.
- **`ContainerChildren`** — Skips the "Drop row here" placeholder and suppresses before/after edge indicators when `isInRowsPanel` is true.
- **`RowPrimitive`** — Added `isDraggable` prop (passed through `DraggableRowContainer`) so palette row previews show `cursor: default` instead of `cursor: grab`.

## Tests ran

- `bun run lint` ✅
- `bun run build` ✅
- `bun run test:unit` (73 pass) ✅
- `bun run test:integration` (77 pass) ✅
- `./run-e2e.sh --skip-ios` (API, marketplace, web e2e all pass) ✅

## Risks

None. The context is only consumed in `ContainerChildren`, and the default is `false`, so phone page behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->