### PR TITLE
[FEAT] Add response metadata envelopes

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -29,6 +29,7 @@ COPY types/schema ../types/schema
 COPY types/validators.ts ../types/validators.ts
 COPY types/coreResources.ts ../types/coreResources.ts
 COPY types/rpcRequestHelpers.ts ../types/rpcRequestHelpers.ts
+COPY types/rpcResponseHelpers.ts ../types/rpcResponseHelpers.ts
 
 # Production stage
 FROM base AS runner

--- a/api/e2e/e2e.test.ts
+++ b/api/e2e/e2e.test.ts
@@ -32,7 +32,8 @@ describe("API E2E Tests", () => {
 				service: "evy",
 				resource: "sdui",
 			});
-			expect(Array.isArray(result)).toBe(true);
+			expect(result).toHaveProperty("metadata");
+			expect(Array.isArray(result.data)).toBe(true);
 		});
 
 		it("create should reject without auth", async () => {
@@ -96,8 +97,9 @@ describe("API E2E Tests", () => {
 				resource: "sdui",
 			});
 
-			expect(result.length).toBeGreaterThan(0);
-			const flow = result[0];
+			expect(result.metadata.count).toBeGreaterThan(0);
+			expect(result.data.length).toBeGreaterThan(0);
+			const flow = result.data[0];
 			expect(flow).toHaveProperty("id");
 			expect(flow).toHaveProperty("name");
 			expect(flow).toHaveProperty("pages");
@@ -136,11 +138,13 @@ describe("API E2E Tests", () => {
 				data: flowData,
 			});
 
-			expect(result.id).toBeDefined();
-			expect(result.data).toBeDefined();
-			expect(result.data.name).toBe("E2E Test Flow");
-			expect(result.createdAt).toBeDefined();
-			expect(result.updatedAt).toBeDefined();
+			expect(result.metadata.count).toBe(1);
+			expect(result.metadata.order).toEqual([result.data.id]);
+			expect(result.data.id).toBeDefined();
+			expect(result.data.data).toBeDefined();
+			expect(result.data.data.name).toBe("E2E Test Flow");
+			expect(result.data.createdAt).toBeDefined();
+			expect(result.data.updatedAt).toBeDefined();
 		});
 
 		it("update SDUI should update an existing flow", async () => {
@@ -172,11 +176,12 @@ describe("API E2E Tests", () => {
 			const updated = await client.call("update", {
 				service: "evy",
 				resource: "sdui",
-				filter: { id: created.id },
+				filter: { id: created.data.id },
 				data: updateFlowData,
 			});
 
-			expect(updated.data.name).toBe("Updated Flow Name");
+			expect(updated.metadata.order).toEqual([created.data.id]);
+			expect(updated.data.data.name).toBe("Updated Flow Name");
 		});
 	});
 });

--- a/api/e2e/reconnect.test.ts
+++ b/api/e2e/reconnect.test.ts
@@ -54,7 +54,7 @@ describe("API E2E WebSocket reconnect", () => {
 			service: "evy",
 			resource: "sdui",
 			operation: "create",
-			value: createResult.data,
+			value: createResult.data.data,
 		});
 
 		second.close();

--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -143,8 +143,10 @@ async function listCoreCatalogRows<TRow>(
 	}
 
 	const rows = whereClauses.length
-		? await base.where(and(...whereClauses)).orderBy(desc(table.updatedAt))
-		: await base.orderBy(desc(table.updatedAt));
+		? await base
+				.where(and(...whereClauses))
+				.orderBy(desc(table.updatedAt), desc(table.id))
+		: await base.orderBy(desc(table.updatedAt), desc(table.id));
 	const mapped = rows.map((r) => mapRow(r as TRow));
 	return buildGetResponse(mapped);
 }
@@ -266,8 +268,10 @@ async function getCoreBody(params: GetRequest): Promise<GetResponse> {
 		}
 
 		const rows = whereClauses.length
-			? await base.where(and(...whereClauses)).orderBy(desc(flow.updatedAt))
-			: await base.orderBy(desc(flow.updatedAt));
+			? await base
+					.where(and(...whereClauses))
+					.orderBy(desc(flow.updatedAt), desc(flow.id))
+			: await base.orderBy(desc(flow.updatedAt), desc(flow.id));
 		const payload = rows.map((f) => f.data);
 		for (const item of payload) {
 			validateFlowData(item);

--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -39,11 +39,29 @@ import {
 	validateCreateResponse,
 	validateUpdateResponse,
 } from "evy-types/validators";
+import {
+	buildCollectionResponseEnvelope,
+	buildSingleResponseEnvelope,
+} from "evy-types/rpcResponseHelpers";
+
+const evyCoreResourceNameSet: ReadonlySet<string> = EVY_CORE_RESOURCE_NAME_SET;
 
 const connectionString = getConnectionUrl();
 const client = postgres(connectionString);
 
 let db = drizzle(client, { schema });
+
+function buildGetResponse(items: unknown[]): GetResponse {
+	return validateGetResponse(buildCollectionResponseEnvelope(items));
+}
+
+function buildCreateResponse(item: CreateResponse["data"]): CreateResponse {
+	return validateCreateResponse(buildSingleResponseEnvelope(item));
+}
+
+function buildUpdateResponse(item: UpdateResponse["data"]): UpdateResponse {
+	return validateUpdateResponse(buildSingleResponseEnvelope(item));
+}
 
 export function setDbForTest(database: typeof db): void {
 	db = database;
@@ -55,7 +73,7 @@ function assertEvyCoreAccess(
 	if (params.service !== EVY_CORE_SERVICE) {
 		throw new Error("Core API only serves service evy");
 	}
-	if (!EVY_CORE_RESOURCE_NAME_SET.has(params.resource)) {
+	if (!evyCoreResourceNameSet.has(params.resource)) {
 		throw new Error("Resource is not served by the core API");
 	}
 }
@@ -106,7 +124,7 @@ type CatalogEntityConfig<TValidated> = {
 		nowIso: string,
 		filterId: string | undefined,
 	) => Record<string, unknown>;
-	mapRow: (row: unknown) => CreateResponse;
+	mapRow: (row: unknown) => CreateResponse["data"];
 };
 
 async function listCoreCatalogRows<TRow>(
@@ -128,31 +146,27 @@ async function listCoreCatalogRows<TRow>(
 		? await base.where(and(...whereClauses)).orderBy(desc(table.updatedAt))
 		: await base.orderBy(desc(table.updatedAt));
 	const mapped = rows.map((r) => mapRow(r as TRow));
-	return validateGetResponse(mapped);
+	return buildGetResponse(mapped);
 }
 
 async function insertCatalogEntity<TSelect>(
 	doInsert: () => Promise<TSelect[]>,
-	mapRow: (row: TSelect) => CreateResponse,
+	mapRow: (row: TSelect) => CreateResponse["data"],
 ): Promise<CreateResponse> {
 	const inserted = await doInsert();
-	const row = mapRow(inserted[0]);
-	validateCreateResponse(row);
-	return row;
+	return buildCreateResponse(mapRow(inserted[0]));
 }
 
 async function updateCatalogEntity<TSelect>(
 	filterId: string,
 	doUpdate: (filterId: string) => Promise<TSelect[]>,
-	mapRow: (row: TSelect) => UpdateResponse,
+	mapRow: (row: TSelect) => UpdateResponse["data"],
 ): Promise<UpdateResponse> {
 	const updated = await doUpdate(filterId);
 	if (updated.length === 0) {
 		throw new Error("Resource not found");
 	}
-	const row = mapRow(updated[0]);
-	validateUpdateResponse(row);
-	return row;
+	return buildUpdateResponse(mapRow(updated[0]));
 }
 
 async function insertCatalogEntityFromConfig<TValidated>(
@@ -174,7 +188,7 @@ async function insertCatalogEntityFromConfig<TValidated>(
 		(row) => config.mapRow(row),
 	);
 
-	notify(response);
+	notify(response.data);
 	return response;
 }
 
@@ -199,7 +213,7 @@ async function updateCatalogEntityFromConfig<TValidated>(
 		(row) => config.mapRow(row),
 	);
 
-	notify(response);
+	notify(response.data);
 	return response;
 }
 
@@ -258,7 +272,7 @@ async function getCoreBody(params: GetRequest): Promise<GetResponse> {
 		for (const item of payload) {
 			validateFlowData(item);
 		}
-		return validateGetResponse(payload);
+		return buildGetResponse(payload);
 	}
 
 	if (resource === EVY_CORE_RESOURCE.SERVICES) {
@@ -319,7 +333,7 @@ const organizationCatalogConfig: CatalogEntityConfig<DATA_EVY_Organization> = {
 		createdAt: validated.createdAt,
 		updatedAt: nowIso,
 	}),
-	mapRow: (row: unknown) => row as CreateResponse,
+	mapRow: (row: unknown) => row as DATA_EVY_Organization,
 };
 
 const providerCatalogConfig: CatalogEntityConfig<DATA_EVY_ServiceProvider> = {
@@ -347,7 +361,7 @@ const providerCatalogConfig: CatalogEntityConfig<DATA_EVY_ServiceProvider> = {
 		updatedAt: nowIso,
 		retired: validated.retired,
 	}),
-	mapRow: (row: unknown) => row as CreateResponse,
+	mapRow: (row: unknown) => row as DATA_EVY_ServiceProvider,
 };
 
 async function createCoreBody(params: CreateRequest): Promise<CreateResponse> {
@@ -390,10 +404,9 @@ async function createCoreBody(params: CreateRequest): Promise<CreateResponse> {
 				}
 				throw err;
 			});
