### PR TITLE
[BUG] Preserve search order on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If smartphones and the internet were built by the people for the people. Create 
 
 ## Architecture at a glance
 
-EVY is split into thin clients (iOS, web builder), one public edge (`api`), and per-service backend workers that speak a shared gRPC contract (`evy.Service`). JSON-RPC requests are routed by `service + resource`:
+EVY is split into 2 thin clients (iOS, web builder), one public edge (`api`), and per-service backend workers that speak a shared gRPC contract (`evy.Service`). JSON-RPC requests are routed by `service + resource`:
 - `service: "evy"` is handled in-process in the API (SDUI flows and core catalog tables)
 - any other declared service (e.g. `marketplace`) is reached over gRPC from [`api/src/services.ts`](./api/src/services.ts).
 

--- a/api/bun.lock
+++ b/api/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "evy",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
+        "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.1",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -15,8 +15,8 @@
         "rpc-websockets": "^10.0.1",
       },
       "devDependencies": {
-        "@electric-sql/pglite": "^0.4.5",
-        "@types/node": "^25.9.0",
+        "@electric-sql/pglite": "^0.4.6",
+        "@types/node": "^25.9.1",
         "@types/pluralize": "^0.0.33",
         "@types/uuid": "^11.0.0",
         "@types/ws": "^8.18.1",
@@ -28,7 +28,7 @@
   "packages": {
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.5", "", {}, "sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g=="],
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.6", "", {}, "sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -86,7 +86,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
@@ -114,7 +114,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.18", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ=="],
 
-    "@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/pluralize": ["@types/pluralize@0.0.33", "", {}, "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg=="],
 
@@ -224,9 +224,9 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
-    "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
-
     "@types/ws/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "bun-types/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
 
     "protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 

--- a/api/package.json
+++ b/api/package.json
@@ -21,8 +21,8 @@
 		"db:studio": "bun --env-file=../.env drizzle-kit studio"
 	},
 	"devDependencies": {
-		"@electric-sql/pglite": "^0.4.5",
-		"@types/node": "^25.9.0",
+		"@electric-sql/pglite": "^0.4.6",
+		"@types/node": "^25.9.1",
 		"@types/pluralize": "^0.0.33",
 		"@types/uuid": "^11.0.0",
 		"@types/ws": "^8.18.1",
@@ -30,7 +30,7 @@
 		"drizzle-kit": "^0.31.10"
 	},
 	"dependencies": {
-		"@grpc/grpc-js": "^1.14.3",
+		"@grpc/grpc-js": "^1.14.4",
 		"@grpc/proto-loader": "^0.8.1",
 		"ajv": "^8.20.0",
 		"ajv-formats": "^3.0.1",

--- a/ios/README.md
+++ b/ios/README.md
@@ -12,6 +12,14 @@ Pages can receive query parameters through navigation actions. Query params are 
 
 SDUI bindings use plural resource-only names such as `{conditions}` or `{timeslots}`. Edit rows write drafts through plural destinations such as `{item.title}` or `{item.condition}`. Those bindings resolve exact local keys first, then explicitly fall back to synced service resources. Search rows and dynamic ListContainer rows read local/synced data from their `source` and render `view.content.child` templates using `{$datum.}`. This keeps local draft/entity data separate from backend catalog data while preserving simple SDUI source strings.
 
+### Search result ordering
+
+When the backend returns a collection (via sync or a `dataChanged` notification envelope), the
+response includes `metadata.order` — an array of IDs in display order. iOS stores each item with
+a `sortIndex` equal to its position in that array, so `getAll` returns items in backend order.
+Items created locally or received via single-item notifications are assigned `sortIndex =
+maxExisting + 1` so they append to the end. No separate order-state layer is needed.
+
 ### Draft scopes and draft cache keys
 
 iOS drafts are stored in the in-memory draft cache, separate from public/private SwiftData stores.

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		74A100132F32000100000001 /* EVYActionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100162F32000100000001 /* EVYActionRunnerTests.swift */; };
 		74A100172F32000100000001 /* EVYDraftMergesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100182F32000100000001 /* EVYDraftMergesTests.swift */; };
 		74A100222F32000100000001 /* EVYDraftBindingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A100212F32000100000001 /* EVYDraftBindingsTests.swift */; };
+		E00100112F73010100000001 /* EVYDataStoreSortIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E00100122F73010100000001 /* EVYDataStoreSortIndexTests.swift */; };
 		7858E83074C330353C4844E5 /* EVY+DatumExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A43F6468C5603E3B57ECD3 /* EVY+DatumExpression.swift */; };
 /* End PBXBuildFile section */
 
