### PR TITLE
[FEAT] Add findFirst function to resolve ID-based data lookups

### DIFF
--- a/docs/evy/sddata/functions.md
+++ b/docs/evy/sddata/functions.md
@@ -28,6 +28,17 @@ Variable: "Hello"
 Output: 5
 ```
 
+#### findFirst
+
+Finds the first datum in a named collection whose `id` matches the given identifier. The returned datum can be chained with a property accessor.
+
+```
+findFirst({_variable_type_string_collection_}, {_variable_type_string_id_})
+Collection: conditions = [{ "id": "c1", "value": "Excellent" }, ...]
+Id variable: "c1"
+Output: {findFirst(conditions, item.condition_id).value} → "Excellent"
+```
+
 ## Formatting functions
 
 These are functions that do 3 things:

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -42,7 +42,7 @@
 						"view": {
 							"content": {
 								"title": "Condition",
-								"subtitle": "{item.condition}",
+								"subtitle": "{findFirst(conditions, item.condition_id).value}",
 								"icon": "::badge-check::"
 							}
 						}
@@ -56,7 +56,7 @@
 						"view": {
 							"content": {
 								"title": "Selling reason",
-								"subtitle": "{item.selling_reason}",
+								"subtitle": "{findFirst(selling_reasons, item.selling_reason_id).value}",
 								"icon": "::circle-question-mark::"
 							}
 						}

--- a/ios/evy/Data/Models/EVYData.swift
+++ b/ios/evy/Data/Models/EVYData.swift
@@ -211,7 +211,7 @@ public enum EVYJson: Codable, Hashable {
         return self
       }
       if props.count == 1 {
-        return parseIdOrIds(props: props, value: subData)
+        return subData
       }
 
       return subData.parseProp(props: Array(props[1...]))
@@ -225,76 +225,12 @@ public enum EVYJson: Codable, Hashable {
 
       let subData = arrayValue[index]
       if props.count == 1 {
-        return parseIdOrIds(props: props, value: subData)
+        return subData
       }
       return subData.parseProp(props: Array(props[1...]))
     default:
-      return parseIdOrIds(props: props, value: self)
+      return self
     }
-  }
-
-  @MainActor
-  private func parseIdOrIds(props: [String], value: EVYJson) -> EVYJson {
-    let key = props.first!
-
-    if !key.hasSuffix("_id") && !key.hasSuffix("_ids") {
-      return value
-    }
-
-    var inputValues: [String] = []
-    if case .array(let arrayValue) = value {
-      inputValues.append(contentsOf: arrayValue.map { $0.toString() })
-    } else if case .string(_) = value {
-      inputValues.append(value.toString())
-    }
-
-    if inputValues.isEmpty {
-      return value
-    }
-
-    do {
-      if key.hasSuffix("_ids") {
-        let data = try EVY.getDataFromProps(String(key.dropLast(4) + "s"))
-        if case .array(let arrayValue) = data {
-          let filteredValues = arrayValue.filter {
-            inputValues.contains($0.identifierValue())
-          }
-          if filteredValues.count > 0 {
-            let data = try JSONEncoder().encode(filteredValues)
-            return try JSONDecoder().decode(EVYJson.self, from: data)
-          }
-        }
-      }
-      if key.hasSuffix("_id") {
-        let data = try EVY.getDataFromProps(String(key.dropLast(3) + "s"))
-        if case .array(let arrayValue) = data {
-          let matchingValue = arrayValue.first {
-            inputValues.contains($0.identifierValue())
-          }
-          if matchingValue != nil {
-            return matchingValue!
-          }
-        }
-      }
-    } catch EVYDataError.keyNotFound {
-      #if DEBUG
-        print("[EVYData] parseIdOrIds: key not found for \(key)")
-      #endif
-    } catch EVYParamError.invalidProps {
-      #if DEBUG
-        print("[EVYData] parseIdOrIds: invalid props for \(key)")
-      #endif
-    } catch {
-      #if DEBUG
-        print("[EVYData] parseIdOrIds unexpected error: \(error)")
-      #endif
-      NotificationCenter.default.post(
-        name: Notification.Name.evyErrorOccurred,
-        object: error
-      )
-    }
-
-    return value
   }
 }
 

--- a/ios/evy/Utils/functions.swift
+++ b/ios/evy/Utils/functions.swift
@@ -43,6 +43,23 @@ func evyLength(_ args: String) throws -> EVYFunctionOutput {
 }
 
 @MainActor
+func evyFindFirst(_ args: String, remainingProps: [String] = []) throws -> EVYJson {
+  let parts = splitFunctionArguments(args)
+  guard parts.count == 2 else { throw EVYParamError.invalidProps }
+  let collectionArg = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+  let idArg = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+  let collection = try EVY.getDataFromProps(collectionArg)
+  let idValue =
+    (try? EVY.getDataFromProps(idArg))?.toString() ?? stripOptionalSurroundingQuotes(idArg)
+  guard case .array(let items) = collection,
+    let match = items.first(where: { $0.identifierValue() == idValue })
+  else {
+    return .string("")
+  }
+  return match.parseProp(props: remainingProps)
+}
+
+@MainActor
 func evyFormatCurrency(
   _ args: String,
   _ editing: Bool = false

--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -21,7 +21,7 @@ public func splitPropsFromText(_ props: String) throws -> [String] {
     throw EVYParamError.invalidProps
   }
 
-  var splitProps = props.components(separatedBy: PROP_SEPARATOR)
+  var splitProps = splitTopLevel(props, separator: PROP_SEPARATOR, includingEmptyValues: false)
   if splitProps.count < 1 {
     throw EVYParamError.invalidProps
   }
@@ -246,6 +246,12 @@ func _getDataFromProps(_ props: String) throws -> EVYJson {
     throw EVYParamError.invalidProps
   }
 
+  let remainingProps = splitProps.count > 1 ? Array(splitProps[1...]) : []
+
+  if let (funcName, funcArgs) = parseFunctionCall(firstProp), funcName == "findFirst" {
+    return try evyFindFirst(funcArgs, remainingProps: remainingProps)
+  }
+
   // 1. Check draft store — user's unsaved edits
   if let scopeId = EVY.draftStore.activeScopeId,
     let draftBinding = try? EVY.draftStore.binding(fromParsedProps: cleanProps, scopeId: scopeId),
@@ -262,12 +268,10 @@ func _getDataFromProps(_ props: String) throws -> EVYJson {
     let cachedRow = try? EVY.cacheStore.get(
       namespace: EVYNamespace.cache, resource: scopeId, id: firstProp)
   {
-    let remainingProps = splitProps.count > 1 ? Array(splitProps[1...]) : []
     return try cachedRow.decoded().parseProp(props: remainingProps)
   }
 
   // 2. Fall back to persistent store — synced API data
-  let remainingProps = splitProps.count > 1 ? Array(splitProps[1...]) : []
   let json = try store.getJsonForBinding(key: firstProp)
   return json.parseProp(props: remainingProps)
 }

--- a/ios/evyTests/interpreterTests.swift
+++ b/ios/evyTests/interpreterTests.swift
@@ -530,6 +530,62 @@ final class InterpreterTests: XCTestCase {
     )
   }
 
+  func testFindFirstReturnsMatchingDatumField() throws {
+    let conditionsKey = uniqueKey("conditions")
+    let itemKey = uniqueKey("item")
+    let conditionId = UUID().uuidString
+
+    try store(
+      .array([
+        .dictionary(["id": .string(conditionId), "value": .string("Excellent")]),
+        .dictionary(["id": .string(UUID().uuidString), "value": .string("Other")]),
+      ]),
+      at: "marketplace:\(conditionsKey)"
+    )
+    try store(.dictionary(["condition_id": .string(conditionId)]), at: itemKey)
+
+    let result = try parseTextFromText(
+      "{findFirst(\(conditionsKey), \(itemKey).condition_id).value}")
+
+    XCTAssertEqual(result.value, "Excellent")
+  }
+
+  func testFindFirstReturnsEmptyForNoMatch() throws {
+    let conditionsKey = uniqueKey("conditions")
+    let itemKey = uniqueKey("item")
+
+    try store(
+      .array([.dictionary(["id": .string("abc"), "value": .string("Excellent")])]),
+      at: "marketplace:\(conditionsKey)"
+    )
+    try store(.dictionary(["condition_id": .string("no_match")]), at: itemKey)
+
+    let result = try parseTextFromText(
+      "{findFirst(\(conditionsKey), \(itemKey).condition_id).value}")
+
+    XCTAssertEqual(result.value, "")
+  }
+
+  func testFindFirstDoesNotMutateStore() throws {
+    let conditionsKey = uniqueKey("conditions")
+    let itemKey = uniqueKey("item")
+    let conditionId = UUID().uuidString
+
+    try store(
+      .array([.dictionary(["id": .string(conditionId), "value": .string("Good")])]),
+      at: "marketplace:\(conditionsKey)"
+    )
+    try store(.dictionary(["condition_id": .string(conditionId)]), at: itemKey)
+
+    let countBefore = try EVY.publicStore.getAll().count
+    let result = try parseTextFromText(
+      "{findFirst(\(conditionsKey), \(itemKey).condition_id).value}")
+    let countAfter = try EVY.publicStore.getAll().count
+
+    XCTAssertEqual(result.value, "Good")
+    XCTAssertEqual(countBefore, countAfter)
+  }
+
   private func store(_ value: EVYJson, at key: String) throws {
     let encodedValue = try JSONEncoder().encode(value)
 

--- a/web/app/utils/functions.ts
+++ b/web/app/utils/functions.ts
@@ -24,6 +24,11 @@ function evyLength(): EVYFunctionOutput {
 	return { value: "1" };
 }
 
+function evyFindFirst(args: string): EVYFunctionOutput {
+	const [data] = args.split(",");
+	return { value: data?.trim() ?? "" };
+}
+
 function evyFormatCurrency(): EVYFunctionOutput {
 	return { value: "1.00", prefix: "$" };
 }
@@ -115,6 +120,7 @@ const evyFormatDurationStub = (): EVYFunctionOutput => ({
 const functionHandlers: Record<string, EVYFunctionHandler> = {
 	count: evyCount,
 	length: evyLength,
+	findFirst: evyFindFirst,
 	formatCurrency: evyFormatCurrency,
 	formatDimension: evyFormatDimension,
 	formatWeight: evyFormatWeight,

--- a/web/app/utils/interpreter.test.ts
+++ b/web/app/utils/interpreter.test.ts
@@ -78,12 +78,24 @@ describe("parseText", () => {
 		);
 	});
 
+	it("resolves findFirst to the data argument for mock data", () => {
+		expect(
+			parseText("{findFirst(selling_reasons, item.selling_reason_id)}"),
+		).toBe("selling_reasons");
+	});
+
+	it("keeps text after findFirst as a normal suffix", () => {
+		expect(
+			parseText("{findFirst(selling_reasons, item.selling_reason_id)}.value"),
+		).toBe("selling_reasons.value");
+	});
+
 	it("keeps dimension preview safe for unresolved values", () => {
 		expect(parseText("{formatDimension(item.unknown)}")).toBe("100mm");
 	});
 
-	it("replaces property path with friendly label", () => {
-		expect(parseText("Hello {item.title}")).toBe("Hello Item title");
+	it("replaces property path with its raw prop path", () => {
+		expect(parseText("Hello {item.title}")).toBe("Hello item.title");
 	});
 
 	it("strips comparison expressions in braces", () => {

--- a/web/app/utils/interpreter.ts
+++ b/web/app/utils/interpreter.ts
@@ -1,5 +1,4 @@
 import { callFunction, type EVYFunctionContext } from "./functions";
-import { propPathToFriendlyLabel } from "./labelFormatting";
 
 const FUNCTION_CALL_PATTERN = /([a-zA-Z_]+)\(([^()]*)\)/;
 const PROPS_PATTERN = /\{(?!")[^}^"]*(?!")\}/;
@@ -22,10 +21,6 @@ function replaceFunctionCall(
 	const matchStart = match.index;
 	const matchEnd = matchStart + match[0].length;
 	return `${text.slice(0, matchStart)}${resolved}${text.slice(matchEnd)}`;
-}
-
-function shouldUnwrapResolvedExpression(inner: string): boolean {
-	return /\s/.test(inner) || /[()]/.test(inner);
 }
 
 export function parseText(input: string, context?: EVYFunctionContext): string {
@@ -53,10 +48,7 @@ export function parseText(input: string, context?: EVYFunctionContext): string {
 				continue;
 			}
 
-			const replacement = shouldUnwrapResolvedExpression(inner)
-				? inner
-				: propPathToFriendlyLabel(inner);
-			text = text.replace(propsMatch[0], replacement);
+			text = text.replace(propsMatch[0], inner);
 			continue;
 		}
 

--- a/web/app/utils/labelFormatting.ts
+++ b/web/app/utils/labelFormatting.ts
@@ -26,15 +26,3 @@ export function splitCamelCaseToWords(identifier: string): string {
 		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
 		.trim();
 }
-
-/**
- * Converts a dotted path to a readable label, preserving full context.
- * e.g. "item.title" → "Item title", "user.address.postcode" → "User address postcode"
- */
-export function propPathToFriendlyLabel(propPath: string): string {
-	const segments = propPath.split(".");
-	if (segments.length === 0) return propPath;
-	const spaced = segments.map((segment) => underscoresToSpaces(segment));
-	spaced[0] = sentenceCaseFirstLetter(spaced[0]);
-	return spaced.join(" ");
-}

--- a/web/e2e/e2e.pw.ts
+++ b/web/e2e/e2e.pw.ts
@@ -202,14 +202,40 @@ test.describe("Web E2E Integration Tests", () => {
 	});
 
 	test("should persist SDUI edits after page refresh", async ({ page }) => {
+		const uniqueFlowName = `E2E SDUI Edit Flow ${Date.now()}`;
+		const initialRowTitle = "Item title";
 		const uniqueTitle = `E2E Test Title ${Date.now()}`;
+
+		await createFlowInApi({
+			id: crypto.randomUUID(),
+			name: uniqueFlowName,
+			pages: [
+				{
+					id: crypto.randomUUID(),
+					title: "",
+					rows: [
+						{
+							id: crypto.randomUUID(),
+							type: "Text",
+							source: "",
+							actions: [],
+							view: {
+								content: {
+									title: initialRowTitle,
+								},
+							},
+						},
+					],
+				},
+			],
+		});
 
 		await page.goto("/");
 		await waitForAppLoaded(page);
 
-		await selectFlowByLabel(page, "View Item");
+		await selectFlowByLabel(page, uniqueFlowName);
 
-		const textRow = page.getByText("Item title", { exact: true });
+		const textRow = page.getByText(initialRowTitle, { exact: true });
 		await expect(textRow).toBeVisible();
 
 		await textRow.click();
@@ -221,12 +247,12 @@ test.describe("Web E2E Integration Tests", () => {
 		await titleInput.clear();
 		await titleInput.fill(uniqueTitle);
 		await expect(titleInput).toHaveValue(uniqueTitle);
-		await expectFlowRowTitlePersisted("View Item", uniqueTitle);
+		await expectFlowRowTitlePersisted(uniqueFlowName, uniqueTitle);
 
 		await page.reload();
 		await waitForAppLoaded(page);
 
-		await selectFlowByLabel(page, "View Item");
+		await selectFlowByLabel(page, uniqueFlowName);
 
 		const editedRow = page.getByText(uniqueTitle, { exact: true });
 		await expect(editedRow).toBeVisible();


### PR DESCRIPTION
## Summary

Adds a `findFirst` function that looks up a datum in a named collection by matching its `id` field, replacing the previous auto-resolution of `_id`/`_ids` suffixed properties. This makes data lookups explicit and composable.

## Major changes

- **iOS: Removed `parseIdOrIds` method** from `EVYData.swift` — the automatic resolution of properties ending in `_id`/`_ids` has been removed in favor of explicit `findFirst` calls
- **iOS: Added `evyFindFirst` function** in `functions.swift` — looks up the first matching item in a collection by ID, with optional remaining prop chaining
- **iOS: Updated interpreter** to handle `findFirst` function calls with chained property access
- **Web: Added `evyFindFirst` stub** in `functions.ts` for preview/editor contexts
- **Web: Removed `propPathToFriendlyLabel`** — simplified expression resolution to return raw prop paths instead of friendly labels
- **Docs: Added `findFirst` documentation** in `functions.md`
- **Docs: Updated service_sdui.json** to use `findFirst` for condition/selling_reason lookups
- **Tests: Added iOS unit tests** for matching, no-match, and non-mutation scenarios

## Tests ran

- iOS unit tests passing (interpreter tests for `findFirst` and existing tests)
- Web unit tests updated and passing

## Risks & suggestions

- The web stub returns just the first argument as a placeholder — should be wired to actual data when the web interpreter gains store access
- The removal of `parseIdOrIds` means any existing templates relying on automatic `_id` resolution will need updating to use `findFirst` explicitly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784034912&installation_id=127792561&pr_number=213&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F213&signature=c92832dbd583ad4ca82db1a0be55681b1e4442cc3bc58d42cc3051c42c11d2cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->