### PR TITLE
[REFACTOR] Sort all resource responses oldest first

### DIFF
--- a/api/src/data.ts
+++ b/api/src/data.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt } from "drizzle-orm";
+import { and, asc, eq, gt } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
@@ -145,8 +145,8 @@ async function listCoreCatalogRows<TRow>(
 	const rows = whereClauses.length
 		? await base
 				.where(and(...whereClauses))
-				.orderBy(desc(table.updatedAt), desc(table.id))
-		: await base.orderBy(desc(table.updatedAt), desc(table.id));
+				.orderBy(asc(table.updatedAt), asc(table.id))
+		: await base.orderBy(asc(table.updatedAt), asc(table.id));
 	const mapped = rows.map((r) => mapRow(r as TRow));
 	return buildGetResponse(mapped);
 }
@@ -270,8 +270,8 @@ async function getCoreBody(params: GetRequest): Promise<GetResponse> {
 		const rows = whereClauses.length
 			? await base
 					.where(and(...whereClauses))
-					.orderBy(desc(flow.updatedAt), desc(flow.id))
-			: await base.orderBy(desc(flow.updatedAt), desc(flow.id));
+					.orderBy(asc(flow.updatedAt), asc(flow.id))
+			: await base.orderBy(asc(flow.updatedAt), asc(flow.id));
 		const payload = rows.map((f) => f.data);
 		for (const item of payload) {
 			validateFlowData(item);

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -516,7 +516,7 @@ describe("get", () => {
 		expect(result.data[0]).toHaveProperty("pages");
 	});
 
-	it("should return flow data ordered by most recently updated", async () => {
+	it("should return flow data ordered by oldest first", async () => {
 		const olderFlow = createTestFlow({
 			name: "Older Flow",
 			pages: [{ title: "P1", rows: [] }],
@@ -546,10 +546,10 @@ describe("get", () => {
 		});
 
 		expect(result.data.map((flow) => flow.id)).toEqual([
-			newerFlow.id,
 			olderFlow.id,
+			newerFlow.id,
 		]);
-		expect(result.metadata.order).toEqual([newerFlow.id, olderFlow.id]);
+		expect(result.metadata.order).toEqual([olderFlow.id, newerFlow.id]);
 	});
 
 	it("should return single flow for resource SDUI when filter.id provided", async () => {
@@ -661,7 +661,7 @@ describe("get", () => {
 		expect(typeof serviceRow.updatedAt).toBe("string");
 	});
 
-	it("should return non-SDUI resources ordered by most recently updated", async () => {
+	it("should return non-SDUI resources ordered by oldest first", async () => {
 		const olderService = {
 			id: crypto.randomUUID(),
 			name: "OlderSvc",
@@ -684,10 +684,10 @@ describe("get", () => {
 		});
 
 		expect(result.data.map((row) => row.id)).toEqual([
-			newerService.id,
 			olderService.id,
+			newerService.id,
 		]);
-		expect(result.metadata.order).toEqual([newerService.id, olderService.id]);
+		expect(result.metadata.order).toEqual([olderService.id, newerService.id]);
 	});
 
 	it("should return empty array for non-SDUI resource when no data", async () => {

--- a/services/marketplace/src/data.ts
+++ b/services/marketplace/src/data.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, gt } from "drizzle-orm";
+import { and, asc, eq, gt } from "drizzle-orm";
 
 import type {
 	CreateRequest,
@@ -70,7 +70,7 @@ async function marketplaceGetBody(params: GetRequest): Promise<GetResponse> {
 		.select({ data: data.data })
 		.from(data)
 		.where(and(...whereClauses))
-		.orderBy(desc(data.updatedAt), desc(data.id));
+		.orderBy(asc(data.updatedAt), asc(data.id));
 
 	return buildGetResponse(rows.map((r) => r.data));
 }

--- a/services/marketplace/src/tests/data.test.ts
+++ b/services/marketplace/src/tests/data.test.ts
@@ -65,7 +65,7 @@ describe("marketplace get/create/update", () => {
 		expect(result.data).toEqual([row]);
 	});
 
-	it("returns rows ordered by most recently updated", async () => {
+	it("returns rows ordered by oldest first", async () => {
 		const olderRow = { id: crypto.randomUUID(), value: "older" };
 		const newerRow = { id: crypto.randomUUID(), value: "newer" };
 
@@ -91,8 +91,8 @@ describe("marketplace get/create/update", () => {
 			resource: "conditions",
 		});
 
-		expect(result.data).toEqual([newerRow, olderRow]);
-		expect(result.metadata.order).toEqual([newerRow.id, olderRow.id]);
+		expect(result.data).toEqual([olderRow, newerRow]);
+		expect(result.metadata.order).toEqual([olderRow.id, newerRow.id]);
 	});
 
 	it("filters rows by updatedAfter", async () => {


### PR DESCRIPTION
## Summary

Changes sort order for all resource `get` responses from newest-first to oldest-first across the API and Marketplace service.

## Changes

**`api/src/data.ts`**
- Replaced `desc(updatedAt), desc(id)` with `asc(updatedAt), asc(id)` in `listCoreCatalogRows` (used for services, organisations, providers)
- Same replacement in `getCoreBody` for the SDUI flow query

**`services/marketplace/src/data.ts`**
- Replaced `desc(updatedAt), desc(id)` with `asc(updatedAt), asc(id)` in `marketplaceGetBody`

**`api/src/tests/data.test.ts`** / **`services/marketplace/src/tests/data.test.ts`**
- Updated test names and assertions to reflect oldest-first ordering

## Tests

- `bun run build` — passes for both api and marketplace
- `bun run lint` — clean
- `bun run test:unit` — 70/70 pass (api), 9/9 pass (marketplace)

## Risks

Any client or UI that relied on newest-first ordering will now receive results in the opposite order. The iOS `sortIndex` from the response `metadata.order` will reflect oldest-first, so iOS rendering order is consistent with the server.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782356040&installation_id=127792561&pr_number=194&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F194&signature=7af544b67dc8b2d1a2f8ac5b20c33337a130977e6982f8cb88118e9d389570b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->