@@ -195,6 +196,7 @@
 		74A100162F32000100000001 /* EVYActionRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYActionRunnerTests.swift; sourceTree = "<group>"; };
 		74A100182F32000100000001 /* EVYDraftMergesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYDraftMergesTests.swift; sourceTree = "<group>"; };
 		74A100212F32000100000001 /* EVYDraftBindingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYDraftBindingsTests.swift; sourceTree = "<group>"; };
+		E00100122F73010100000001 /* EVYDataStoreSortIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYDataStoreSortIndexTests.swift; sourceTree = "<group>"; };
 		97A43F6468C5603E3B57ECD3 /* EVY+DatumExpression.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EVY+DatumExpression.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -480,6 +482,7 @@
 				74A100142F32000100000001 /* ContentViewTests.swift */,
 				74A100182F32000100000001 /* EVYDraftMergesTests.swift */,
 				74A100212F32000100000001 /* EVYDraftBindingsTests.swift */,
+				E00100122F73010100000001 /* EVYDataStoreSortIndexTests.swift */,
 				74A100042F32000100000001 /* interpreterTests.swift */,
 			);
 			path = evyTests;
@@ -717,6 +720,7 @@
 				74A100112F32000100000001 /* ContentViewTests.swift in Sources */,
 				74A100172F32000100000001 /* EVYDraftMergesTests.swift in Sources */,
 				74A100222F32000100000001 /* EVYDraftBindingsTests.swift in Sources */,
