### PR TITLE
[REFACTOR] Order fields in configuration panel

### DIFF
--- a/web/app/components/ConfigurationPanel.tsx
+++ b/web/app/components/ConfigurationPanel.tsx
@@ -18,14 +18,24 @@ function isContainerKey(k: string): boolean {
 	return k === "child" || k === "children";
 }
 
+const panelFieldOrder = ["icon", "title", "subtitle", "text", "placeholder"];
+
+function getPanelFieldRank(key: string): number {
+	const index = panelFieldOrder.indexOf(key.toLowerCase());
+	return index === -1 ? panelFieldOrder.length : index;
+}
+
 function sortContentEntriesForPanel(
 	entries: [string, unknown][],
 ): [string, unknown][] {
-	const containers = entries.filter(([k]) => isContainerKey(k));
-	const rest = entries
-		.filter(([k]) => !isContainerKey(k))
-		.sort(([a], [b]) => a.localeCompare(b));
-	return [...rest, ...containers];
+	return entries.sort(([a], [b]) => {
+		const rankDifference = getPanelFieldRank(a) - getPanelFieldRank(b);
+		if (rankDifference !== 0) return rankDifference;
+		if (isContainerKey(a) && isContainerKey(b)) {
+			return a === "child" ? -1 : 1;
+		}
+		return a.localeCompare(b);
+	});
 }
 
 function isRow(value: unknown): value is Row {
@@ -203,46 +213,12 @@ export function ConfigurationPanel() {
 		(configRow: Row): React.ReactNode[] => {
 			const merged = mergeRowContentWithPaletteDefaults(configRow);
 			const entries = sortContentEntriesForPanel(Object.entries(merged));
+			const contentEntries = entries.filter(([key]) => !isContainerKey(key));
+			const containerEntries = entries.filter(([key]) => isContainerKey(key));
 
-			const contentElements = entries.map(([key, value]) => {
+			const contentElements = contentEntries.map(([key, value]) => {
 				const uniqueId = `${configRow.id}-${key}`;
 
-				if (key === "child" || key === "children") {
-					const items =
-						key === "child"
-							? isRow(value)
-								? [value]
-								: []
-							: isRowArray(value)
-								? value
-								: [];
-					if (items.length === 0) return null;
-					const label = key === "child" ? "Child" : "Children";
-					return (
-						<div key={uniqueId}>
-							<div className="evy-text-sm evy-font-medium evy-text-black evy-mb-2">
-								{label}
-							</div>
-							<div
-								className={
-									items.length > 1
-										? "evy-flex evy-flex-col evy-gap-4"
-										: undefined
-								}
-							>
-								{items.map((childRow) => (
-									<ChildRowButton
-										key={childRow.id}
-										child={childRow}
-										onClick={() =>
-											openChildConfiguration(childRow.id, configRow)
-										}
-									/>
-								))}
-							</div>
-						</div>
-					);
-				}
 				return (
 					<ConfigTextField
 						key={uniqueId}
@@ -252,6 +228,40 @@ export function ConfigurationPanel() {
 						onChange={(next) => updateRowContent(key, next, configRow.id)}
 						required
 					/>
+				);
+			});
+
+			const containerElements = containerEntries.map(([key, value]) => {
+				const uniqueId = `${configRow.id}-${key}`;
+				const items =
+					key === "child"
+						? isRow(value)
+							? [value]
+							: []
+						: isRowArray(value)
+							? value
+							: [];
+				if (items.length === 0) return null;
+				const label = key === "child" ? "Child" : "Children";
+				return (
+					<div key={uniqueId}>
+						<div className="evy-text-sm evy-font-medium evy-text-black evy-mb-2">
+							{label}
+						</div>
+						<div
+							className={
+								items.length > 1 ? "evy-flex evy-flex-col evy-gap-4" : undefined
+							}
+						>
+							{items.map((childRow) => (
+								<ChildRowButton
+									key={childRow.id}
+									child={childRow}
+									onClick={() => openChildConfiguration(childRow.id, configRow)}
+								/>
+							))}
+						</div>
+					</div>
 				);
 			});
 
@@ -286,6 +296,7 @@ export function ConfigurationPanel() {
 						fieldClassName=""
 					/>
 				</div>,
+				...containerElements,
 			];
 		},
 		[openChildConfiguration, updateRowContent, updateRowRoot],


### PR DESCRIPTION
## Summary

The ConfigurationPanel was sorting content fields alphabetically, with child/children sections before source/destination. This made frequently-used fields hard to find.

## Changes

- Added a priority sort order for content fields: Icon, Title, Subtitle, Text, Placeholder, then any other attributes alphabetically
- Moved Source and Destination fields to appear after content fields (as before)
- Moved Child/Children sections to the very end, after Source/Destination
- Extracted container rendering into a separate pass so child/children always appear after source/destination bindings

## Tests ran

- `bun run --cwd web lint` — no issues
- `bun run --cwd web test:unit` — 100/100 pass
- `bun run --cwd web build` — no errors
- Biome format applied

## Risks

None. This only changes the display order in the ConfigurationPanel UI; no data model or logic changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903178&installation_id=127792561&pr_number=211&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F211&signature=fa0d4a5569a49c07ea1b690469cc1d69573c9114f557019a7ce37bc1c6534f03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->