### PR TITLE
[FEAT] SelectSegmentContainer row shows selected child on main page and segment-bar clicks change visible child

### DIFF
--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -1,10 +1,11 @@
-import { useState, type CSSProperties } from "react";
+import { useState, type CSSProperties, type MouseEvent } from "react";
 
 import type { Row, RowConfig } from "../../types/row";
 import { ContainerChildren } from "../../components/ContainerChildren";
 import { defineRow } from "../defineRow";
 import EVYText from "../design-system/EVYText";
 import { useRowById } from "../../hooks/useRowById";
+import { useFlowsContext } from "../../state";
 
 const typeName = "SelectSegmentContainerRow";
 
@@ -43,6 +44,7 @@ export default defineRow(typeName, {
 		rowId: string;
 	}) {
 		const row = useRowById(rowId);
+		const { activeRowId, configStack, dispatchRow } = useFlowsContext();
 		const [selectedTab, setSelectedTab] = useState(0);
 
 		if (!row) {
@@ -57,9 +59,34 @@ export default defineRow(typeName, {
 				: [];
 		const rawChildren = row.config.view.content.children;
 		const children: Row[] = Array.isArray(rawChildren) ? rawChildren : [];
-		const selectedChild = children[selectedTab];
-		const rowsToShow =
-			selectedChild !== undefined ? [selectedChild] : undefined;
+
+		// Segment button handler: stop propagation so the click doesn't bubble to
+		// RowPrimitive and trigger the generic row-toggle, then ensure the container
+		// row stays active.
+		const selectSegment = (
+			event: MouseEvent<HTMLButtonElement>,
+			index: number,
+		) => {
+			event.stopPropagation();
+			setSelectedTab(index);
+			const isContainerAlreadyActiveWithNoChildSelected =
+				activeRowId === rowId && configStack.length === 0;
+			if (!isContainerAlreadyActiveWithNoChildSelected) {
+				dispatchRow({ type: "SET_ACTIVE_ROW", rowId });
+			}
+		};
+
+		const activeRowPath = activeRowId ? [activeRowId, ...configStack] : [];
+		const rowPathIndex = activeRowPath.indexOf(rowId);
+		const activeDirectChildId =
+			rowPathIndex >= 0 ? activeRowPath[rowPathIndex + 1] : undefined;
+		const activeDirectChildIndex = children.findIndex(
+			(child) => child.id === activeDirectChildId,
+		);
+		const visibleChildIndex =
+			activeDirectChildIndex >= 0 ? activeDirectChildIndex : selectedTab;
+
+		const selectedChild = children[visibleChildIndex];
 
 		const title = row.config.view.content.title;
 
@@ -78,8 +105,8 @@ export default defineRow(typeName, {
 							<button
 								key={segment}
 								type="button"
-								onClick={() => setSelectedTab(index)}
-								className={`evy-flex-1 evy-border ${selectedTab === index ? "evy-bg-gray-light" : "evy-bg-white"}`}
+								onClick={(e) => selectSegment(e, index)}
+								className={`evy-flex-1 evy-border ${visibleChildIndex === index ? "evy-bg-gray-light" : "evy-bg-white"}`}
 								style={{
 									...(isFirst && firstSegmentStyle),
 									...(isLast && lastSegmentStyle),
@@ -91,7 +118,7 @@ export default defineRow(typeName, {
 					})}
 				</div>
 				<ContainerChildren
-					rows={rowsToShow}
+					rows={selectedChild !== undefined ? [selectedChild] : undefined}
 					containerRowId={rowId}
 					containerType="children"
 				/>

--- a/web/integration/childPage.pw.ts
+++ b/web/integration/childPage.pw.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { openAppWithTestFlows } from "./flowFixtures";
 import {
 	SELECTORS,
@@ -7,6 +7,49 @@ import {
 	getPageRow,
 	getSidebarRow,
 } from "./utils";
+
+async function openTwoSegmentTabContainer(page: Page) {
+	await openAppWithTestFlows(page, [
+		{
+			id: "step_1",
+			title: "Page 1",
+			rows: [
+				{
+					type: "SelectSegmentContainer" as const,
+					view: {
+						content: {
+							title: "Tab Container",
+							segments: ["Segment A", "Segment B"],
+							children: [
+								{
+									type: "Info" as const,
+									view: {
+										content: {
+											title: "First Segment Child",
+											subtitle: "First content",
+										},
+									},
+									actions: [],
+								},
+								{
+									type: "Text" as const,
+									view: {
+										content: {
+											title: "Second Segment Child",
+											text: "Second content",
+										},
+									},
+									actions: [],
+								},
+							],
+						},
+					},
+					actions: [],
+				},
+			],
+		},
+	]);
+}
 
 test.describe("Child Page Rendering", () => {
 	test("should show blank child page when selecting a row without a child", async ({
@@ -544,5 +587,77 @@ test.describe("Child Page Rendering", () => {
 		await expect(
 			activePage.getByText("Example tag", { exact: true }),
 		).not.toBeVisible();
+	});
+
+	test("clicking a SelectSegmentContainer child from the config panel shows that child on the main page", async ({
+		page,
+	}) => {
+		await openTwoSegmentTabContainer(page);
+
+		// Select the SelectSegmentContainer row on the page
+		await getPageRow(page, "Tab Container").click();
+
+		// Initially, the first segment child should be visible on the main page
+		const activePage = getFirstPage(page);
+		await expect(
+			activePage.getByText("First Segment Child", { exact: true }),
+		).toBeVisible();
+
+		// Click the second child row in the configuration panel
+		const configPanel = getConfigPanel(page);
+		await configPanel
+			.getByRole("button", { name: "Text", exact: true })
+			.click();
+
+		// Now the main phone page should show the second segment child
+		await expect(
+			activePage.getByText("Second Segment Child", { exact: true }),
+		).toBeVisible();
+
+		// The first segment child should no longer be visible on the main page
+		await expect(
+			activePage.getByText("First Segment Child", { exact: true }),
+		).not.toBeVisible();
+	});
+
+	test("clicking segment buttons in the bar switches the visible child without toggling the container row inactive", async ({
+		page,
+	}) => {
+		await openTwoSegmentTabContainer(page);
+
+		// Select the container row first
+		const activePage = getFirstPage(page);
+		await getPageRow(page, "Tab Container").click();
+		await expect(
+			activePage.getByText("First Segment Child", { exact: true }),
+		).toBeVisible();
+		await expect(
+			getConfigPanel(page).getByText("SelectSegmentContainer Row"),
+		).toBeVisible();
+
+		// Click the second segment in the bar — child should switch, row should stay active
+		await activePage
+			.getByRole("button", { name: "Segment B", exact: true })
+			.click();
+		await expect(
+			activePage.getByText("Second Segment Child", { exact: true }),
+		).toBeVisible();
+		await expect(
+			activePage.getByText("First Segment Child", { exact: true }),
+		).not.toBeVisible();
+		await expect(
+			getConfigPanel(page).getByText("SelectSegmentContainer Row"),
+		).toBeVisible();
+
+		// Click back to the first segment — should switch back without deactivating
+		await activePage
+			.getByRole("button", { name: "Segment A", exact: true })
+			.click();
+		await expect(
+			activePage.getByText("First Segment Child", { exact: true }),
+		).toBeVisible();
+		await expect(
+			getConfigPanel(page).getByText("SelectSegmentContainer Row"),
+		).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

When editing a `SelectSegmentContainer` row in the web app builder, clicking into a child row from the configuration panel previously had no effect on the main phone preview — the first segment child was always shown. Additionally, clicking the segment buttons in the bar could accidentally toggle the container row inactive instead of switching children.

## Major changes

- **`web/app/rows/container/SelectSegmentContainerRow.tsx`**
  - Derive the visible child from the active selection path (`activeRowId` + `configStack`) so the main page shows whichever child is selected via the configuration panel.
  - Added `selectSegment` handler with `event.stopPropagation()` so segment button clicks don't bubble to `RowPrimitive`'s row toggle.
  - Segments dispatch `SET_ACTIVE_ROW` for the container row only when it won't toggle it inactive, keeping the container active across tab switches.
  - Import cleanup: `MouseEvent` directly instead of the full `React` namespace.

- **`web/integration/childPage.pw.ts`**
  - Extracted `openTwoSegmentTabContainer` helper to eliminate duplicated fixture data.
  - Added regression test: clicking a child from the config panel shows that child on the main page.
  - Added regression test: clicking segment buttons switches children without deactivating the container row.

## Tests ran

- `bun run build` ✅
- `bun run lint` ✅
- `bun run test:unit` — 82 passed ✅
- `bun run test:integration` — 80 passed ✅
- `./run-e2e.sh --skip-ios` — API ✅ Marketplace ✅ Web ✅

## Risks / suggestions for later

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782394189&installation_id=127792561&pr_number=196&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F196&signature=278c7fbf877a2cd5832ec19523c3bc572a74e8135f7593eda720d440b261ed59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->