+				E00100112F73010100000001 /* EVYDataStoreSortIndexTests.swift in Sources */,
 				74A100012F32000100000001 /* interpreterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/evy/Core/EVY+Mutations.swift
+++ b/ios/evy/Core/EVY+Mutations.swift
@@ -79,11 +79,13 @@ extension EVY {
       data: dataWithId
     )
     let encodedData = try JSONEncoder().encode(dataWithId)
+    let nextSortIndex = publicStore.nextSortIndex(namespace: namespace, resource: resource)
     try publicStore.create(
       namespace: namespace,
       resource: resource,
       id: newId,
-      value: encodedData
+      value: encodedData,
+      sortIndex: nextSortIndex
     )
 
     Task { @MainActor in

--- a/ios/evy/Data/EVYDataStore.swift
+++ b/ios/evy/Data/EVYDataStore.swift
@@ -144,7 +144,15 @@ final class EVYDataStore {
     }
 
     let encoded = try JSONEncoder().encode(value)
-    try upsert(namespace: namespace, resource: resource, id: singletonId(for: value), value: encoded)
+    let itemId = singletonId(for: value)
+    let existingSortIndex = (try? get(namespace: namespace, resource: resource, id: itemId))?.sortIndex
+    let sortIndex = existingSortIndex ?? nextSortIndex(namespace: namespace, resource: resource)
+    try upsert(namespace: namespace, resource: resource, id: itemId, value: encoded, sortIndex: sortIndex)
+  }
+
+  func nextSortIndex(namespace: String, resource: String) -> Int {
+    let maxExisting = (try? getAll(namespace: namespace, resource: resource))?.map(\.sortIndex).max()
+    return (maxExisting ?? -1) + 1
   }
 
   private func getResponseEnvelope(from value: EVYJson) -> (items: [EVYJson], order: [String])? {

--- a/ios/evyTests/EVYDataStoreSortIndexTests.swift
+++ b/ios/evyTests/EVYDataStoreSortIndexTests.swift
@@ -1,0 +1,63 @@
+//
+//  EVYDataStoreSortIndexTests.swift
+//  evyTests
+//
+
+import XCTest
+
+@testable import evy
+
+@MainActor
+final class EVYDataStoreSortIndexTests: XCTestCase {
+  override func setUp() async throws {
+    try await super.setUp()
+    try? EVY.publicStore.deleteAll(namespace: "test", resource: "items")
+  }
+
+  override func tearDown() async throws {
+    try? EVY.publicStore.deleteAll(namespace: "test", resource: "items")
+    try await super.tearDown()
+  }
+
+  func testApplySyncedValuePreservesSortIndexForExistingItem() throws {
+    let originalData = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("item-1"), "title": .string("Original")]))
+    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-1", value: originalData, sortIndex: 7)
+
+    let updatedValue = EVYJson.dictionary(["id": .string("item-1"), "title": .string("Updated")])
+    try EVY.publicStore.applySyncedValue(namespace: "test", resource: "items", value: updatedValue)
+
+    let stored = try EVY.publicStore.get(namespace: "test", resource: "items", id: "item-1")
+    XCTAssertEqual(stored.sortIndex, 7)
+
+    let decoded = try stored.decoded()
+    guard case .dictionary(let dict) = decoded, case .string(let title) = dict["title"] else {
+      XCTFail("Unexpected decoded shape")
+      return
+    }
+    XCTAssertEqual(title, "Updated")
+  }
+
+  func testApplySyncedValueSingleNewItemAppendsAfterExistingItems() throws {
+    let item1Data = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("item-1")]))
+    let item2Data = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("item-2")]))
+    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-1", value: item1Data, sortIndex: 0)
+    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-2", value: item2Data, sortIndex: 5)
+
+    let newValue = EVYJson.dictionary(["id": .string("item-3"), "title": .string("New")])
+    try EVY.publicStore.applySyncedValue(namespace: "test", resource: "items", value: newValue)
+
+    let stored = try EVY.publicStore.get(namespace: "test", resource: "items", id: "item-3")
+    XCTAssertEqual(stored.sortIndex, 6)
+
+    let all = try EVY.publicStore.getAll(namespace: "test", resource: "items")
+    XCTAssertEqual(all.last?.id, "item-3")
+  }
+
+  func testApplySyncedValueSingleNewItemUsesZeroWhenCollectionIsEmpty() throws {
+    let newValue = EVYJson.dictionary(["id": .string("item-1"), "title": .string("First")])
+    try EVY.publicStore.applySyncedValue(namespace: "test", resource: "items", value: newValue)
+
+    let stored = try EVY.publicStore.get(namespace: "test", resource: "items", id: "item-1")
+    XCTAssertEqual(stored.sortIndex, 0)
+  }
+}

--- a/ios/evyTests/EVYDataStoreSortIndexTests.swift
+++ b/ios/evyTests/EVYDataStoreSortIndexTests.swift
@@ -28,20 +28,12 @@ final class EVYDataStoreSortIndexTests: XCTestCase {
 
     let stored = try EVY.publicStore.get(namespace: "test", resource: "items", id: "item-1")
     XCTAssertEqual(stored.sortIndex, 7)
-
-    let decoded = try stored.decoded()
-    guard case .dictionary(let dict) = decoded, case .string(let title) = dict["title"] else {
-      XCTFail("Unexpected decoded shape")
-      return
-    }
-    XCTAssertEqual(title, "Updated")
+    XCTAssertEqual(try stored.decoded(), .dictionary(["id": .string("item-1"), "title": .string("Updated")]))
   }
 
   func testApplySyncedValueSingleNewItemAppendsAfterExistingItems() throws {
-    let item1Data = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("item-1")]))
-    let item2Data = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("item-2")]))
-    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-1", value: item1Data, sortIndex: 0)
-    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-2", value: item2Data, sortIndex: 5)
+    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-1", value: makeItemData(id: "item-1"), sortIndex: 0)
+    try EVY.publicStore.create(namespace: "test", resource: "items", id: "item-2", value: makeItemData(id: "item-2"), sortIndex: 5)
 
     let newValue = EVYJson.dictionary(["id": .string("item-3"), "title": .string("New")])
     try EVY.publicStore.applySyncedValue(namespace: "test", resource: "items", value: newValue)
@@ -59,5 +51,9 @@ final class EVYDataStoreSortIndexTests: XCTestCase {
 
     let stored = try EVY.publicStore.get(namespace: "test", resource: "items", id: "item-1")
     XCTAssertEqual(stored.sortIndex, 0)
+  }
+
+  private func makeItemData(id: String) throws -> Data {
+    try JSONEncoder().encode(EVYJson.dictionary(["id": .string(id)]))
   }
 }

--- a/ios/evyTests/EVYDraftMergesTests.swift
+++ b/ios/evyTests/EVYDraftMergesTests.swift
@@ -79,4 +79,21 @@ final class EVYCreateMergesDraftsTests: XCTestCase {
       "expected price value 99, got \(String(describing: value))"
     )
   }
+
+  func testCreateAppendsNewItemWithHighestSortIndex() throws {
+    let seed1Data = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("seed-1")]))
+    let seed2Data = try JSONEncoder().encode(EVYJson.dictionary(["id": .string("seed-2")]))
+    try EVY.publicStore.create(namespace: "marketplace", resource: "items", id: "seed-1", value: seed1Data, sortIndex: 0)
+    try EVY.publicStore.create(namespace: "marketplace", resource: "items", id: "seed-2", value: seed2Data, sortIndex: 1)
+
+    EVY.ensureDraftExists(variableName: "title")
+    try EVY.updateValue("New Item", at: "{title}")
+    try EVY.create(namespace: "marketplace", resource: "items", draftScopeId: testDraftScope)
+
+    let instances = try EVY.publicStore.getAll(namespace: "marketplace", resource: "items")
+    XCTAssertEqual(instances.count, 3)
+    let newItem = try XCTUnwrap(instances.first(where: { $0.id != "seed-1" && $0.id != "seed-2" }))
+    XCTAssertEqual(newItem.sortIndex, 2)
+    XCTAssertEqual(instances.last?.id, newItem.id)
+  }
 }

--- a/services/marketplace/bun.lock
+++ b/services/marketplace/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "evy-marketplace",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
+        "@grpc/grpc-js": "^1.14.4",
         "@grpc/proto-loader": "^0.8.1",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -13,8 +13,8 @@
         "postgres": "^3.4.9",
       },
       "devDependencies": {
-        "@electric-sql/pglite": "^0.4.5",
-        "@types/node": "^25.9.0",
+        "@electric-sql/pglite": "^0.4.6",
+        "@types/node": "^25.9.1",
         "@types/ws": "^8.18.1",
         "bun-types": "^1.3.14",
         "drizzle-kit": "^0.31.10",
@@ -25,7 +25,7 @@
   "packages": {
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.5", "", {}, "sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g=="],
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.6", "", {}, "sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -83,7 +83,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
 
@@ -111,7 +111,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
 
-    "@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -213,9 +213,9 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
-    "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
-
     "@types/ws/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
 
     "protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 

--- a/services/marketplace/package.json
+++ b/services/marketplace/package.json
@@ -21,15 +21,15 @@
 		"db:studio": "bun --env-file=../../.env drizzle-kit studio"
 	},
 	"devDependencies": {
-		"@electric-sql/pglite": "^0.4.5",
-		"@types/node": "^25.9.0",
+		"@electric-sql/pglite": "^0.4.6",
+		"@types/node": "^25.9.1",
 		"@types/ws": "^8.18.1",
 		"bun-types": "^1.3.14",
 		"drizzle-kit": "^0.31.10",
 		"rpc-websockets": "^10.0.1"
 	},
 	"dependencies": {
-		"@grpc/grpc-js": "^1.14.3",
+		"@grpc/grpc-js": "^1.14.4",
 		"@grpc/proto-loader": "^0.8.1",
 		"ajv": "^8.20.0",
 		"ajv-formats": "^3.0.1",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -18,7 +18,7 @@
         "@biomejs/biome": "^2.4.15",
         "@playwright/test": "1.60.0",
         "@types/bun": "^1.3.14",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
       },
     },
@@ -58,7 +58,7 @@
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+    "@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,7 @@
 		"@playwright/test": "1.60.0",
 		"@biomejs/biome": "^2.4.15",
 		"@types/bun": "^1.3.14",
-		"@types/react": "^19.2.14",
+		"@types/react": "^19.2.15",
 		"@types/react-dom": "^19.2.3"
 	}
 }


### PR DESCRIPTION
## Summary

When the backend returns a collection (via sync or a `dataChanged` notification envelope), the response now includes `metadata.order` — an array of IDs in display order. This change ensures iOS preserves the backend's search result ordering across sync operations.

## Major changes

- **`ios/evy/Data/EVYDataStore.swift`** — Added `nextSortIndex(namespace:resource:)` to compute the next sort index (`maxExisting + 1`) for locally created or single-item synced values. Modified `applySyncedValue` to preserve the existing `sortIndex` on updates and assign `nextSortIndex` for new items outside an envelope.

- **`ios/evy/Core/EVY+Mutations.swift`** — `create` now passes a computed `sortIndex` (via `nextSortIndex`) so newly created items are appended to the end of the collection.

- **`ios/README.md`** — Documented the search result ordering strategy.

- **`ios/evyTests/EVYDataStoreSortIndexTests.swift`** (new) — Tests for `applySyncedValue` sort index behavior: preserving existing index on update, appending after existing items, and assigning 0 when the collection is empty.

- **`ios/evyTests/EVYDraftMergesTests.swift`** — Added `testCreateAppendsNewItemWithHighestSortIndex` to verify that calling `EVY.create` assigns the correct sort index.

## Tests

- `EVYDataStoreSortIndexTests` — 3 unit tests covering sort index preservation, appending, and empty-collection edge case.
- `EVYDraftMergesTests.testCreateAppendsNewItemWithHighestSortIndex` — Verifies end-to-end create path produces the expected sort index.
- iOS build passes with Xcode targeting iPhone 17 iOS 26.5.

## Risks

None — the change is purely additive in terms of behavior (items previously without explicit sort order now get one) and covered by new unit tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782384128&installation_id=127792561&pr_number=195&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F195&signature=d48ef118850a22515011f8db1ed6ba91a91ce40d393389f76dc05a3c015185d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->