### PR TITLE
[REFACTOR] Multi watch state system

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -134,8 +134,7 @@ flowchart LR
     WS -. post .-> Notif
     Views -. post errors .-> Notif
     Notif -. observe .-> Content
-    Notif -. observe .-> EVYState["EVYState T"]
-    Notif -. observe .-> Views
+    Notif -. observe .-> EVYState["EVYState T (single or multi-watch)"]
     EVYState -. drives .-> Views
     EVYState -. drives .-> Atoms
 ```

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		E00100112F73010100000001 /* EVYDataStoreSortIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E00100122F73010100000001 /* EVYDataStoreSortIndexTests.swift */; };
 		FA001001PG00000100000001 /* EVYPhotoGalleryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA001002PG00000100000001 /* EVYPhotoGalleryTests.swift */; };
 		FA001003TP00000100000001 /* EVYTimeslotPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA001004TP00000100000001 /* EVYTimeslotPickerTests.swift */; };
+		FA001005ST00000100000001 /* EVYStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA001006ST00000100000001 /* EVYStateTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -220,6 +221,7 @@
 		E00100122F73010100000001 /* EVYDataStoreSortIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYDataStoreSortIndexTests.swift; sourceTree = "<group>"; };
 		FA001002PG00000100000001 /* EVYPhotoGalleryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYPhotoGalleryTests.swift; sourceTree = "<group>"; };
 		FA001004TP00000100000001 /* EVYTimeslotPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYTimeslotPickerTests.swift; sourceTree = "<group>"; };
+		FA001006ST00000100000001 /* EVYStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYStateTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -513,6 +515,7 @@
 				E00100122F73010100000001 /* EVYDataStoreSortIndexTests.swift */,
 				FA001002PG00000100000001 /* EVYPhotoGalleryTests.swift */,
 				FA001004TP00000100000001 /* EVYTimeslotPickerTests.swift */,
+				FA001006ST00000100000001 /* EVYStateTests.swift */,
 				74A100262F32000100000001 /* EVYCalendarTests.swift */,
 				74A100042F32000100000001 /* interpreterTests.swift */,
 			);
@@ -758,6 +761,7 @@
 				E00100112F73010100000001 /* EVYDataStoreSortIndexTests.swift in Sources */,
 				FA001001PG00000100000001 /* EVYPhotoGalleryTests.swift in Sources */,
 				FA001003TP00000100000001 /* EVYTimeslotPickerTests.swift in Sources */,
+				FA001005ST00000100000001 /* EVYStateTests.swift in Sources */,
 				74A100252F32000100000001 /* EVYCalendarTests.swift in Sources */,
 				74A100012F32000100000001 /* interpreterTests.swift in Sources */,
 			);

--- a/ios/evy/Data/EVYStores.swift
+++ b/ios/evy/Data/EVYStores.swift
@@ -24,44 +24,29 @@ extension Notification.Name {
   static let evyUserAlertRequested = Notification.Name("EVYUserAlertRequested")
 }
 
-// Parses a watch string (e.g. "{item.pickup_selection}") once at init and caches its
-// dot-separated segments so that incoming `.evyDataChanged` notification keys can be
-// efficiently prefix-matched without re-parsing on every notification.
-@MainActor
-struct EVYDataChangeWatch: Equatable {
-  let rawTarget: String
-  let segments: [String]
-
-  init(_ watch: String) {
-    rawTarget = watch
-    guard !watch.isEmpty else {
-      segments = []
-      return
-    }
-    let parsedWatch = EVY.parsePropsFromText(watch)
-    segments = parsedWatch.components(separatedBy: PROP_SEPARATOR)
-  }
-
-  var isEmpty: Bool {
-    segments.isEmpty
-  }
-
-  func isAffected(by notificationKey: String) -> Bool {
-    guard !segments.isEmpty else { return false }
-    let notificationSegments = notificationKey.components(separatedBy: PROP_SEPARATOR)
-    let comparedSegmentCount = min(segments.count, notificationSegments.count)
-    return segments.prefix(comparedSegmentCount)
-      == notificationSegments.prefix(comparedSegmentCount)
-  }
-}
-
-@MainActor
-func dataChangeKey(_ notificationKey: String, affects watch: EVYDataChangeWatch) -> Bool {
-  watch.isAffected(by: notificationKey)
-}
-
 @MainActor
 @Observable class EVYState<T: Equatable> {
+  @MainActor
+  private struct Watch: Equatable {
+    let segments: [String]
+
+    init(_ watch: String) {
+      guard !watch.isEmpty else {
+        segments = []
+        return
+      }
+      segments = EVY.parsePropsFromText(watch).components(separatedBy: PROP_SEPARATOR)
+    }
+
+    func isAffected(by notificationKey: String) -> Bool {
+      guard !segments.isEmpty else { return false }
+      let notificationSegments = notificationKey.components(separatedBy: PROP_SEPARATOR)
+      let comparedSegmentCount = min(segments.count, notificationSegments.count)
+      return segments.prefix(comparedSegmentCount)
+        == notificationSegments.prefix(comparedSegmentCount)
+    }
+  }
+
   private var _value: T
   @ObservationIgnored private var observerTokens: [NSObjectProtocol] = []
   var value: T {
@@ -71,26 +56,44 @@ func dataChangeKey(_ notificationKey: String, affects watch: EVYDataChangeWatch)
     }
   }
 
-  init(watch: String, setter: @escaping (_ input: String) -> T) {
-    _value = setter(watch)
-    let dataChangeWatch = EVYDataChangeWatch(watch)
-
+  private func registerObserver(
+    watchTargets: [String],
+    recompute: @escaping () -> T
+  ) {
+    let watches = watchTargets.map(Watch.init)
+    // Observer runs synchronously on the posting thread (no queue specified).
+    // All posters of `.evyDataChanged` are `@MainActor`-isolated, so the block runs on
+    // the main thread; `MainActor.assumeIsolated` bridges to MainActor without an async hop.
+    // Synchronous semantics matter: it lets `withAnimation { writeData(...) }` capture the
+    // notification-driven `EVYState.value` mutation inside the same animation transaction.
     observerTokens.append(
       NotificationCenter.default.addObserver(
         forName: .evyDataChanged,
         object: nil,
-        queue: .main
+        queue: nil
       ) { [weak self] notif in
-        Task { @MainActor in
+        MainActor.assumeIsolated {
+          guard let self else { return }
           guard let notifProp = notif.object as? String else {
-            self?.value = setter(watch)
+            self.value = recompute()
             return
           }
-
-          if dataChangeKey(notifProp, affects: dataChangeWatch) { self?.value = setter(watch) }
+          if watches.contains(where: { $0.isAffected(by: notifProp) }) {
+            self.value = recompute()
+          }
         }
       }
     )
+  }
+
+  init(watch: String, setter: @escaping (_ input: String) -> T) {
+    _value = setter(watch)
+    registerObserver(watchTargets: [watch]) { setter(watch) }
+  }
+
+  init(watches: [String], setter: @escaping () -> T) {
+    _value = setter()
+    registerObserver(watchTargets: watches, recompute: setter)
   }
 
   init(staticString: T) {

--- a/ios/evy/Data/Models/EVYCalendarSlot.swift
+++ b/ios/evy/Data/Models/EVYCalendarSlot.swift
@@ -3,7 +3,7 @@
 //  evy
 //
 
-struct EVYCalendarSlot {
+struct EVYCalendarSlot: Equatable {
   let dateTimeISO: String
   let x: Int
   let y: Int

--- a/ios/evy/UI/Views/EVYCalendar.swift
+++ b/ios/evy/UI/Views/EVYCalendar.swift
@@ -79,7 +79,7 @@ struct ViewOffsetKey: PreferenceKey {
   }
 }
 
-struct EVYCalendarViewState {
+struct EVYCalendarViewState: Equatable {
   let xLabels: [EVYCalendarLabel]
   let yLabels: [EVYCalendarLabel]
   let rows: Int
@@ -89,17 +89,16 @@ struct EVYCalendarViewState {
 
 struct EVYCalendar: View {
   private let content: CalendarRowContent
-  private let primaryDataChangeWatch: EVYDataChangeWatch
-  private let secondaryDataChangeWatch: EVYDataChangeWatch
+  private let calendarState: EVYState<EVYCalendarViewState>
 
-  @State private var state: EVYCalendarViewState
   @State private var scrollOffset = CGPoint.zero
 
   init(content: CalendarRowContent) {
     self.content = content
-    primaryDataChangeWatch = EVYDataChangeWatch(content.primary)
-    secondaryDataChangeWatch = EVYDataChangeWatch(content.secondary)
-    _state = State(initialValue: Self.buildCalendarData(content: content))
+    calendarState = EVYState(
+      watches: [content.primary, content.secondary],
+      setter: { Self.buildCalendarData(content: content) }
+    )
   }
 
   private static func buildCalendarData(content: CalendarRowContent) -> EVYCalendarViewState {
@@ -176,17 +175,6 @@ struct EVYCalendar: View {
     )
   }
 
-  private func reloadData(animated: Bool = false) {
-    let newState = Self.buildCalendarData(content: content)
-    if animated {
-      withAnimation(.linear(duration: animationDuration)) {
-        state = newState
-      }
-    } else {
-      state = newState
-    }
-  }
-
   private func handleOperation(_ operation: EVYCalendarOperation) {
     var selections = readPrimarySelections()
 
@@ -205,16 +193,19 @@ struct EVYCalendar: View {
       selections = removing(dateTimes(forColumn: x), from: selections)
     }
 
-    writePrimarySelections(selections)
-    reloadData(animated: true)
+    // Wrap the write in `withAnimation` so the synchronous notification-driven
+    // `EVYState.value` mutation falls inside the animation transaction.
+    withAnimation(.linear(duration: animationDuration)) {
+      writePrimarySelections(selections)
+    }
   }
 
   private func dateTimes(forRow y: Int) -> [String] {
-    state.slots.filter { $0.y == y }.map { $0.dateTimeISO }
+    calendarState.value.slots.filter { $0.y == y }.map { $0.dateTimeISO }
   }
 
   private func dateTimes(forColumn x: Int) -> [String] {
-    state.slots.filter { $0.x == x }.map { $0.dateTimeISO }
+    calendarState.value.slots.filter { $0.x == x }.map { $0.dateTimeISO }
   }
 
   private func adding(_ values: [String], to selections: [String]) -> [String] {
@@ -240,15 +231,15 @@ struct EVYCalendar: View {
 
   var body: some View {
     HStack(spacing: .zero) {
-      EVYCalendarAxisView(type: .y, labels: state.yLabels, offset: $scrollOffset)
+      EVYCalendarAxisView(type: .y, labels: calendarState.value.yLabels, offset: $scrollOffset)
       VStack(spacing: .zero) {
-        EVYCalendarAxisView(type: .x, labels: state.xLabels, offset: $scrollOffset)
+        EVYCalendarAxisView(type: .x, labels: calendarState.value.xLabels, offset: $scrollOffset)
         ScrollViewReader { _ in
           ScrollView([.vertical, .horizontal]) {
             EVYCalendarTimeslots(
-              rows: state.rows,
-              columns: state.columns,
-              slots: state.slots
+              rows: calendarState.value.rows,
+              columns: calendarState.value.columns,
+              slots: calendarState.value.slots
             )
             .background(
               GeometryReader { geo in
@@ -267,14 +258,6 @@ struct EVYCalendar: View {
     }
     .environment(\.operate) { calendarOperation in
       handleOperation(calendarOperation)
-    }
-    .onReceive(NotificationCenter.default.publisher(for: .evyDataChanged)) { notification in
-      guard let notificationKey = notification.object as? String else { return }
-      if dataChangeKey(notificationKey, affects: primaryDataChangeWatch)
-        || dataChangeKey(notificationKey, affects: secondaryDataChangeWatch)
-      {
-        reloadData()
-      }
     }
   }
 }

--- a/ios/evy/UI/Views/EVYCalendarAxisView.swift
+++ b/ios/evy/UI/Views/EVYCalendarAxisView.swift
@@ -9,7 +9,7 @@ let spaceForFirstLabel: CGFloat = 6
 let columnWidth: CGFloat = 80
 let rowHeight: CGFloat = 30
 
-struct EVYCalendarLabel {
+struct EVYCalendarLabel: Equatable {
   let value: String
   var full: Bool
 }

--- a/ios/evy/UI/Views/EVYTimeslotPicker.swift
+++ b/ios/evy/UI/Views/EVYTimeslotPicker.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 let timeslotWidth: CGFloat = Constants.base * 18
 
-struct EVYTimeslot {
+struct EVYTimeslot: Equatable {
   let timeslot: String
   let available: Bool
 }
 
-struct EVYTimeslotDate {
+struct EVYTimeslotDate: Equatable {
   let header: String
   let subtitle: String
   let timeslots: [EVYTimeslot]
@@ -54,19 +54,16 @@ struct EVYTimeslotPicker: View {
     }
   }
 
-  private let content: TimeslotPickerRowContent
-  private let source: String
-  private let sourceDataChangeWatch: EVYDataChangeWatch
+  private let timeslotDates: EVYState<[EVYTimeslotDate]>
 
-  @State private var timeslotDates: [EVYTimeslotDate]
   @State private var selectedGroupIndex: Int = 0
   @State private var tabViewHeight: CGFloat = 0
 
   init(content: TimeslotPickerRowContent, source: String) {
-    self.content = content
-    self.source = source
-    sourceDataChangeWatch = EVYDataChangeWatch(source)
-    _timeslotDates = State(initialValue: Self.buildDates(content: content, source: source))
+    timeslotDates = EVYState(
+      watches: [source],
+      setter: { Self.buildDates(content: content, source: source) }
+    )
   }
 
   @MainActor
@@ -82,7 +79,7 @@ struct EVYTimeslotPicker: View {
   }
 
   private var numberOfTimeslotsPerDay: Int {
-    timeslotDates.map { $0.timeslots.count }.max() ?? 0
+    timeslotDates.value.map { $0.timeslots.count }.max() ?? 0
   }
 
   private func timeslotGroupView(groupedDays: [[EVYTimeslotDate]], index: Int) -> some View {
@@ -117,10 +114,10 @@ struct EVYTimeslotPicker: View {
   }
 
   var body: some View {
-    if timeslotDates.isEmpty || numberOfTimeslotsPerDay <= 0 {
+    if timeslotDates.value.isEmpty || numberOfTimeslotsPerDay <= 0 {
       EmptyView()
     } else {
-      let groupedDays = timeslotDates.chunked(with: 4)
+      let groupedDays = timeslotDates.value.chunked(with: 4)
 
       VStack {
         timeslotHeightMeasurement(groupedDays: groupedDays)
@@ -142,12 +139,6 @@ struct EVYTimeslotPicker: View {
         let roundedHeight = ceil(height)
         if roundedHeight > 0, tabViewHeight != roundedHeight {
           tabViewHeight = roundedHeight
-        }
-      }
-      .onReceive(NotificationCenter.default.publisher(for: .evyDataChanged)) { notification in
-        guard let notificationKey = notification.object as? String else { return }
-        if dataChangeKey(notificationKey, affects: sourceDataChangeWatch) {
-          timeslotDates = Self.buildDates(content: content, source: source)
         }
       }
     }

--- a/ios/evyTests/EVYCalendarTests.swift
+++ b/ios/evyTests/EVYCalendarTests.swift
@@ -199,40 +199,4 @@ final class EVYCalendarTests: XCTestCase {
     XCTAssertEqual(columns, 7)
   }
 
-  func testPrimarySourceExactMatchReturnsTrue() {
-    XCTAssertTrue(
-      dataChangeKey("pickup_selection", affects: EVYDataChangeWatch("{pickup_selection}")))
-  }
-
-  func testSecondarySourceExactMatchReturnsTrue() {
-    XCTAssertTrue(
-      dataChangeKey("delivery_selection", affects: EVYDataChangeWatch("{delivery_selection}")))
-  }
-
-  func testUnrelatedNotificationDoesNotMatch() {
-    XCTAssertFalse(dataChangeKey("conditions", affects: EVYDataChangeWatch("{pickup_selection}")))
-  }
-
-  func testEntityQualifiedNotificationMatchesSource() {
-    XCTAssertTrue(
-      dataChangeKey("item.pickup_selection", affects: EVYDataChangeWatch("{item.pickup_selection}"))
-    )
-  }
-
-  func testNestedKeyChangeMatchesParentSource() {
-    XCTAssertTrue(
-      dataChangeKey(
-        "item.pickup_selection.start", affects: EVYDataChangeWatch("{item.pickup_selection}")))
-  }
-
-  func testEmptySourceDoesNotMatchBroadNotification() {
-    XCTAssertFalse(dataChangeKey("conditions", affects: EVYDataChangeWatch("")))
-  }
-
-  func testWatchReusedAcrossMultipleNotificationKeys() {
-    let watch = EVYDataChangeWatch("{item.pickup_selection}")
-    XCTAssertTrue(dataChangeKey("item.pickup_selection.start", affects: watch))
-    XCTAssertTrue(dataChangeKey("item.pickup_selection.end", affects: watch))
-    XCTAssertFalse(dataChangeKey("conditions", affects: watch))
-  }
 }

--- a/ios/evyTests/EVYStateTests.swift
+++ b/ios/evyTests/EVYStateTests.swift
@@ -1,0 +1,165 @@
+//
+//  EVYStateTests.swift
+//  evyTests
+//
+
+import XCTest
+
+@testable import evy
+
+@MainActor
+final class EVYStateTests: XCTestCase {
+
+  private func makeCountingState(
+    watches: [String]
+  ) -> (state: EVYState<Int>, getCallCount: () -> Int) {
+    var callCount = 0
+    let state = EVYState<Int>(
+      watches: watches,
+      setter: {
+        callCount += 1
+        return callCount
+      })
+    return (state, { callCount })
+  }
+
+  private func postDataChange(_ key: String?) {
+    NotificationCenter.default.post(name: .evyDataChanged, object: key)
+  }
+
+  func testInitialValueComputedAtInit() {
+    let state = EVYState<Int>(watches: ["{counter}"], setter: { 42 })
+    XCTAssertEqual(state.value, 42)
+  }
+
+  func testFirstWatchMatchTriggersRecompute() {
+    var callCount = 0
+    let state = EVYState<Int>(
+      watches: ["{watch1}", "{watch2}"],
+      setter: {
+        callCount += 1
+        return callCount
+      })
+    XCTAssertEqual(callCount, 1)
+
+    postDataChange("watch1")
+
+    XCTAssertEqual(callCount, 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testSecondWatchMatchTriggersRecompute() {
+    var callCount = 0
+    let state = EVYState<Int>(
+      watches: ["{watch1}", "{watch2}"],
+      setter: {
+        callCount += 1
+        return callCount
+      })
+    XCTAssertEqual(callCount, 1)
+
+    postDataChange("watch2")
+
+    XCTAssertEqual(callCount, 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testUnrelatedNotificationDoesNotTriggerRecompute() {
+    var callCount = 0
+    let state = EVYState<Int>(
+      watches: ["{watch1}", "{watch2}"],
+      setter: {
+        callCount += 1
+        return callCount
+      })
+    XCTAssertEqual(callCount, 1)
+
+    postDataChange("unrelated")
+
+    XCTAssertEqual(callCount, 1)
+    XCTAssertEqual(state.value, 1)
+  }
+
+  func testBroadcastNotificationWithNoKeyTriggersRecompute() {
+    let (state, getCallCount) = makeCountingState(watches: ["{watch1}"])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange(nil)
+
+    XCTAssertEqual(getCallCount(), 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testEmptyWatchesIgnoresKeyedNotifications() {
+    let (state, getCallCount) = makeCountingState(watches: [])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("anything")
+    XCTAssertEqual(getCallCount(), 1)
+    XCTAssertEqual(state.value, 1)
+
+    postDataChange(nil)
+    XCTAssertEqual(getCallCount(), 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testExactSourceNotificationTriggersRecompute() {
+    let (state, getCallCount) = makeCountingState(watches: ["{pickup_selection}"])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("pickup_selection")
+
+    XCTAssertEqual(getCallCount(), 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testUnrelatedSourceNotificationDoesNotTriggerRecompute() {
+    let (state, getCallCount) = makeCountingState(watches: ["{pickup_selection}"])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("conditions")
+
+    XCTAssertEqual(getCallCount(), 1)
+    XCTAssertEqual(state.value, 1)
+  }
+
+  func testEntityQualifiedNotificationTriggersRecompute() {
+    let (state, getCallCount) = makeCountingState(watches: ["{item.pickup_selection}"])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("item.pickup_selection")
+
+    XCTAssertEqual(getCallCount(), 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testNestedChildNotificationTriggersParentWatchRecompute() {
+    let (state, getCallCount) = makeCountingState(watches: ["{item.pickup_selection}"])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("item.pickup_selection.start")
+
+    XCTAssertEqual(getCallCount(), 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testParentNotificationTriggersNestedChildWatchRecompute() {
+    let (state, getCallCount) = makeCountingState(watches: ["{item.pickup_selection.start}"])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("item.pickup_selection")
+
+    XCTAssertEqual(getCallCount(), 2)
+    XCTAssertEqual(state.value, 2)
+  }
+
+  func testEmptyWatchIgnoresKeyedNotifications() {
+    let (state, getCallCount) = makeCountingState(watches: [""])
+    XCTAssertEqual(getCallCount(), 1)
+
+    postDataChange("conditions")
+
+    XCTAssertEqual(getCallCount(), 1)
+    XCTAssertEqual(state.value, 1)
+  }
+}


### PR DESCRIPTION
## Summary
Refactored the iOS EVYState system to support multiple data change watches and improve animation handling in calendar and timeslot picker components.

## Major Changes
- **EVYStores.swift**:
  - Added new EVYState initializer that accepts multiple watch targets as an array
  - Refactored EVYDataChangeWatch from a standalone struct to a private nested Watch struct
  - Removed standalone dataChangeKey function in favor of new multi-watch implementation
  - Registered observers now use nil queue for synchronous notification handling with MainActor.assumeIsolated

- **EVYCalendar.swift**:
  - Integrated new EVYState with dual watch capabilities for primary and secondary calendar data
  - Removed manual data change watching logic using .onReceive
  - Simplified data reload by wrapping write operations in withAnimation blocks

- **EVYTimeslotPicker.swift**:
  - Updated to use new EVYState with single watch target
  - Removed manual .onReceive notification handling
  - Simplified state management using reactive EVYState approach

- **Conformance additions**:
  - Made EVYCalendarSlot, EVYCalendarViewState, EVYCalendarLabel, EVYTimeslot, and EVYTimeslotDate conform to Equatable for proper state comparison

- **Tests**:
  - Removed watch-matching unit tests from EVYCalendarTests.swift as they tested the now-removed standalone dataChangeKey function
  - Added new EVYStateTests.swift file to Xcode project structure

## Tests Ran
- iOS tests updated to reflect new state management architecture
- Existing EVYCalendar test suite preserved and updated for new implementation
- Data model Equatable conformance changes validated

## Technical Details
The new synchronous notification handling ensures that state mutations driven by data change notifications fall within the same animation transaction, fixing issues with animated UI updates in calendar components. The multi-watch support allows components to efficiently track multiple data sources simultaneously.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783163448&installation_id=127792561&pr_number=204&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F204&signature=354a6a5ecc1992aa2130d9fee4b430021568cc26f60b6b28681a03454d379d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->