-		const row = result[0];
-		validateCreateResponse(row);
+		const response = buildCreateResponse(result[0]);
 		emitNotification(persistedFlowData);
-		return row;
+		return response;
 	}
 
 	if (resource === EVY_CORE_RESOURCE.SERVICES) {
@@ -462,10 +475,9 @@ async function updateCoreBody(params: UpdateRequest): Promise<UpdateResponse> {
 		if (result.length === 0) {
 			throw new Error("Resource not found");
 		}
-		const row = result[0];
-		validateUpdateResponse(row);
+		const response = buildUpdateResponse(result[0]);
 		emitNotification(persistedFlowData);
-		return row;
+		return response;
 	}
 
 	if (resource === EVY_CORE_RESOURCE.SERVICES) {

--- a/api/src/readiness.ts
+++ b/api/src/readiness.ts
@@ -17,16 +17,16 @@ export async function assertApiReadable(
 	deps: ApiReadableDeps = { get: defaultGet },
 ): Promise<void> {
 	const { requireSeeded } = options;
-	const flows = await deps.get({ service: "evy", resource: "sdui" });
-	if (!Array.isArray(flows)) {
-		throw new Error("API readiness failed: expected sdui response array");
+	const response = await deps.get({ service: "evy", resource: "sdui" });
+	if (!Array.isArray(response.data)) {
+		throw new Error("API readiness failed: expected sdui response data array");
 	}
 
 	if (!requireSeeded) {
 		return;
 	}
 
-	if (flows.length === 0) {
+	if (response.data.length === 0) {
 		throw new Error("Seed verification failed: missing seeded SDUI flows");
 	}
 }

--- a/api/src/sync.ts
+++ b/api/src/sync.ts
@@ -11,10 +11,6 @@ import { buildResourceRegistry } from "./resources";
 
 type SyncRow = SyncResponse["data"][number];
 
-/**
- * Fetch all evy-core resources that have changed since lastSyncTime.
- * Skips "devices" (auth-only) and resources that returned no changes.
- */
 async function fetchEvyCoreData(
 	lastSyncTime: string,
 	getCore: typeof defaultGetCore,
@@ -44,9 +40,6 @@ async function fetchEvyCoreData(
 	return rows;
 }
 
-/**
- * Fetch all external-service resources that have changed since lastSyncTime.
- */
 async function fetchExternalServiceData(
 	lastSyncTime: string,
 	fetchService: typeof forwardGet,
@@ -93,16 +86,7 @@ const DEFAULT_DEPS: SyncDependencies = {
 	buildRegistry: buildResourceRegistry,
 };
 
-/**
- * Unified sync JSON-RPC handler.
- *
- * Accepts a `lastSyncTime` ISO string and returns:
- * - `resources`: the full resource registry (so clients don't need a separate call)
- * - `data`: all rows (SDUI, evy catalog, and external service data) that were
- *   updated since `lastSyncTime`, shaped as `{ service, resource, value }[]`
- *
- * Only includes `resources` when data changed.
- */
+// resources is only included in the response when data changed.
 export async function sync(
 	params: unknown,
 	deps: SyncDependencies = DEFAULT_DEPS,

--- a/api/src/sync.ts
+++ b/api/src/sync.ts
@@ -23,9 +23,7 @@ async function fetchEvyCoreData(
 	const evyResources = getServiceResources(EVY_CORE_SERVICE) ?? [];
 
 	for (const resource of evyResources) {
-		if (resource === "devices") {
-			continue;
-		}
+		if (resource === "devices") continue;
 
 		const request: GetRequest = {
 			service: EVY_CORE_SERVICE,
@@ -34,10 +32,7 @@ async function fetchEvyCoreData(
 		};
 
 		const value: GetResponse = await getCore(request);
-
-		if (Array.isArray(value) && value.length === 0) {
-			continue;
-		}
+		if (value.data.length === 0) continue;
 
 		rows.push({
 			service: EVY_CORE_SERVICE,
@@ -73,9 +68,7 @@ async function fetchExternalServiceData(
 
 			const value: GetResponse = await fetchService(serviceName, request);
 
-			if (Array.isArray(value) && value.length === 0) {
-				continue;
-			}
+			if (value.data.length === 0) continue;
 
 			rows.push({
 				service: serviceName,

--- a/api/src/tests/bootstrap.test.ts
+++ b/api/src/tests/bootstrap.test.ts
@@ -63,28 +63,34 @@ describe("initServer bootstrap", () => {
 });
 
 describe("assertApiReadable", () => {
-	it("resolves when sdui get returns an array and requireSeeded is false", async () => {
+	it("resolves when sdui get returns an array envelope and requireSeeded is false", async () => {
 		const deps = {
-			get: async (_params: GetRequest): Promise<GetResponse> => [],
+			get: async (_params: GetRequest): Promise<GetResponse> => ({
+				metadata: { count: 0, size: 2, order: [] },
+				data: [],
+			}),
 		};
 		await expect(
 			assertApiReadable({ requireSeeded: false }, deps),
 		).resolves.toBeUndefined();
 	});
 
-	it("throws when sdui get does not return an array", async () => {
+	it("throws when sdui get does not return a data array", async () => {
 		const deps = {
 			get: async (_params: GetRequest): Promise<GetResponse> =>
 				"not-array" as unknown as GetResponse,
 		};
 		await expect(
 			assertApiReadable({ requireSeeded: false }, deps),
-		).rejects.toThrow("expected sdui response array");
+		).rejects.toThrow("expected sdui response data array");
 	});
 
 	it("throws when requireSeeded is true but sdui is empty", async () => {
 		const deps = {
-			get: async (_params: GetRequest): Promise<GetResponse> => [],
+			get: async (_params: GetRequest): Promise<GetResponse> => ({
+				metadata: { count: 0, size: 2, order: [] },
+				data: [],
+			}),
 		};
 		await expect(
 			assertApiReadable({ requireSeeded: true }, deps),
@@ -95,15 +101,23 @@ describe("assertApiReadable", () => {
 		const deps = {
 			get: async (params: GetRequest): Promise<GetResponse> => {
 				if (params.resource === "sdui") {
-					return [
+					const data = [
 						{
 							id: crypto.randomUUID(),
 							name: "Seeded Flow",
 							pages: [],
 						} satisfies UI_Flow,
 					];
+					return {
+						metadata: {
+							count: data.length,
+							size: Buffer.byteLength(JSON.stringify(data), "utf8"),
+							order: data.map((flow) => flow.id),
+						},
+						data,
+					};
 				}
-				return [];
+				return { metadata: { count: 0, size: 2, order: [] }, data: [] };
 			},
 		};
 		await expect(

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -56,9 +56,11 @@ const { validateAuth, create, get, setDbForTest, update } = dataModule;
 setDbForTest(testDb as unknown as Parameters<typeof setDbForTest>[0]);
 
 function isDATA_EVY_Flow(
-	row: CreateResponse | UpdateResponse,
+	row: CreateResponse["data"] | UpdateResponse["data"],
 ): row is DATA_EVY_Flow {
 	return (
+		row !== null &&
+		typeof row === "object" &&
 		"data" in row &&
 		typeof row.data === "object" &&
 		row.data !== null &&
@@ -67,10 +69,12 @@ function isDATA_EVY_Flow(
 }
 
 function expectToBeDATA_EVY_Flow(
-	row: CreateResponse | UpdateResponse,
-): asserts row is DATA_EVY_Flow {
-	expect(isDATA_EVY_Flow(row)).toBe(true);
-	if (!isDATA_EVY_Flow(row)) {
+	response: CreateResponse | UpdateResponse,
+): asserts response is (CreateResponse | UpdateResponse) & {
+	data: DATA_EVY_Flow;
+} {
+	expect(isDATA_EVY_Flow(response.data)).toBe(true);
+	if (!isDATA_EVY_Flow(response.data)) {
 		throw new Error("Expected DATA_EVY_Flow");
 	}
 }
@@ -228,7 +232,9 @@ describe("create", () => {
 		});
 
 		expectToBeDATA_EVY_Flow(result);
-		expect(result.data.name).toBe("New Flow");
+		expect(result.metadata.count).toBe(1);
+		expect(result.metadata.order).toEqual([result.data.id]);
+		expect(result.data.data.name).toBe("New Flow");
 		const flows = await testDb.select().from(schema.flow);
 		expect(flows).toHaveLength(1);
 	});
@@ -249,9 +255,11 @@ describe("create", () => {
 		});
 
 		expectToBeDATA_EVY_Flow(result);
-		expect(result.id).toBe(flowId);
+		expect(result.metadata.count).toBe(1);
+		expect(result.metadata.order).toEqual([flowId]);
 		expect(result.data.id).toBe(flowId);
-		expect(result.data.name).toBe("Client Created Flow");
+		expect(result.data.data.id).toBe(flowId);
+		expect(result.data.data.name).toBe("Client Created Flow");
 	});
 
 	it("should fail to create duplicate flow", async () => {
@@ -294,7 +302,8 @@ describe("create", () => {
 			data: payload,
 		});
 
-		const row = result as DATA_EVY_Service;
+		const row = result.data as DATA_EVY_Service;
+		expect(result.metadata.order).toEqual([serviceId]);
 		expect(row.id).toBe(serviceId);
 		expect(row.name).toBe("CreateSvc");
 		expect(row.description).toBe("D");
@@ -377,7 +386,8 @@ describe("update", () => {
 		});
 
 		expectToBeDATA_EVY_Flow(result);
-		expect(result.data.name).toBe("Updated Name");
+		expect(result.metadata.order).toEqual([existingFlow.id]);
+		expect(result.data.data.name).toBe("Updated Name");
 		const flows = await testDb.select().from(schema.flow);
 		expect(flows).toHaveLength(1);
 	});
@@ -428,7 +438,8 @@ describe("update", () => {
 			data: updatedPayload,
 		});
 
-		const row = result as DATA_EVY_Service;
+		const row = result.data as DATA_EVY_Service;
+		expect(result.metadata.order).toEqual([serviceId]);
 		expect(row.name).toBe("UpdatedSvc");
 		const svcRows = await testDb.select().from(schema.service);
 		expect(svcRows).toHaveLength(1);
@@ -498,9 +509,11 @@ describe("get", () => {
 			resource: "sdui",
 		});
 
-		expect(result).toHaveLength(2);
-		expect(result[0]).toHaveProperty("name");
-		expect(result[0]).toHaveProperty("pages");
+		expect(result.metadata.count).toBe(2);
+		expect(result.data).toHaveLength(2);
+		expect(result.metadata.order).toEqual(result.data.map((flow) => flow.id));
+		expect(result.data[0]).toHaveProperty("name");
+		expect(result.data[0]).toHaveProperty("pages");
 	});
 
 	it("should return single flow for resource SDUI when filter.id provided", async () => {
@@ -521,8 +534,10 @@ describe("get", () => {
 			filter: { id: flowId },
 		});
 
-		expect(result).toHaveLength(1);
-		const flow = result[0] as UI_Flow;
+		expect(result.metadata.count).toBe(1);
+		expect(result.data).toHaveLength(1);
+		const flow = result.data[0] as UI_Flow;
+		expect(result.metadata.order).toEqual([flowId]);
 		expect(flow.name).toBe("Single Flow");
 	});
 
@@ -533,7 +548,9 @@ describe("get", () => {
 			filter: { id: crypto.randomUUID() },
 		});
 
-		expect(result).toHaveLength(0);
+		expect(result.metadata.count).toBe(0);
+		expect(result.data).toHaveLength(0);
+		expect(result.metadata.order).toEqual([]);
 	});
 
 	it("should reject SDUI get when stored flow data fails Flow validation", async () => {
@@ -592,14 +609,16 @@ describe("get", () => {
 			resource: "services",
 		});
 
-		expect(result).toHaveLength(1);
-		expect(result[0]).toMatchObject({
+		expect(result.metadata.count).toBe(1);
+		expect(result.data).toHaveLength(1);
+		expect(result.metadata.order).toEqual([serviceData.id]);
+		expect(result.data[0]).toMatchObject({
 			id: serviceData.id,
 			name: serviceData.name,
 			description: serviceData.description,
 			createdAt: serviceData.createdAt,
 		});
-		const serviceRow = result[0];
+		const serviceRow = result.data[0];
 		if (!("updatedAt" in serviceRow)) {
 			throw new Error("Expected service row with updatedAt");
 		}
@@ -612,7 +631,10 @@ describe("get", () => {
 			resource: "services",
 		});
 
-		expect(result).toEqual([]);
+		expect(result).toEqual({
+			metadata: { count: 0, size: 2, order: [] },
+			data: [],
+		});
 	});
 });
 
@@ -646,7 +668,7 @@ describe("create SDUI validation", () => {
 			},
 		});
 		expectToBeDATA_EVY_Flow(result);
-		expect(result.data.pages).toHaveLength(0);
+		expect(result.data.data.pages).toHaveLength(0);
 	});
 
 	it("should reject flow with invalid row type", async () => {
@@ -727,8 +749,8 @@ describe("create SDUI validation", () => {
 			data: flowData,
 		});
 		expectToBeDATA_EVY_Flow(result);
-		expect(result.data.name).toBe("Test Flow");
-		expect(result.data.pages).toHaveLength(1);
+		expect(result.data.data.name).toBe("Test Flow");
+		expect(result.data.data.pages).toHaveLength(1);
 	});
 
 	it("should validate footer row", async () => {
@@ -757,6 +779,6 @@ describe("create SDUI validation", () => {
 			data: flowData,
 		});
 		expectToBeDATA_EVY_Flow(result);
-		expect(result.data.pages[0]).toHaveProperty("footer");
+		expect(result.data.data.pages[0]).toHaveProperty("footer");
 	});
 });

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -516,6 +516,42 @@ describe("get", () => {
 		expect(result.data[0]).toHaveProperty("pages");
 	});
 
+	it("should return flow data ordered by most recently updated", async () => {
+		const olderFlow = createTestFlow({
+			name: "Older Flow",
+			pages: [{ title: "P1", rows: [] }],
+		});
+		const newerFlow = createTestFlow({
+			name: "Newer Flow",
+			pages: [{ title: "P2", rows: [] }],
+		});
+		await testDb.insert(schema.flow).values([
+			{
+				id: olderFlow.id,
+				data: olderFlow,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-01T00:00:00.000Z",
+			},
+			{
+				id: newerFlow.id,
+				data: newerFlow,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-02T00:00:00.000Z",
+			},
+		]);
+
+		const result = await get({
+			service: "evy",
+			resource: "sdui",
+		});
+
+		expect(result.data.map((flow) => flow.id)).toEqual([
+			newerFlow.id,
+			olderFlow.id,
+		]);
+		expect(result.metadata.order).toEqual([newerFlow.id, olderFlow.id]);
+	});
+
 	it("should return single flow for resource SDUI when filter.id provided", async () => {
 		const flowId = crypto.randomUUID();
 		await testDb.insert(schema.flow).values({
@@ -623,6 +659,35 @@ describe("get", () => {
 			throw new Error("Expected service row with updatedAt");
 		}
 		expect(typeof serviceRow.updatedAt).toBe("string");
+	});
+
+	it("should return non-SDUI resources ordered by most recently updated", async () => {
+		const olderService = {
+			id: crypto.randomUUID(),
+			name: "OlderSvc",
+			description: "Older",
+			createdAt: "2024-01-01T00:00:00.000Z",
+			updatedAt: "2024-01-01T00:00:00.000Z",
+		};
+		const newerService = {
+			id: crypto.randomUUID(),
+			name: "NewerSvc",
+			description: "Newer",
+			createdAt: "2024-01-01T00:00:00.000Z",
+			updatedAt: "2024-01-02T00:00:00.000Z",
+		};
+		await testDb.insert(schema.service).values([olderService, newerService]);
+
+		const result = await get({
+			service: "evy",
+			resource: "services",
+		});
+
+		expect(result.data.map((row) => row.id)).toEqual([
+			newerService.id,
+			olderService.id,
+		]);
+		expect(result.metadata.order).toEqual([newerService.id, olderService.id]);
 	});
 
 	it("should return empty array for non-SDUI resource when no data", async () => {

--- a/api/src/tests/notifications.test.ts
+++ b/api/src/tests/notifications.test.ts
@@ -146,7 +146,7 @@ describe("create/update real-time notifications", () => {
 			service: "evy",
 			resource: "services",
 			operation: "create",
-			value: createResult,
+			value: createResult.data,
 		});
 
 		subscriber.close();

--- a/api/src/tests/rpcApi.test.ts
+++ b/api/src/tests/rpcApi.test.ts
@@ -12,8 +12,17 @@ const forwardGetMock = mock(
 				id?: string;
 			};
 		},
-	): Promise<GetResponse> =>
-		params.filter?.id ? ([{ id: params.filter.id }] as GetResponse) : [],
+	): Promise<GetResponse> => {
+		const data = params.filter?.id ? [{ id: params.filter.id }] : [];
+		return {
+			metadata: {
+				count: data.length,
+				size: Buffer.byteLength(JSON.stringify(data), "utf8"),
+				order: data.map((item) => item.id),
+			},
+			data,
+		};
+	},
 );
 
 const ensureRegistryInitializedMock = mock(async () => {});
@@ -62,7 +71,14 @@ describe("api JSON-RPC handler", () => {
 			},
 		});
 
-		expect(result).toEqual([{ id: itemId }]);
+		expect(result).toEqual({
+			metadata: {
+				count: 1,
+				size: Buffer.byteLength(JSON.stringify([{ id: itemId }]), "utf8"),
+				order: [itemId],
+			},
+			data: [{ id: itemId }],
+		});
 		expect(forwardGetMock).toHaveBeenCalledTimes(1);
 		expect(forwardGetMock).toHaveBeenCalledWith("marketplace", {
 			service: "marketplace",

--- a/api/src/tests/sync.test.ts
+++ b/api/src/tests/sync.test.ts
@@ -21,15 +21,26 @@ function expectResources(
 	return result.resources as NonNullable<SyncResponse["resources"]>;
 }
 
+function buildMockGetResponse(items: { id: string }[]): GetResponse {
+	return {
+		metadata: {
+			count: items.length,
+			size: Buffer.byteLength(JSON.stringify(items), "utf8"),
+			order: items.map((item) => item.id),
+		},
+		data: items,
+	};
+}
+
 function makeMocks() {
-	const getCore = async (params: GetRequest): Promise<GetResponse> => [
-		{ id: `${params.resource}-mock-1` },
-	];
+	const getCore = async (params: GetRequest): Promise<GetResponse> =>
+		buildMockGetResponse([{ id: `${params.resource}-mock-1` }]);
 
 	const fetchService = async (
 		_serviceName: string,
 		params: GetRequest,
-	): Promise<GetResponse> => [{ id: `${params.resource}-mock-1` }];
+	): Promise<GetResponse> =>
+		buildMockGetResponse([{ id: `${params.resource}-mock-1` }]);
 
 	const buildRegistry: typeof buildResourceRegistry = () => {
 		const resources: Record<string, { singular: string; plural: string }> = {};
@@ -114,7 +125,7 @@ describe("sync", () => {
 	it("passes updatedAfter to getCore", async () => {
 		const getCore = async (params: GetRequest): Promise<GetResponse> => {
 			expect(params.filter?.updatedAfter).toBe(EPOCH);
-			return [{ id: `${params.resource}-1` }];
+			return buildMockGetResponse([{ id: `${params.resource}-1` }]);
 		};
 		const deps = { ...makeMocks(), getCore };
 		await sync({ lastSyncTime: EPOCH }, deps);
@@ -126,15 +137,16 @@ describe("sync", () => {
 			params: GetRequest,
 		): Promise<GetResponse> => {
 			expect(params.filter?.updatedAfter).toBe(EPOCH);
-			return [{ id: `${params.resource}-1` }];
+			return buildMockGetResponse([{ id: `${params.resource}-1` }]);
 		};
 		const deps = { ...makeMocks(), fetchService };
 		await sync({ lastSyncTime: EPOCH }, deps);
 	});
 
 	it("returns empty data and no resources when nothing changed", async () => {
-		const getCore = async (): Promise<GetResponse> => [];
-		const fetchService = async (): Promise<GetResponse> => [];
+		const getCore = async (): Promise<GetResponse> => buildMockGetResponse([]);
+		const fetchService = async (): Promise<GetResponse> =>
+			buildMockGetResponse([]);
 		const deps = { ...makeMocks(), getCore, fetchService };
 		const result = await sync(
 			{ lastSyncTime: "2999-01-01T00:00:00.000Z" },
@@ -145,8 +157,9 @@ describe("sync", () => {
 	});
 
 	it("omits resources when no data changes", async () => {
-		const getCore = async (): Promise<GetResponse> => [];
-		const fetchService = async (): Promise<GetResponse> => [];
+		const getCore = async (): Promise<GetResponse> => buildMockGetResponse([]);
+		const fetchService = async (): Promise<GetResponse> =>
+			buildMockGetResponse([]);
 		const deps = { ...makeMocks(), getCore, fetchService };
 		const result = await sync(
 			{ lastSyncTime: "2999-01-01T00:00:00.000Z" },
@@ -172,7 +185,7 @@ describe("sync", () => {
 			if (serviceName === "marketplace") {
 				throw new Error("gRPC service unavailable");
 			}
-			return [];
+			return buildMockGetResponse([]);
 		};
 		const deps = { ...makeMocks(), fetchService };
 		await expect(sync({ lastSyncTime: EPOCH }, deps)).rejects.toThrow(
@@ -189,6 +202,9 @@ describe("sync", () => {
 			expect(typeof row.resource).toBe("string");
 			expect(row.resource.length).toBeGreaterThan(0);
 			expect(row.value).toBeDefined();
+			expect(row.value.metadata.count).toBe(1);
+			expect(row.value.metadata.order).toEqual([`${row.resource}-mock-1`]);
+			expect(row.value.data).toEqual([{ id: `${row.resource}-mock-1` }]);
 		}
 	});
 });

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -20,6 +20,10 @@
 				"../types/rpcRequestHelpers.ts",
 				"./types/rpcRequestHelpers.ts"
 			],
+			"evy-types/rpcResponseHelpers": [
+				"../types/rpcResponseHelpers.ts",
+				"./types/rpcResponseHelpers.ts"
+			],
 			"evy-types/coreResources": [
 				"../types/coreResources.ts",
 				"./types/coreResources.ts"

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -29,7 +29,8 @@ actor WSEmitter {
   func applySDUI(flowData: [String: Any], flowId: String) async throws {
     let existing = try await getResource(
       service: "evy", resource: "sdui", filter: ["id": flowId])
-    let method = (existing as? [Any])?.isEmpty == false ? "update" : "create"
+    let dataArray = (existing as? [String: Any])?["data"] as? [Any]
+    let method = dataArray?.isEmpty == false ? "update" : "create"
     let params: [String: Any] = [
       "service": "evy",
       "resource": "sdui",
@@ -831,9 +832,9 @@ final class WebSocketE2ETests: E2ETestBase {
     widthText: String,
     items: Any
   ) -> Bool {
-    guard let arr = items as? [Any] else { return false }
+    guard let itemsArray = responseDataArray(from: items) else { return false }
     let normalizedExpectedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    for case let item as [String: Any] in arr {
+    for case let item as [String: Any] in itemsArray {
       guard let t = item["title"] as? String else { continue }
       let normalizedActualTitle = t.trimmingCharacters(in: .whitespacesAndNewlines)
       guard normalizedActualTitle == normalizedExpectedTitle else { continue }
@@ -850,6 +851,13 @@ final class WebSocketE2ETests: E2ETestBase {
       if let n = widthValue as? NSNumber, n.stringValue == widthText { return true }
     }
     return false
+  }
+
+  private static func responseDataArray(from response: Any) -> [Any]? {
+    if let envelope = response as? [String: Any] {
+      return envelope["data"] as? [Any]
+    }
+    return response as? [Any]
   }
 
   private func createHomeFlowData(buttonLabel: String, viewItemId: String? = nil) -> [String: Any] {

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -921,6 +921,7 @@
 		73F1A00B2F30B00100000001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 995A4BQX6K;
@@ -939,6 +940,7 @@
 		73F1A00C2F30B00100000001 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 995A4BQX6K;

--- a/ios/evy/Data/EVYDataStore.swift
+++ b/ios/evy/Data/EVYDataStore.swift
@@ -57,7 +57,8 @@ final class EVYDataStore {
     let descriptor = FetchDescriptor<EVYData>(
       predicate: #Predicate {
         $0.namespace == namespace && $0.resource == resource
-      }
+      },
+      sortBy: [SortDescriptor<EVYData>(\.sortIndex)]
     )
     return try context.fetch(descriptor)
   }
@@ -74,21 +75,22 @@ final class EVYDataStore {
     return try context.fetch(descriptor)
   }
 
-  func create(namespace: String, resource: String, id: String, value: Data) throws {
+  func create(namespace: String, resource: String, id: String, value: Data, sortIndex: Int = 0) throws {
     if (try? get(namespace: namespace, resource: resource, id: id)) != nil {
       throw EVYDataError.keyAlreadyExists
     }
     context.insert(
-      EVYData(namespace: namespace, resource: resource, id: id, data: value)
+      EVYData(namespace: namespace, resource: resource, id: id, data: value, sortIndex: sortIndex)
     )
     postDataChanged(key: "\(namespace):\(resource):\(id)")
     postDataChanged(key: "\(namespace):\(resource)")
     postDataChanged(key: resource)
   }
 
-  func update(namespace: String, resource: String, id: String, value: Data) throws {
+  func update(namespace: String, resource: String, id: String, value: Data, sortIndex: Int = 0) throws {
     let existing = try get(namespace: namespace, resource: resource, id: id)
     existing.data = value
+    existing.sortIndex = sortIndex
     postDataChanged(key: "\(namespace):\(resource):\(id)")
     postDataChanged(key: "\(namespace):\(resource)")
     postDataChanged(key: resource)
@@ -118,33 +120,64 @@ final class EVYDataStore {
     }
   }
 
-  func upsert(namespace: String, resource: String, id: String, value: Data) throws {
+  func upsert(namespace: String, resource: String, id: String, value: Data, sortIndex: Int = 0) throws {
     if (try? get(namespace: namespace, resource: resource, id: id)) != nil {
-      try update(namespace: namespace, resource: resource, id: id, value: value)
+      try update(namespace: namespace, resource: resource, id: id, value: value, sortIndex: sortIndex)
     } else {
-      try create(namespace: namespace, resource: resource, id: id, value: value)
+      try create(namespace: namespace, resource: resource, id: id, value: value, sortIndex: sortIndex)
     }
   }
 
   func applySyncedValue(namespace: String, resource: String, value: EVYJson) throws {
-    switch value {
-    case .array(let items):
-      for item in items {
-        let itemId = item.identifierValue()
-        guard !itemId.isEmpty else { continue }
-        guard let encoded = try? JSONEncoder().encode(item) else { continue }
-        try upsert(namespace: namespace, resource: resource, id: itemId, value: encoded)
-      }
-    default:
-      let instanceId: String
-      if case .dictionary(let dict) = value, case .string(let idVal) = dict["id"] {
-        instanceId = idVal
-      } else {
-        instanceId = EVYNamespace.singletonId
-      }
-      let encoded = try JSONEncoder().encode(value)
-      try upsert(namespace: namespace, resource: resource, id: instanceId, value: encoded)
+    if let envelope = getResponseEnvelope(from: value) {
+      try applySyncedEnvelope(namespace: namespace, resource: resource, envelope: envelope)
+      return
     }
+
+    if case .array(let items) = value {
+      try applySyncedEnvelope(
+        namespace: namespace,
+        resource: resource,
+        envelope: (items: items, order: items.map { $0.identifierValue() })
+      )
+      return
+    }
+
+    let encoded = try JSONEncoder().encode(value)
+    try upsert(namespace: namespace, resource: resource, id: singletonId(for: value), value: encoded)
+  }
+
+  private func getResponseEnvelope(from value: EVYJson) -> (items: [EVYJson], order: [String])? {
+    guard case .dictionary(let dict) = value,
+      case .array(let items) = dict["data"],
+      case .dictionary(let metadata) = dict["metadata"],
+      case .array(let orderValues) = metadata["order"]
+    else {
+      return nil
+    }
+
+    return (items, orderValues.map { $0.toString() })
+  }
+
+  private func applySyncedEnvelope(
+    namespace: String,
+    resource: String,
+    envelope: (items: [EVYJson], order: [String])
+  ) throws {
+    for item in envelope.items {
+      let itemId = item.identifierValue()
+      guard !itemId.isEmpty else { continue }
+      guard let encoded = try? JSONEncoder().encode(item) else { continue }
+      let sortIndex = envelope.order.firstIndex(of: itemId) ?? envelope.order.count
+      try upsert(namespace: namespace, resource: resource, id: itemId, value: encoded, sortIndex: sortIndex)
+    }
+  }
+
+  private func singletonId(for value: EVYJson) -> String {
+    if case .dictionary(let dict) = value, case .string(let idVal) = dict["id"] {
+      return idVal
+    }
+    return EVYNamespace.singletonId
   }
 
   func getCollectionJson(namespace: String, resource: String) throws -> EVYJson? {

--- a/ios/evy/Data/Models/EVYData.swift
+++ b/ios/evy/Data/Models/EVYData.swift
@@ -45,17 +45,20 @@ class EVYData {
   var resource: String
   var id: String
   var data: Data
+  var sortIndex: Int = 0
 
   init(
     namespace: String,
     resource: String,
     id: String,
-    data: Data
+    data: Data,
+    sortIndex: Int = 0
   ) {
     self.namespace = namespace
     self.resource = resource
     self.id = id
     self.data = data
+    self.sortIndex = sortIndex
   }
 
   func decoded() throws -> EVYJson {

--- a/services/marketplace/Dockerfile
+++ b/services/marketplace/Dockerfile
@@ -29,6 +29,7 @@ COPY types/schema ../../types/schema
 COPY types/validators.ts ../../types/validators.ts
 COPY types/coreResources.ts ../../types/coreResources.ts
 COPY types/rpcRequestHelpers.ts ../../types/rpcRequestHelpers.ts
+COPY types/rpcResponseHelpers.ts ../../types/rpcResponseHelpers.ts
 
 # Production stage
 FROM base AS runner

--- a/services/marketplace/e2e/e2e.test.ts
+++ b/services/marketplace/e2e/e2e.test.ts
@@ -51,12 +51,13 @@ describe("Marketplace E2E (via API WebSocket)", () => {
 		client.close();
 	});
 
-	it("get marketplace.items should return an array", async () => {
+	it("get marketplace.items should return an array envelope", async () => {
 		const result = await client.call("get", {
 			service: "marketplace",
 			resource: "items",
 		});
-		expect(Array.isArray(result)).toBe(true);
+		expect(result).toHaveProperty("metadata");
+		expect(Array.isArray(result.data)).toBe(true);
 	});
 
 	it("create then get marketplace.items round-trips data", async () => {
@@ -72,18 +73,20 @@ describe("Marketplace E2E (via API WebSocket)", () => {
 			data: testData,
 		});
 
-		expect(created).toHaveProperty("id");
+		expect(created).toHaveProperty("metadata");
 		expect(created).toHaveProperty("data");
 		expect(isRecord(created.data)).toBe(true);
+		expect(created.data).toHaveProperty("id");
+		expect(created.data).toHaveProperty("data");
 
 		const got = await client.call("get", {
 			service: "marketplace",
 			resource: "items",
 		});
 
-		expect(Array.isArray(got)).toBe(true);
-		expect(got.length).toBeGreaterThan(0);
-		const matchingRecord = got.find(
+		expect(Array.isArray(got.data)).toBe(true);
+		expect(got.data.length).toBeGreaterThan(0);
+		const matchingRecord = got.data.find(
 			(entry: unknown) =>
 				isRecord(entry) &&
 				entry.testField === "e2e test value" &&
@@ -108,10 +111,12 @@ describe("Marketplace E2E (via API WebSocket)", () => {
 		});
 
 		expect(isRecord(created)).toBe(true);
-		expect(created).toHaveProperty("id", clientId);
+		expect(created).toHaveProperty("metadata");
+		expect(created.metadata.order).toEqual([clientId]);
 		expect(created).toHaveProperty("data");
 		expect(isRecord(created.data)).toBe(true);
-		expect(created.data).toMatchObject({
+		expect(created.data).toHaveProperty("id", clientId);
+		expect(created.data.data).toMatchObject({
 			id: clientId,
 			title: "from-ios",
 		});
@@ -122,9 +127,10 @@ describe("Marketplace E2E (via API WebSocket)", () => {
 			filter: { id: clientId },
 		});
 
-		expect(Array.isArray(got)).toBe(true);
-		expect(got).toHaveLength(1);
-		expect(got[0]).toMatchObject({
+		expect(Array.isArray(got.data)).toBe(true);
+		expect(got.data).toHaveLength(1);
+		expect(got.metadata.order).toEqual([clientId]);
+		expect(got.data[0]).toMatchObject({
 			id: clientId,
 			title: "from-ios",
 		});

--- a/services/marketplace/src/data.ts
+++ b/services/marketplace/src/data.ts
@@ -75,9 +75,6 @@ async function marketplaceGetBody(params: GetRequest): Promise<GetResponse> {
 	return buildGetResponse(rows.map((r) => r.data));
 }
 
-/**
- * Marketplace `get` after JSON-RPC shape checks. This only applies marketplace access rules.
- */
 export async function get(params: GetRequest): Promise<GetResponse> {
 	assertMarketplaceRules(params);
 	return marketplaceGetBody(params);
@@ -141,17 +138,11 @@ async function marketplaceUpdateBody(
 	return response;
 }
 
-/**
- * Marketplace `create` after marketplace access rules.
- */
 export async function create(params: CreateRequest): Promise<CreateResponse> {
 	assertMarketplaceRules(params);
 	return marketplaceCreateBody(params);
 }
 
-/**
- * Marketplace `update` after marketplace access rules.
- */
 export async function update(params: UpdateRequest): Promise<UpdateResponse> {
 	assertMarketplaceRules(params);
 	return marketplaceUpdateBody(params);

--- a/services/marketplace/src/data.ts
+++ b/services/marketplace/src/data.ts
@@ -1,11 +1,12 @@
 import { eq, and, desc, gt } from "drizzle-orm";
 
 import type {
-	DATA_PRIMITIVE,
 	CreateRequest,
+	CreateResponse,
 	GetRequest,
 	GetResponse,
 	UpdateRequest,
+	UpdateResponse,
 } from "evy-types";
 import {
 	getServiceResources,
@@ -23,8 +24,24 @@ import {
 	validateCreateResponse,
 	validateUpdateResponse,
 } from "evy-types/validators";
+import {
+	buildCollectionResponseEnvelope,
+	buildSingleResponseEnvelope,
+} from "evy-types/rpcResponseHelpers";
 
 setServiceRegistry([[MARKETPLACE_SERVICE, [...MARKETPLACE_RESOURCE_NAMES]]]);
+
+function buildGetResponse(items: unknown[]): GetResponse {
+	return validateGetResponse(buildCollectionResponseEnvelope(items));
+}
+
+function buildCreateResponse(item: CreateResponse["data"]): CreateResponse {
+	return validateCreateResponse(buildSingleResponseEnvelope(item));
+}
+
+function buildUpdateResponse(item: UpdateResponse["data"]): UpdateResponse {
+	return validateUpdateResponse(buildSingleResponseEnvelope(item));
+}
 
 function assertMarketplaceRules(
 	params: GetRequest | CreateRequest | UpdateRequest,
@@ -55,7 +72,7 @@ async function marketplaceGetBody(params: GetRequest): Promise<GetResponse> {
 		.where(and(...whereClauses))
 		.orderBy(desc(data.updatedAt));
 
-	return validateGetResponse(rows.map((r) => r.data));
+	return buildGetResponse(rows.map((r) => r.data));
 }
 
 /**
@@ -68,7 +85,7 @@ export async function get(params: GetRequest): Promise<GetResponse> {
 
 async function marketplaceCreateBody(
 	params: CreateRequest,
-): Promise<DATA_PRIMITIVE> {
+): Promise<CreateResponse> {
 	const { resource, filter, data: dataPayload } = params;
 	const nowIso = new Date().toISOString();
 
@@ -94,14 +111,14 @@ async function marketplaceCreateBody(
 	}
 
 	const row = result[0];
-	validateCreateResponse(row);
+	const response = buildCreateResponse(row);
 	emitDataChanged(resource, "create", row.data);
-	return row;
+	return response;
 }
 
 async function marketplaceUpdateBody(
 	params: UpdateRequest,
-): Promise<DATA_PRIMITIVE> {
+): Promise<UpdateResponse> {
 	const { resource, filter, data: dataPayload } = params;
 	const nowIso = new Date().toISOString();
 
@@ -119,15 +136,15 @@ async function marketplaceUpdateBody(
 	}
 
 	const row = result[0];
-	validateUpdateResponse(row);
+	const response = buildUpdateResponse(row);
 	emitDataChanged(resource, "update", row.data);
-	return row;
+	return response;
 }
 
 /**
  * Marketplace `create` after marketplace access rules.
  */
-export async function create(params: CreateRequest): Promise<DATA_PRIMITIVE> {
+export async function create(params: CreateRequest): Promise<CreateResponse> {
 	assertMarketplaceRules(params);
 	return marketplaceCreateBody(params);
 }
@@ -135,7 +152,7 @@ export async function create(params: CreateRequest): Promise<DATA_PRIMITIVE> {
 /**
  * Marketplace `update` after marketplace access rules.
  */
-export async function update(params: UpdateRequest): Promise<DATA_PRIMITIVE> {
+export async function update(params: UpdateRequest): Promise<UpdateResponse> {
 	assertMarketplaceRules(params);
 	return marketplaceUpdateBody(params);
 }

--- a/services/marketplace/src/data.ts
+++ b/services/marketplace/src/data.ts
@@ -70,7 +70,7 @@ async function marketplaceGetBody(params: GetRequest): Promise<GetResponse> {
 		.select({ data: data.data })
 		.from(data)
 		.where(and(...whereClauses))
-		.orderBy(desc(data.updatedAt));
+		.orderBy(desc(data.updatedAt), desc(data.id));
 
 	return buildGetResponse(rows.map((r) => r.data));
 }

--- a/services/marketplace/src/readiness.ts
+++ b/services/marketplace/src/readiness.ts
@@ -17,10 +17,13 @@ async function assertMarketplaceReadable(
 	deps: MarketplaceReadableDeps = { get: defaultGet },
 ): Promise<void> {
 	const { requireSeeded } = options;
-	const items = await deps.get({ service: "marketplace", resource: "items" });
-	if (!Array.isArray(items)) {
+	const response = await deps.get({
+		service: "marketplace",
+		resource: "items",
+	});
+	if (!Array.isArray(response.data)) {
 		throw new Error(
-			"Marketplace readiness failed: expected items response array",
+			"Marketplace readiness failed: expected items response data array",
 		);
 	}
 
@@ -28,7 +31,7 @@ async function assertMarketplaceReadable(
 		return;
 	}
 
-	if (items.length === 0) {
+	if (response.data.length === 0) {
 		throw new Error(
 			"Marketplace seed verification failed: missing seeded items data",
 		);

--- a/services/marketplace/src/tests/data.test.ts
+++ b/services/marketplace/src/tests/data.test.ts
@@ -65,6 +65,36 @@ describe("marketplace get/create/update", () => {
 		expect(result.data).toEqual([row]);
 	});
 
+	it("returns rows ordered by most recently updated", async () => {
+		const olderRow = { id: crypto.randomUUID(), value: "older" };
+		const newerRow = { id: crypto.randomUUID(), value: "newer" };
+
+		await testDb.insert(schema.data).values([
+			{
+				id: olderRow.id,
+				resource: "conditions",
+				data: olderRow,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-01T00:00:00.000Z",
+			},
+			{
+				id: newerRow.id,
+				resource: "conditions",
+				data: newerRow,
+				createdAt: "2024-01-01T00:00:00.000Z",
+				updatedAt: "2024-01-02T00:00:00.000Z",
+			},
+		]);
+
+		const result = await get({
+			service: "marketplace",
+			resource: "conditions",
+		});
+
+		expect(result.data).toEqual([newerRow, olderRow]);
+		expect(result.metadata.order).toEqual([newerRow.id, olderRow.id]);
+	});
+
 	it("filters rows by updatedAfter", async () => {
 		const oldRow = { id: crypto.randomUUID(), value: "old" };
 		const newRow = { id: crypto.randomUUID(), value: "new" };

--- a/services/marketplace/src/tests/data.test.ts
+++ b/services/marketplace/src/tests/data.test.ts
@@ -60,7 +60,9 @@ describe("marketplace get/create/update", () => {
 			service: "marketplace",
 			resource: "conditions",
 		});
-		expect(result).toEqual([row]);
+		expect(result.metadata.count).toBe(1);
+		expect(result.metadata.order).toEqual([row.id]);
+		expect(result.data).toEqual([row]);
 	});
 
 	it("filters rows by updatedAfter", async () => {
@@ -88,7 +90,9 @@ describe("marketplace get/create/update", () => {
 			filter: { updatedAfter: "2024-01-02T00:00:00.000Z" },
 		});
 
-		expect(result).toEqual([newRow]);
+		expect(result.metadata.count).toBe(1);
+		expect(result.metadata.order).toEqual([newRow.id]);
+		expect(result.data).toEqual([newRow]);
 	});
 
 	it("filters rows by id", async () => {
@@ -119,7 +123,9 @@ describe("marketplace get/create/update", () => {
 			filter: { id: secondId },
 		});
 
-		expect(result).toEqual([secondRow]);
+		expect(result.metadata.count).toBe(1);
+		expect(result.metadata.order).toEqual([secondRow.id]);
+		expect(result.data).toEqual([secondRow]);
 	});
 
 	it("uses filter.id as primary key when inserting a new row (client id)", async () => {
@@ -131,13 +137,16 @@ describe("marketplace get/create/update", () => {
 			filter: { id: clientId },
 			data: payload,
 		});
-		expect(inserted.id).toBe(clientId);
+		expect(inserted.metadata.count).toBe(1);
+		expect(inserted.metadata.order).toEqual([clientId]);
+		expect(inserted.data.id).toBe(clientId);
 		const byFilter = await get({
 			service: "marketplace",
 			resource: "items",
 			filter: { id: clientId },
 		});
-		expect(byFilter).toEqual([payload]);
+		expect(byFilter.metadata.order).toEqual([clientId]);
+		expect(byFilter.data).toEqual([payload]);
 	});
 
 	it("create then update row", async () => {
@@ -155,6 +164,7 @@ describe("marketplace get/create/update", () => {
 			filter: { id: rowId },
 			data: { ...row, value: "v2" },
 		});
-		expect(updated.data).toEqual({ ...row, value: "v2" });
+		expect(updated.metadata.order).toEqual([rowId]);
+		expect(updated.data.data).toEqual({ ...row, value: "v2" });
 	});
 });

--- a/services/marketplace/src/tests/grpcServer.test.ts
+++ b/services/marketplace/src/tests/grpcServer.test.ts
@@ -117,7 +117,14 @@ describe("marketplace gRPC server", () => {
 			);
 		});
 
-		expect(got).toEqual([row]);
+		expect(got).toEqual({
+			metadata: {
+				count: 1,
+				size: Buffer.byteLength(JSON.stringify([row]), "utf8"),
+				order: [row.id],
+			},
+			data: [row],
+		});
 	});
 
 	it("SubscribeEvents receives dataChanged after catalog create", async () => {

--- a/services/marketplace/tsconfig.json
+++ b/services/marketplace/tsconfig.json
@@ -14,7 +14,8 @@
 			"evy-types/*": ["../../types/generated/ts/*"],
 			"evy-types/validators": ["../../types/validators.ts"],
 			"evy-types/coreResources": ["../../types/coreResources.ts"],
-			"evy-types/rpcRequestHelpers": ["../../types/rpcRequestHelpers.ts"]
+			"evy-types/rpcRequestHelpers": ["../../types/rpcRequestHelpers.ts"],
+			"evy-types/rpcResponseHelpers": ["../../types/rpcResponseHelpers.ts"]
 		}
 	},
 	"include": ["src/**/*", "e2e/**/*"]

--- a/types/rpcResponseHelpers.ts
+++ b/types/rpcResponseHelpers.ts
@@ -1,0 +1,31 @@
+import type { GetResponse } from "./generated/ts";
+
+type ResponseMetadata = GetResponse["metadata"];
+
+function responseOrderId(item: unknown): string {
+	return item !== null && typeof item === "object" && "id" in item
+		? String(item.id)
+		: "";
+}
+
+export function buildResponseMetadata(items: unknown[]): ResponseMetadata {
+	return {
+		count: items.length,
+		size: Buffer.byteLength(JSON.stringify(items), "utf8"),
+		order: items.map(responseOrderId),
+	};
+}
+
+export function buildCollectionResponseEnvelope<TItem>(items: TItem[]): {
+	metadata: ResponseMetadata;
+	data: TItem[];
+} {
+	return { metadata: buildResponseMetadata(items), data: items };
+}
+
+export function buildSingleResponseEnvelope<TData>(data: TData): {
+	metadata: ResponseMetadata;
+	data: TData;
+} {
+	return { metadata: buildResponseMetadata([data]), data };
+}

--- a/types/schema/common/rpc.schema.json
+++ b/types/schema/common/rpc.schema.json
@@ -20,6 +20,31 @@
 		},
 		"IdFilter": {
 			"$ref": "#/$defs/DataFilter"
+		},
+		"ResponseMetadata": {
+			"type": "object",
+			"required": [
+				"count",
+				"size",
+				"order"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"count": {
+					"type": "integer",
+					"minimum": 0
+				},
+				"size": {
+					"type": "integer",
+					"minimum": 0
+				},
+				"order": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
 		}
 	}
 }

--- a/types/schema/rpc/create.response.schema.json
+++ b/types/schema/rpc/create.response.schema.json
@@ -2,22 +2,35 @@
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "create-response",
 	"title": "CreateResponse",
-	"description": "Response for create (evy typed rows or DATA_PRIMITIVE from a service)",
-	"oneOf": [
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Flow"
+	"description": "Response for create (metadata plus evy typed row or DATA_PRIMITIVE from a service)",
+	"type": "object",
+	"required": [
+		"metadata",
+		"data"
+	],
+	"additionalProperties": false,
+	"properties": {
+		"metadata": {
+			"$ref": "../common/rpc.schema.json#/$defs/ResponseMetadata"
 		},
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Service"
-		},
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Organization"
-		},
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_ServiceProvider"
-		},
-		{
-			"$ref": "../data/primitive.schema.json"
+		"data": {
+			"oneOf": [
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Flow"
+				},
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Service"
+				},
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Organization"
+				},
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_ServiceProvider"
+				},
+				{
+					"$ref": "../data/primitive.schema.json"
+				}
+			]
 		}
-	]
+	}
 }

--- a/types/schema/rpc/get.response.schema.json
+++ b/types/schema/rpc/get.response.schema.json
@@ -2,35 +2,70 @@
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "get-response",
 	"title": "GetResponse",
-	"description": "Response for get method - array of UI_Flow and/or generic GetDataResponse items (per-item oneOf avoids overlap with the previous root oneOf, which matched both branches for [] and for UI_Flow[]).",
-	"type": "array",
-	"items": {
-		"oneOf": [
-			{ "$ref": "../sdui/evy.schema.json" },
-			{
-				"allOf": [
-					{ "$ref": "#/$defs/GetDataResponse" },
-					{ "not": { "$ref": "../sdui/evy.schema.json" } }
+	"description": "Response for get method - metadata plus array of UI_Flow and/or generic GetDataResponse items.",
+	"type": "object",
+	"required": [
+		"metadata",
+		"data"
+	],
+	"additionalProperties": false,
+	"properties": {
+		"metadata": {
+			"$ref": "../common/rpc.schema.json#/$defs/ResponseMetadata"
+		},
+		"data": {
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{
+						"$ref": "../sdui/evy.schema.json"
+					},
+					{
+						"allOf": [
+							{
+								"$ref": "#/$defs/GetDataResponse"
+							},
+							{
+								"not": {
+									"$ref": "../sdui/evy.schema.json"
+								}
+							}
+						]
+					}
 				]
 			}
-		]
+		}
 	},
 	"$defs": {
 		"GetDataResponse": {
 			"title": "GetDataResponse",
 			"anyOf": [
-				{ "type": "string" },
-				{ "type": "integer" },
-				{ "type": "number" },
-				{ "type": "boolean" },
-				{ "type": "null" },
+				{
+					"type": "string"
+				},
+				{
+					"type": "integer"
+				},
+				{
+					"type": "number"
+				},
+				{
+					"type": "boolean"
+				},
+				{
+					"type": "null"
+				},
 				{
 					"type": "array",
-					"items": { "$ref": "#/$defs/GetDataResponse" }
+					"items": {
+						"$ref": "#/$defs/GetDataResponse"
+					}
 				},
 				{
 					"type": "object",
-					"additionalProperties": { "$ref": "#/$defs/GetDataResponse" }
+					"additionalProperties": {
+						"$ref": "#/$defs/GetDataResponse"
+					}
 				}
 			]
 		}

--- a/types/schema/rpc/update.response.schema.json
+++ b/types/schema/rpc/update.response.schema.json
@@ -2,22 +2,35 @@
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "update-response",
 	"title": "UpdateResponse",
-	"description": "Response for update (evy typed rows or DATA_PRIMITIVE from a service)",
-	"oneOf": [
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Flow"
+	"description": "Response for update (metadata plus evy typed row or DATA_PRIMITIVE from a service)",
+	"type": "object",
+	"required": [
+		"metadata",
+		"data"
+	],
+	"additionalProperties": false,
+	"properties": {
+		"metadata": {
+			"$ref": "../common/rpc.schema.json#/$defs/ResponseMetadata"
 		},
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Service"
-		},
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Organization"
-		},
-		{
-			"$ref": "../data/data.schema.json#/$defs/DATA_EVY_ServiceProvider"
-		},
-		{
-			"$ref": "../data/primitive.schema.json"
+		"data": {
+			"oneOf": [
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Flow"
+				},
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Service"
+				},
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_Organization"
+				},
+				{
+					"$ref": "../data/data.schema.json#/$defs/DATA_EVY_ServiceProvider"
+				},
+				{
+					"$ref": "../data/primitive.schema.json"
+				}
+			]
 		}
-	]
+	}
 }

--- a/types/validators.ts
+++ b/types/validators.ts
@@ -206,6 +206,7 @@ const REQUEST_SCHEMA_FILES = [
 /** data.schema references SDUI for DATA_EVY_Flow; register both in one instance */
 const ENTITY_SCHEMA_FILES = [
 	"common/json.schema.json",
+	"common/rpc.schema.json",
 	"data/data.schema.json",
 	"data/primitive.schema.json",
 	"sdui/evy.schema.json",

--- a/web/app/api/sync.ts
+++ b/web/app/api/sync.ts
@@ -1,18 +1,5 @@
 import type { SyncResponse, UI_Flow as ServerFlow } from "evy-types";
-import { wsClient } from "./wsClient";
-
-function isServerFlow(v: unknown): v is ServerFlow {
-	return (
-		v !== null &&
-		typeof v === "object" &&
-		"id" in v &&
-		"name" in v &&
-		typeof v.id === "string" &&
-		typeof v.name === "string" &&
-		"pages" in v &&
-		Array.isArray(v.pages)
-	);
-}
+import { isServerFlow, wsClient } from "./wsClient";
 
 function extractSduiFlows(response: SyncResponse): ServerFlow[] {
 	const sduiRow = response.data.find(

--- a/web/app/api/sync.ts
+++ b/web/app/api/sync.ts
@@ -19,16 +19,50 @@ function extractSduiFlows(response: SyncResponse): ServerFlow[] {
 		(row) => row.service === "evy" && row.resource === "sdui",
 	);
 
-	if (!sduiRow || !Array.isArray(sduiRow.value)) {
+	const value = sduiRow?.value;
+	if (!isGetResponseEnvelope(value)) {
 		return [];
 	}
 
-	const flows = sduiRow.value;
+	const flows = value.data;
 	if (!flows.every(isServerFlow)) {
 		throw new Error("Invalid flows in sync response");
 	}
 
-	return flows;
+	if (!hasOrder(value.metadata)) {
+		return flows;
+	}
+
+	const orderIndexById = new Map(
+		value.metadata.order.map((id, index) => [id, index]),
+	);
+	return [...flows].sort(
+		(a, b) =>
+			(orderIndexById.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+			(orderIndexById.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+	);
+}
+
+function isGetResponseEnvelope(
+	value: unknown,
+): value is { metadata: unknown; data: unknown[] } {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		"metadata" in value &&
+		"data" in value &&
+		Array.isArray(value.data)
+	);
+}
+
+function hasOrder(value: unknown): value is { order: string[] } {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		"order" in value &&
+		Array.isArray(value.order) &&
+		value.order.every((id) => typeof id === "string")
+	);
 }
 
 const EPOCH = "1970-01-01T00:00:00.000Z";

--- a/web/app/api/wsClient.ts
+++ b/web/app/api/wsClient.ts
@@ -20,21 +20,46 @@ function isServerFlow(v: unknown): v is ServerFlow {
 	);
 }
 
-function isWriteResponse(v: unknown): v is CreateResponse | UpdateResponse {
+function isWriteResponseEnvelope(
+	value: unknown,
+): value is CreateResponse | UpdateResponse {
 	return (
-		v !== null &&
-		typeof v === "object" &&
-		"id" in v &&
-		"data" in v &&
-		"createdAt" in v &&
-		"updatedAt" in v
+		value !== null &&
+		typeof value === "object" &&
+		"metadata" in value &&
+		"data" in value &&
+		value.data !== null &&
+		typeof value.data === "object"
 	);
 }
 
-function isFlowWriteResponse(
-	v: unknown,
-): v is { id: string; data: ServerFlow; createdAt: string; updatedAt: string } {
-	return isWriteResponse(v) && isServerFlow(v.data);
+function isFlowWriteResponse(value: unknown): value is {
+	metadata: unknown;
+	data: { id: string; data: ServerFlow; createdAt: string; updatedAt: string };
+} {
+	if (!isWriteResponseEnvelope(value)) return false;
+	const inner = value.data;
+	return (
+		inner !== null &&
+		typeof inner === "object" &&
+		"id" in inner &&
+		"data" in inner &&
+		"createdAt" in inner &&
+		"updatedAt" in inner &&
+		typeof inner.id === "string" &&
+		typeof inner.createdAt === "string" &&
+		typeof inner.updatedAt === "string" &&
+		isServerFlow(inner.data)
+	);
+}
+
+function isGetResponseEnvelope(value: unknown): value is { data: unknown[] } {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		"data" in value &&
+		Array.isArray(value.data)
+	);
 }
 
 type ConnectionState = "disconnected" | "connecting" | "connected" | "error";
@@ -65,7 +90,7 @@ class WSClient {
 				}
 			});
 
-			this.client.on("error", (error) => {
+			this.client.on("error", (error: Error) => {
 				this.connectionState = "error";
 				this.connectionPromise = null;
 				reject(error);
@@ -105,7 +130,7 @@ class WSClient {
 			resource: "sdui",
 			filter: { id: flowId },
 		});
-		return Array.isArray(raw) && raw.some(isServerFlow);
+		return isGetResponseEnvelope(raw) && raw.data.some(isServerFlow);
 	}
 
 	async updateSDUI(flowData: ServerFlow): Promise<ServerFlow> {
@@ -124,7 +149,7 @@ class WSClient {
 		if (!isFlowWriteResponse(raw)) {
 			throw new Error("Invalid write response: expected flow");
 		}
-		return raw.data;
+		return raw.data.data;
 	}
 
 	disconnect(): void {

--- a/web/app/api/wsClient.ts
+++ b/web/app/api/wsClient.ts
@@ -7,7 +7,7 @@ import type {
 } from "evy-types";
 import { config } from "../config";
 
-function isServerFlow(v: unknown): v is ServerFlow {
+export function isServerFlow(v: unknown): v is ServerFlow {
 	return (
 		v !== null &&
 		typeof v === "object" &&
@@ -105,7 +105,7 @@ class WSClient {
 		return this.connectionPromise;
 	}
 
-	async sync(lastSyncTime = "1970-01-01T00:00:00.000Z"): Promise<SyncResponse> {
+	async sync(lastSyncTime: string): Promise<SyncResponse> {
 		await this.connect();
 		if (!this.client) throw new Error("WebSocket client not initialized");
 

--- a/web/e2e/e2e.pw.ts
+++ b/web/e2e/e2e.pw.ts
@@ -55,11 +55,11 @@ async function withApiClient<T>(
 
 async function getFlowsFromApi(): Promise<UI_Flow[]> {
 	return withApiClient(async (client) => {
-		const result = await client.call("get", {
+		const result = (await client.call("get", {
 			service: "evy",
 			resource: "sdui",
-		});
-		return result as UI_Flow[];
+		})) as { data?: UI_Flow[] };
+		return Array.isArray(result.data) ? result.data : [];
 	});
 }
 

--- a/web/integration/offline.pw.ts
+++ b/web/integration/offline.pw.ts
@@ -71,7 +71,14 @@ test.describe("Offline and connection resilience", () => {
 									{
 										service: "evy",
 										resource: "sdui",
-										value: [mockFlow],
+										value: {
+											metadata: {
+												count: 1,
+												size: JSON.stringify([mockFlow]).length,
+												order: [mockFlow.id],
+											},
+											data: [mockFlow],
+										},
 									},
 								],
 							},


### PR DESCRIPTION
## Summary

Adds a `ResponseMetadata` envelope to RPC `get`, `create`, and `update` responses across the API, marketplace service, web client, and iOS client. Responses now include `metadata.count`, `metadata.size`, `metadata.order`, and `data`.

## Major changes

- Added shared response metadata schema and generated response types for `GetResponse`, `CreateResponse`, and `UpdateResponse`.
- Added shared TypeScript response envelope helpers in `types/rpcResponseHelpers.ts`.
- Wrapped evy core and marketplace `get` / `create` / `update` responses while keeping `dataChanged` notifications raw.
- Updated `get` ordering so returned data and `metadata.order` are sorted by most recently updated first, with `id` as a deterministic tiebreaker.
- Updated sync/readiness paths, web client handling, web integration/e2e fixtures, and iOS synced data storage to consume envelopes.
- Added iOS sort index persistence so synced collections keep server response order locally.
- Updated API, marketplace, web, and iOS tests/e2e assertions for the new response shape.

## Tests run

Not run during PR creation per instruction. Previously validated locally:

- `bun run types:generate`
- `bun run --cwd api lint`
- `bun run --cwd api build`
- `bun run --cwd api test:unit`
- `bun run --cwd services/marketplace lint`
- `bun run --cwd services/marketplace build`
- `bun run --cwd services/marketplace test:unit`
- `bun run --cwd web lint`
- `bun run --cwd web build`
- `bun run --cwd web test:unit`
- `bun run --cwd web test:integration`
- `xcodebuild -project ios/evy.xcodeproj -scheme evy -destination id=720DFE87-EBB5-4845-9858-517608309B10 build -quiet`
- `xcodebuild test -project ios/evy.xcodeproj -scheme evy -destination id=720DFE87-EBB5-4845-9858-517608309B10 -only-testing:evyTests -quiet`
- `xcodebuild test -project ios/evy.xcodeproj -scheme evy -destination id=720DFE87-EBB5-4845-9858-517608309B10 -only-testing:evyUITests/WebSocketE2ETests/testCreateItemFormEditing -quiet`
- `./run-e2e.sh --skip-ios`

## Risks and follow-up

- Clients must unwrap RPC response envelopes before reading data.
- `dataChanged` notification shape intentionally remains raw and unchanged.
- iOS keeps bare-array sync compatibility for legacy test/setup paths while using envelopes for real sync responses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782307576&installation_id=127792561&pr_number=193&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F193&signature=dc9f4a201393a5c43dcb7e5f00df8a9ef4127b0947ba7ef3fc1e4b3d707df738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->