### PR TITLE
[REFACTOR] Remove unused JsonRPC and Serializable Swift packages

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -73,7 +73,7 @@ sequenceDiagram
 
 ### Real-time notifications
 
-`ws.ts` registers the `dataChanged` server event and ships a custom `emitJsonRpc` helper because `rpc-websockets` emits a non-standard wire shape that `JsonRPC.swift` on iOS cannot parse. All pushed frames therefore use standard JSON-RPC 2.0:
+`ws.ts` registers the `dataChanged` server event and ships a custom `emitJsonRpc` helper because `rpc-websockets` emits a non-standard wire shape. All pushed frames therefore use standard JSON-RPC 2.0:
 
 ```json
 { "jsonrpc": "2.0", "method": "dataChanged", "params": { "service": "evy", "resource": "sdui", "operation": "create", "value": { /* row */ } } }

--- a/api/src/ws.ts
+++ b/api/src/ws.ts
@@ -15,9 +15,8 @@ function getListenPort(): number {
 	return parseInt(apiPort, 10);
 }
 
-// Custom emit function that sends proper JSON-RPC 2.0 notifications
-// rpc-websockets uses non-standard format: { notification: name, params }
-// JsonRPC.swift expects standard format: { jsonrpc: "2.0", method: name, params }
+// rpc-websockets emits non-standard notifications: { notification: name, params }
+// EVY clients expect standard JSON-RPC 2.0: { jsonrpc: "2.0", method: name, params }
 function emitJsonRpc(server: WSServer, eventName: string, params: unknown) {
 	const namespace = server.namespaces["/"];
 	const nsEvent = namespace?.events?.[eventName];

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -20,8 +20,6 @@
 		730187D62F20E232002EF894 /* user_data.json in Resources */ = {isa = PBXBuildFile; fileRef = 730187D52F20E232002EF894 /* user_data.json */; };
 		7303B31A2C3EB8A000796123 /* EVYCalendarSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7303B3192C3EB8A000796123 /* EVYCalendarSlot.swift */; };
 
-		731988822C271BBD0035E094 /* JsonRPC in Frameworks */ = {isa = PBXBuildFile; productRef = 731988812C271BBD0035E094 /* JsonRPC */; };
-		731988852C271BC40035E094 /* Serializable in Frameworks */ = {isa = PBXBuildFile; productRef = 731988842C271BC40035E094 /* Serializable */; };
 		7320F5902C2FF8F000297C48 /* EVYInfoRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7320F58F2C2FF8F000297C48 /* EVYInfoRow.swift */; };
 		732A50822C1D6AE80036B98B /* EVY.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A50812C1D6AE80036B98B /* EVY.swift */; };
 		7330E4392C9BFABB00FE8F31 /* EVYSelectItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7330E4382C9BFABB00FE8F31 /* EVYSelectItem.swift */; };
@@ -221,8 +219,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				731988822C271BBD0035E094 /* JsonRPC in Frameworks */,
-				731988852C271BC40035E094 /* Serializable in Frameworks */,
 				73F4B0032F40B00100000001 /* LucideIcons in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -529,8 +525,6 @@
 			);
 			name = evy;
 			packageProductDependencies = (
-				731988812C271BBD0035E094 /* JsonRPC */,
-				731988842C271BC40035E094 /* Serializable */,
 				73F4B0022F40B00100000001 /* LucideIcons */,
 			);
 			productName = evy;
@@ -606,8 +600,6 @@
 			);
 			mainGroup = 737C6A992B2706890093D00C;
 			packageReferences = (
-				731988802C271BBD0035E094 /* XCRemoteSwiftPackageReference "JsonRPC.swift" */,
-				731988832C271BC40035E094 /* XCRemoteSwiftPackageReference "Serializable.swift" */,
 				73F4B0012F40B00100000001 /* XCRemoteSwiftPackageReference "lucide-icons-swift" */,
 			);
 			productRefGroup = 737C6AA32B2706890093D00C /* Products */;
@@ -1084,22 +1076,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		731988802C271BBD0035E094 /* XCRemoteSwiftPackageReference "JsonRPC.swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/tesseract-one/JsonRPC.swift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.3;
-			};
-		};
-		731988832C271BC40035E094 /* XCRemoteSwiftPackageReference "Serializable.swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/tesseract-one/Serializable.swift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.1;
-			};
-		};
 		73F4B0012F40B00100000001 /* XCRemoteSwiftPackageReference "lucide-icons-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/JakubMazur/lucide-icons-swift.git";
@@ -1111,16 +1087,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		731988812C271BBD0035E094 /* JsonRPC */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 731988802C271BBD0035E094 /* XCRemoteSwiftPackageReference "JsonRPC.swift" */;
-			productName = JsonRPC;
-		};
-		731988842C271BC40035E094 /* Serializable */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 731988832C271BC40035E094 /* XCRemoteSwiftPackageReference "Serializable.swift" */;
-			productName = Serializable;
-		};
 		73F4B0022F40B00100000001 /* LucideIcons */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 73F4B0012F40B00100000001 /* XCRemoteSwiftPackageReference "lucide-icons-swift" */;

--- a/ios/evy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/evy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,48 +2,12 @@
   "originHash" : "6534efd8ea993963bce057b973314ead51afeb2f711ce47d1af156f707db472c",
   "pins" : [
     {
-      "identity" : "contextcodable.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tesseract-one/ContextCodable.swift.git",
-      "state" : {
-        "revision" : "c80b0f83752590ea88f5b4e2946da04c3acb12de",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "jsonrpc.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tesseract-one/JsonRPC.swift.git",
-      "state" : {
-        "revision" : "d9df3ff3afaefa82cc7d8ca813a1795755197079",
-        "version" : "0.2.3"
-      }
-    },
-    {
       "identity" : "lucide-icons-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/JakubMazur/lucide-icons-swift.git",
       "state" : {
         "revision" : "498792127b18c539259cef2ce27a5db22de8abab",
         "version" : "0.577.0"
-      }
-    },
-    {
-      "identity" : "serializable.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tesseract-one/Serializable.swift.git",
-      "state" : {
-        "revision" : "55b6a16213627d20b2943f6969c2f61c8b1066ec",
-        "version" : "0.3.1"
-      }
-    },
-    {
-      "identity" : "tuples.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tesseract-one/Tuples.swift.git",
-      "state" : {
-        "revision" : "4d2cf7c64443cdf4df833d0bedd767bf9dbc49d9",
-        "version" : "0.1.3"
       }
     }
   ],

--- a/ios/evy/Data/API/EVYWebsocket.swift
+++ b/ios/evy/Data/API/EVYWebsocket.swift
@@ -57,6 +57,7 @@ actor EVYWebsocket: EVYWebsocketProtocol {
   private var task: URLSessionWebSocketTask?
   private var pendingRequests: [Int: CheckedContinuation<String, Error>] = [:]
   private var nextId = 1
+  private var urlSession: URLSession?
   private let wsURL: URL
 
   init(host: String) {
@@ -123,9 +124,11 @@ actor EVYWebsocket: EVYWebsocketProtocol {
     let delegate = EVYWebSocketDelegate { [weak self] in
       Task { [weak self] in await self?.handleDisconnect() }
     }
-    let urlSession = URLSession(
+    let session = URLSession(
       configuration: .default, delegate: delegate, delegateQueue: nil)
-    let wsTask = urlSession.webSocketTask(with: wsURL)
+    urlSession = session
+    let wsTask = session.webSocketTask(with: wsURL)
+    wsTask.maximumMessageSize = 20 * 1024 * 1024
     task = wsTask
     wsTask.resume()
     startReceiveLoop(for: wsTask)

--- a/ios/evy/Data/EVYDataStore.swift
+++ b/ios/evy/Data/EVYDataStore.swift
@@ -14,6 +14,9 @@ final class EVYDataStore {
 
   convenience init(name: String, inMemoryOnly: Bool = false) {
     let config = ModelConfiguration(name, isStoredInMemoryOnly: inMemoryOnly)
+    if !inMemoryOnly {
+      Self.createStoreDirectory(for: config)
+    }
     do {
       let container = try ModelContainer(for: EVYData.self, configurations: config)
       self.init(container: container)
@@ -25,6 +28,11 @@ final class EVYDataStore {
       let container = try! ModelContainer(for: EVYData.self, configurations: config)
       self.init(container: container)
     }
+  }
+
+  private static func createStoreDirectory(for config: ModelConfiguration) {
+    try? FileManager.default.createDirectory(
+      at: config.url.deletingLastPathComponent(), withIntermediateDirectories: true)
   }
 
   private static func deleteStoreFiles(for config: ModelConfiguration) {


### PR DESCRIPTION
## Summary

Removes the  and  (tesseract-one) Swift packages from the iOS Xcode project. The iOS WebSocket layer now uses  directly, building and parsing JSON-RPC messages manually.

## Major changes

- **Xcode project** (): Removed  and  from the Frameworks build phase, target package product dependencies, Swift package references, and product declarations.
- **Package.resolved**: Stripped , , and their transitive dependencies (, ). Only  remains.
- **API docs** (): Removed stale reference to  in the real-time notifications section.
- **Code comment** (): Updated out-of-date comment referencing .
- **Unrelated fixes in same branch**: Added  to WebSocket task and added store directory creation in .

## Validation

- Xcode package resolution resolves only .
- iOS build succeeds on iPhone 17 / iOS 26.5 simulator.
- All iOS unit tests and UI tests pass (serial run).

## Risks

Low risk — the removed packages had zero Swift import/usage in the app codebase. The JSON-RPC message construction is fully handled inline in `EVYWebsocket.swift`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782603384&installation_id=127792561&pr_number=200&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F200&signature=90218c85df856c0466780b6337688dfb4cae7c070d746ce245f19e66e2951e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->