### PR TITLE
[FEAT] Update README to remove obsolete information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ If smartphones and the internet were built by the people for the people. Create 
 
 ## Architecture at a glance
 
-EVY is split into 2 thin clients (iOS, web builder), one public edge (`api`), and per-service backend workers that speak a shared gRPC contract (`evy.Service`). JSON-RPC requests are routed by `service + resource`, while authenticated binary WebSocket frames stage uploads before a normal JSON-RPC `create` finalises metadata:
-- `service: "evy"` is handled in-process in the API (SDUI flows, core resource tables, and binary files)
-- any other declared service (e.g. `marketplace`) is reached over gRPC from [`api/src/procedures/services.ts`](./api/src/procedures/services.ts).
+EVY is fully server-driven, meaning that the iOS app pulls in flows, page layout, data from the API to decide what to render. The API acts as gateway to other service backends, speaking a shared gRPC contract. Clients store the entire public database in local storage, and keep it in sync with a `sync` JSON-RPC method, taking a `lastSyncTime` to decide what data to return.
 
 ```mermaid
 flowchart LR
@@ -25,16 +23,6 @@ flowchart LR
     marketplace -- Drizzle --> mpDb
 ```
 
-Resource routing, unified `dataChanged` notifications, service data sync, and gRPC forwarding are covered in [`api/README.md`](./api/README.md).
-
-## Sync and local keying
-
-Clients refresh local cache state with the protected `sync` JSON-RPC method. The request includes an ISO `lastSyncTime`; the response returns changed rows across SDUI, evy core data, and backend service data shaped as `{ service, resource, value }`. When there are changes, the response also includes the current resource registry. For startup/cache refresh, the API fetches every syncable resource using `filter.updatedAfter = lastSyncTime`.
-
-Clients store synced backend resources with service-qualified keys such as `evy:sdui`, `marketplace:items`, and `marketplace:conditions`. For full details on SDUI data bindings, source/destination conventions, navigate query params, and client key resolution, see [SDUI Data](./docs/evy/sdui/readme.md#data).
-
-iOS draft scope IDs and cache keys are internal to the iOS draft store; see [iOS README § Draft scopes and draft cache keys](./ios/README.md#draft-scopes-and-draft-cache-keys).
-
 # Documentation
 
 - EVY Platform
@@ -50,10 +38,6 @@ iOS draft scope IDs and cache keys are internal to the iOS draft store; see [iOS
   - [Data models](./docs/services/marketplace/data.md)
   - [Example data](./docs/services/service_data.json)
   - [Example UI flow for view & create item pages](./docs/services/service_sdui.json)
-
-## Shared type system
-
-Schema layout, codegen steps, and outputs: [`docs/evy/types.md`](./docs/evy/types.md). In short: source JSON Schema lives under `types/schema/`; run `bun run types:generate` from the repo root after schema changes, or `bun run types:generate:exclude-ios` when only TypeScript output is needed (Docker images use this path). gRPC contract: [`types/schema/service.proto`](./types/schema/service.proto). The `evy` data path is implemented under [`api/src/data/`](./api/src/data/); [`api/src/procedures/services.ts`](./api/src/procedures/services.ts) holds gRPC clients and `SubscribeEvents` fan-out for non-`evy` services.
 
 ## Setup
 


### PR DESCRIPTION
Removed outdated sections on resource routing, sync, and shared type system from the README.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783599999&installation_id=127792561&pr_number=205&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F205&signature=36e4eb0176d7fa8b0f929b69512c720a87fd89ac866ee08a133b7f8b88069b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->