### PR TITLE
[FEAT] ListItem row with image, web alignment, and RowLayout simplification

### DIFF
--- a/docs/evy/evy_sdui.json
+++ b/docs/evy/evy_sdui.json
@@ -12,12 +12,12 @@
 						"content": {
 							"child": {
 								"id": "d5922ca1-fc26-430a-81ed-fd343c13dab1",
-								"type": "Text",
+								"type": "ListItem",
 								"view": {
 									"content": {
-										"icon": "",
 										"title": "{$datum.title}",
-										"subtitle": "{formatCurrency($datum.price)}"
+										"subtitle": "{formatCurrency($datum.price)}",
+										"image": "{$datum.photo_ids.0}"
 									}
 								},
 								"source": "",

--- a/docs/evy/sdui/readme.md
+++ b/docs/evy/sdui/readme.md
@@ -218,7 +218,7 @@ Row types are defined in the schema (`types/schema/sdui/evy.schema.json`) and th
 
 | Category   | Row types |
 | ---------- | --------- |
-| View       | Text, InputList, PhotoGallery, Map |
+| View       | Text, InputList, ListItem, PhotoGallery, Map |
 | Edit       | Calendar, Dropdown, InlinePicker, Input, Search, SelectPhoto, TextArea, TextSelect, TimeslotPicker |
 | Action     | Button |
 | Container  | ColumnContainer, ListContainer, SelectSegmentContainer |
@@ -226,6 +226,8 @@ Row types are defined in the schema (`types/schema/sdui/evy.schema.json`) and th
 Each row type’s `view.content` may include type-specific keys (e.g. `label`, `value`, `placeholder`, `format`, `child`, `children`). `Text` supports compact `title`/`subtitle`/`icon` display and longer text display with `text`, `placeholder`, `action`, and `view.max_lines`. See `row-content.spec.json` for the exact keys per type.
 
 For list-backed rows (Dropdown, InlinePicker, InputList, etc.), `format` is evaluated per item from the list resolved via `source`. Use `{$datum.}` as the placeholder for the current item, e.g. `{$datum.value}` or `{$datum.unit} {$datum.street}, {$datum.city}`.
+
+For **ListItem** rows, `view.content.image` must be a string expression that resolves to an EVY file ID (e.g. `"{item.photo_ids.0}"`). iOS fetches the binary from `evy:files` using `EVYRemoteFile` and clips it to a rounded square. `title` and `subtitle` are displayed beside the image. The web builder renders a gray placeholder in place of the image.
 
 For **Search** rows, iOS reads the data array from `source`, renders each hit using `view.content.child` (typically a `Text` row template) instead of `format`, and filters locally using rendered child display strings (`title`, `subtitle`, `text`, `label`, `placeholder`, and `value`). String fields in that child row are evaluated with `{$datum.}` the same way. Tapping a result runs actions from the rendered child row with that datum in scope. The web builder shows deterministic preview results for the child template, but it does not fetch or filter live data.
 

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -381,6 +381,33 @@ class E2ETestBase: XCTestCase {
     ]
   }
 
+  static func listItemRow(
+    id: String,
+    title: String,
+    subtitle: String = "",
+    image: String = "",
+    visible: String = ""
+  ) -> [String: Any] {
+    var row: [String: Any] = [
+      "id": id,
+      "type": "ListItem",
+      "source": "",
+      "destination": "",
+      "actions": [],
+      "view": [
+        "content": [
+          "title": title,
+          "subtitle": subtitle,
+          "image": image,
+        ]
+      ],
+    ]
+    if !visible.isEmpty {
+      row["visible"] = visible
+    }
+    return row
+  }
+
   static func inputRow(
     id: String,
     title: String,

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -386,14 +386,15 @@ class E2ETestBase: XCTestCase {
     title: String,
     subtitle: String = "",
     image: String = "",
-    visible: String = ""
+    visible: String = "true"
   ) -> [String: Any] {
-    var row: [String: Any] = [
+    return [
       "id": id,
       "type": "ListItem",
       "source": "",
       "destination": "",
       "actions": [],
+      "visible": visible,
       "view": [
         "content": [
           "title": title,
@@ -402,10 +403,6 @@ class E2ETestBase: XCTestCase {
         ]
       ],
     ]
-    if !visible.isEmpty {
-      row["visible"] = visible
-    }
-    return row
   }
 
   static func inputRow(

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		730187D62F20E232002EF894 /* user_data.json in Resources */ = {isa = PBXBuildFile; fileRef = 730187D52F20E232002EF894 /* user_data.json */; };
 		7303B31A2C3EB8A000796123 /* EVYCalendarSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7303B3192C3EB8A000796123 /* EVYCalendarSlot.swift */; };
 		7320F5902C2FF8F000297C48 /* EVYTextRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7320F58F2C2FF8F000297C48 /* EVYTextRow.swift */; };
+		7320F5922C2FF8F000297C48 /* EVYListItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7320F5912C2FF8F000297C48 /* EVYListItemRow.swift */; };
 		732A50822C1D6AE80036B98B /* EVY.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732A50812C1D6AE80036B98B /* EVY.swift */; };
 		7330E4392C9BFABB00FE8F31 /* EVYSelectItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7330E4382C9BFABB00FE8F31 /* EVYSelectItem.swift */; };
 		7333F45B2FAA2D1C006BEA92 /* EVY+QueryParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7333F4502FAA2D1C006BEA92 /* EVY+QueryParams.swift */; };
@@ -135,6 +136,7 @@
 		730187D52F20E232002EF894 /* user_data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = user_data.json; path = ../docs/evy/user_data.json; sourceTree = SOURCE_ROOT; };
 		7303B3192C3EB8A000796123 /* EVYCalendarSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYCalendarSlot.swift; sourceTree = "<group>"; };
 		7320F58F2C2FF8F000297C48 /* EVYTextRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYTextRow.swift; sourceTree = "<group>"; };
+		7320F5912C2FF8F000297C48 /* EVYListItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYListItemRow.swift; sourceTree = "<group>"; };
 		732A50812C1D6AE80036B98B /* EVY.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVY.swift; sourceTree = "<group>"; };
 		7330E4382C9BFABB00FE8F31 /* EVYSelectItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EVYSelectItem.swift; sourceTree = "<group>"; };
 		7333F44E2FAA2D1C006BEA92 /* EVY+Mutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EVY+Mutations.swift"; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 			children = (
 				7320F58F2C2FF8F000297C48 /* EVYTextRow.swift */,
 				73CB09532C7609E5008F7D2C /* EVYInputListRow.swift */,
+				7320F5912C2FF8F000297C48 /* EVYListItemRow.swift */,
 				FA002004MP00001000000001 /* EVYMapRow.swift */,
 				C97D5780FBD0B1C8C63B4E94 /* EVYPhotoGalleryRow.swift */,
 
@@ -691,6 +694,7 @@
 				732A50822C1D6AE80036B98B /* EVY.swift in Sources */,
 				73C78AEE2BC54DFE0026F39D /* EVYSearchRow.swift in Sources */,
 				7320F5902C2FF8F000297C48 /* EVYTextRow.swift in Sources */,
+				7320F5922C2FF8F000297C48 /* EVYListItemRow.swift in Sources */,
 				737334F92B7B5F1800D2E1CF /* EVYInputRow.swift in Sources */,
 				737C6ACB2B270AD90093D00C /* EVYWebsocket.swift in Sources */,
 				2E0B20F22B816AFA002C86A3 /* EVYSelectPhotoRow.swift in Sources */,

--- a/ios/evy/UI/EVYRow.swift
+++ b/ios/evy/UI/EVYRow.swift
@@ -100,6 +100,7 @@ struct EVYRow: View, Identifiable {
     case .input(let v, _, let d, _):
       EVYInputRow(view: v, destination: d, isInteractive: row.actions.isEmpty)
     case .listContainer(let v, let s, _, _): EVYListContainerRow(view: v, source: s)
+    case .listItem(let v, _, _, _): EVYListItemRow(view: v)
     case .map(let v, _, _, _): EVYMapRow(view: v)
     case .search(let v, let s, _, _): EVYSearchRow(view: v, source: s)
     case .photoGallery(let v, let s, _, _): EVYPhotoGalleryRow(view: v, source: s)

--- a/ios/evy/UI/Rows/View/EVYListItemRow.swift
+++ b/ios/evy/UI/Rows/View/EVYListItemRow.swift
@@ -1,0 +1,64 @@
+//
+//  EVYListItemRow.swift
+//  evy
+//
+
+import SwiftUI
+
+struct EVYListItemRow: View {
+
+  private let view: ListItemRowViewData
+
+  init(view: ListItemRowViewData) {
+    self.view = view
+  }
+
+  private var imageId: String {
+    (try? EVY.getDataFromText(view.content.image).toString()) ?? view.content.image
+  }
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 8) {
+      EVYRemoteFile(fileId: imageId)
+        .frame(width: 52, height: 52)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+
+      VStack(alignment: .leading, spacing: 2) {
+        if !view.content.title.isEmpty {
+          EVYTextView(view.content.title)
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
+        if !view.content.subtitle.isEmpty {
+          EVYTextView(view.content.subtitle, style: .info)
+            .lineLimit(2)
+            .truncationMode(.tail)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+#Preview {
+  EVYPreviewRow(
+    json: """
+      {
+        "id": "preview-list-item-row",
+        "type": "ListItem",
+        "source": "",
+        "destination": "",
+        "actions": [],
+        "visible": "true",
+        "view": {
+          "content": {
+            "title": "Red mountain bike",
+            "subtitle": "Great condition · $120",
+            "image": ""
+          }
+        }
+      }
+      """,
+    failureMessage: "Unable to build list item row preview"
+  )
+}

--- a/ios/evyTests/ContentViewTests.swift
+++ b/ios/evyTests/ContentViewTests.swift
@@ -120,6 +120,31 @@ final class ContentViewTests: XCTestCase {
     XCTAssertEqual(viewData.content.child?.id, "text-child")
   }
 
+  func testListItemRowDecodesCorrectly() throws {
+    let json: [String: Any] = [
+      "id": "list-item-row-id",
+      "type": "ListItem",
+      "source": "",
+      "destination": "",
+      "actions": [],
+      "view": [
+        "content": [
+          "title": "Test title",
+          "subtitle": "Test subtitle",
+          "image": "",
+        ]
+      ],
+    ]
+
+    let data = try JSONSerialization.data(withJSONObject: json)
+    let row = try JSONDecoder().decode(UI_Row.self, from: data)
+    guard case .listItem(let viewData, _, _, _) = try UI_RowPayload.from(row: row) else {
+      return XCTFail("Expected .listItem payload")
+    }
+    XCTAssertEqual(viewData.content.title, "Test title")
+    XCTAssertEqual(viewData.content.subtitle, "Test subtitle")
+  }
+
   private func makeFlows() throws -> [UI_Flow] {
     let json: [[String: Any]] = [
       [

--- a/types/schema/sdui/evy.schema.json
+++ b/types/schema/sdui/evy.schema.json
@@ -68,6 +68,7 @@
 						"InputList",
 						"Input",
 						"ListContainer",
+						"ListItem",
 						"Search",
 						"PhotoGallery",
 						"SelectPhoto",
@@ -170,6 +171,9 @@
 					"type": "string"
 				},
 				"icon": {
+					"type": "string"
+				},
+				"image": {
 					"type": "string"
 				},
 				"content": {

--- a/types/schema/sdui/row-content.spec.json
+++ b/types/schema/sdui/row-content.spec.json
@@ -112,6 +112,13 @@
 			"placeholder": "string"
 		}
 	},
+	"ListItem": {
+		"content": {
+			"title": "string",
+			"subtitle": "string",
+			"image": "string"
+		}
+	},
 	"ColumnContainer": {
 		"content": {
 			"title": "string",

--- a/web/app/rows/action/ButtonRow.tsx
+++ b/web/app/rows/action/ButtonRow.tsx
@@ -18,7 +18,7 @@ export default defineRow("ButtonRow", {
 	} satisfies RowConfig,
 	render: (row) => (
 		<RowLayout title={row.config.view.content.title}>
-			<div className="evy-p-2 evy-flex evy-justify-center">
+			<div className="evy-py-2 evy-flex evy-justify-center">
 				<Button label={row.config.view.content.label} />
 			</div>
 		</RowLayout>

--- a/web/app/rows/baseRows.ts
+++ b/web/app/rows/baseRows.ts
@@ -12,9 +12,10 @@ import SelectPhotoRow from "./edit/SelectPhotoRow";
 import TextAreaRow from "./edit/TextAreaRow";
 import TextSelectRow from "./edit/TextSelectRow";
 import TimeslotPickerRow from "./edit/TimeslotPickerRow";
-import TextRow from "./view/TextRow";
 import InputListRow from "./view/InputListRow";
+import ListItemRow from "./view/ListItemRow";
 import MapRow from "./view/MapRow";
+import TextRow from "./view/TextRow";
 
 export const baseRows = [
 	TextRow,
@@ -25,6 +26,7 @@ export const baseRows = [
 	TextSelectRow,
 	SearchRow,
 	InputListRow,
+	ListItemRow,
 	PhotoGalleryRow,
 	SelectPhotoRow,
 	CalendarRow,

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -1,7 +1,7 @@
 import type { RowConfig } from "../../types/row";
 import { ContainerChildren } from "../../components/ContainerChildren";
 import { defineRow } from "../defineRow";
-import EVYText from "../design-system/EVYText";
+import { RowLayout } from "../design-system/RowLayout";
 
 const typeName = "ListContainerRow";
 
@@ -22,12 +22,7 @@ export default defineRow(typeName, {
 	render: (row) => {
 		const title = row.config.view.content.title;
 		return (
-			<div className="evy-flex evy-flex-col">
-				{title ? (
-					<p className="evy-text-md evy-p-2">
-						<EVYText text={title} />
-					</p>
-				) : null}
+			<RowLayout title={title} fullWidthContent>
 				<ContainerChildren
 					rows={row.config.view.content.children}
 					orientation="vertical"
@@ -35,7 +30,7 @@ export default defineRow(typeName, {
 					containerRowId={row.id}
 					containerType="children"
 				/>
-			</div>
+			</RowLayout>
 		);
 	},
 });

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -3,7 +3,7 @@ import { useState, type CSSProperties, type MouseEvent } from "react";
 import type { Row, RowConfig } from "../../types/row";
 import { ContainerChildren } from "../../components/ContainerChildren";
 import { defineRow } from "../defineRow";
-import EVYText from "../design-system/EVYText";
+import { RowLayout } from "../design-system/RowLayout";
 import { useRowById } from "../../hooks/useRowById";
 import { useFlowsContext } from "../../state";
 
@@ -92,12 +92,7 @@ export default defineRow(typeName, {
 		const title = row.config.view.content.title;
 
 		return (
-			<>
-				{title ? (
-					<p className="evy-text-md evy-p-2">
-						<EVYText text={title} />
-					</p>
-				) : null}
+			<RowLayout title={title} fullWidthContent>
 				<div className="evy-flex evy-mb-2 evy-px-2" style={segmentGroupStyle}>
 					{segments.map((segment, index) => {
 						const isFirst = index === 0;
@@ -123,7 +118,7 @@ export default defineRow(typeName, {
 					containerRowId={rowId}
 					containerType="children"
 				/>
-			</>
+			</RowLayout>
 		);
 	},
 });

--- a/web/app/rows/design-system/RowLayout.tsx
+++ b/web/app/rows/design-system/RowLayout.tsx
@@ -20,11 +20,11 @@ export function RowLayout({
 	childrenClassName?: string;
 	fullWidthContent?: boolean;
 }) {
-	const titleElement = (
+	const titleElement = title.trim() ? (
 		<p className={titleClassName}>
 			<EVYText text={title} />
 		</p>
-	);
+	) : null;
 	const childrenElement = childrenClassName ? (
 		<div className={childrenClassName}>{children}</div>
 	) : (

--- a/web/app/rows/design-system/RowLayout.tsx
+++ b/web/app/rows/design-system/RowLayout.tsx
@@ -1,21 +1,49 @@
 import type { ReactNode } from "react";
 import EVYText from "./EVYText";
 
+function classNames(...values: Array<string | undefined>) {
+	return values.filter(Boolean).join(" ");
+}
+
 export function RowLayout({
 	title,
 	children,
 	titleClassName = "evy-text-md",
+	contentClassName,
+	childrenClassName,
+	fullWidthContent = false,
 }: {
 	title: string;
 	children?: ReactNode;
 	titleClassName?: string;
+	contentClassName?: string;
+	childrenClassName?: string;
+	fullWidthContent?: boolean;
 }) {
+	const titleElement = (
+		<p className={titleClassName}>
+			<EVYText text={title} />
+		</p>
+	);
+	const childrenElement = childrenClassName ? (
+		<div className={childrenClassName}>{children}</div>
+	) : (
+		children
+	);
+
+	if (fullWidthContent) {
+		return (
+			<div className={contentClassName}>
+				<div className="evy-p-2">{titleElement}</div>
+				{childrenElement}
+			</div>
+		);
+	}
+
 	return (
-		<div className="evy-p-2">
-			<p className={titleClassName}>
-				<EVYText text={title} />
-			</p>
-			{children}
+		<div className={classNames("evy-p-2", contentClassName)}>
+			{titleElement}
+			{childrenElement}
 		</div>
 	);
 }

--- a/web/app/rows/design-system/RowLayout.tsx
+++ b/web/app/rows/design-system/RowLayout.tsx
@@ -1,23 +1,15 @@
 import type { ReactNode } from "react";
 import EVYText from "./EVYText";
 
-function classNames(...values: Array<string | undefined>) {
-	return values.filter(Boolean).join(" ");
-}
-
 export function RowLayout({
 	title,
 	children,
 	titleClassName = "evy-text-md",
-	contentClassName,
-	childrenClassName,
 	fullWidthContent = false,
 }: {
 	title: string;
 	children?: ReactNode;
 	titleClassName?: string;
-	contentClassName?: string;
-	childrenClassName?: string;
 	fullWidthContent?: boolean;
 }) {
 	const titleElement = title.trim() ? (
@@ -25,25 +17,20 @@ export function RowLayout({
 			<EVYText text={title} />
 		</p>
 	) : null;
-	const childrenElement = childrenClassName ? (
-		<div className={childrenClassName}>{children}</div>
-	) : (
-		children
-	);
 
 	if (fullWidthContent) {
 		return (
-			<div className={contentClassName}>
-				<div className="evy-p-2">{titleElement}</div>
-				{childrenElement}
+			<div>
+				{titleElement && <div className="evy-p-2">{titleElement}</div>}
+				{children}
 			</div>
 		);
 	}
 
 	return (
-		<div className={classNames("evy-p-2", contentClassName)}>
+		<div className="evy-p-2">
 			{titleElement}
-			{childrenElement}
+			{children}
 		</div>
 	);
 }

--- a/web/app/rows/design-system/lineClamp.ts
+++ b/web/app/rows/design-system/lineClamp.ts
@@ -1,0 +1,12 @@
+import type { CSSProperties } from "react";
+
+export function lineClampStyle(lines: number): CSSProperties {
+	return {
+		display: "-webkit-box",
+		WebkitLineClamp: lines,
+		WebkitBoxOrient: "vertical",
+		overflow: "hidden",
+		overflowWrap: "anywhere",
+		wordBreak: "break-word",
+	};
+}

--- a/web/app/rows/edit/PhotoGalleryRow.tsx
+++ b/web/app/rows/edit/PhotoGalleryRow.tsx
@@ -1,7 +1,7 @@
 import type { RowConfig } from "../../types/row";
 import { defineRow } from "../defineRow";
-import EVYText from "../design-system/EVYText";
 import CarouselIndicator from "../design-system/CarouselIndicator";
+import { RowLayout } from "../design-system/RowLayout";
 
 export default defineRow("PhotoGalleryRow", {
 	config: {
@@ -17,12 +17,7 @@ export default defineRow("PhotoGalleryRow", {
 		destination: "",
 	} satisfies RowConfig,
 	render: (row) => (
-		<div>
-			<div className="evy-p-2">
-				<p className="evy-text-md">
-					<EVYText text={row.config.view.content.title} />
-				</p>
-			</div>
+		<RowLayout title={row.config.view.content.title} fullWidthContent>
 			<div
 				className="evy-relative evy-w-full evy-bg-gray-light evy-overflow-hidden evy-flex evy-items-center evy-justify-center"
 				style={{ aspectRatio: "4/3" }}
@@ -45,6 +40,6 @@ export default defineRow("PhotoGalleryRow", {
 					/>
 				</div>
 			</div>
-		</div>
+		</RowLayout>
 	),
 });

--- a/web/app/rows/view/ListItemRow.tsx
+++ b/web/app/rows/view/ListItemRow.tsx
@@ -1,19 +1,7 @@
-import type { CSSProperties } from "react";
-
 import type { RowConfig } from "../../types/row";
 import EVYText from "../design-system/EVYText";
+import { lineClampStyle } from "../design-system/lineClamp";
 import { defineRow } from "../defineRow";
-
-function lineClampStyle(lines: number): CSSProperties {
-	return {
-		display: "-webkit-box",
-		WebkitLineClamp: lines,
-		WebkitBoxOrient: "vertical",
-		overflow: "hidden",
-		overflowWrap: "anywhere",
-		wordBreak: "break-word",
-	};
-}
 
 export default defineRow("ListItemRow", {
 	config: {

--- a/web/app/rows/view/ListItemRow.tsx
+++ b/web/app/rows/view/ListItemRow.tsx
@@ -1,0 +1,57 @@
+import type { CSSProperties } from "react";
+
+import type { RowConfig } from "../../types/row";
+import EVYText from "../design-system/EVYText";
+import { defineRow } from "../defineRow";
+
+function lineClampStyle(lines: number): CSSProperties {
+	return {
+		display: "-webkit-box",
+		WebkitLineClamp: lines,
+		WebkitBoxOrient: "vertical",
+		overflow: "hidden",
+		overflowWrap: "anywhere",
+		wordBreak: "break-word",
+	};
+}
+
+export default defineRow("ListItemRow", {
+	config: {
+		type: "ListItem",
+		actions: [],
+		source: "",
+		visible: "true",
+		view: {
+			content: {
+				title: "List item title",
+				subtitle: "Subtitle",
+				image: "",
+			},
+		},
+	} satisfies RowConfig,
+	render: (row) => {
+		const { title = "", subtitle = "", image = "" } = row.config.view.content;
+
+		return (
+			<div className="evy-flex evy-flex-row evy-items-center evy-gap-2 evy-px-3 evy-py-2">
+				<div
+					className="evy-shrink-0 evy-bg-gray-light evy-rounded"
+					style={{ width: 52, height: 52 }}
+					title={image || "image placeholder"}
+				/>
+				<div className="evy-flex-1 evy-min-w-0">
+					{title.trim() ? (
+						<p className="evy-text-md" style={lineClampStyle(1)}>
+							<EVYText text={title} />
+						</p>
+					) : null}
+					{subtitle.trim() ? (
+						<p className="evy-text-sm evy-text-gray" style={lineClampStyle(2)}>
+							<EVYText text={subtitle} />
+						</p>
+					) : null}
+				</div>
+			</div>
+		);
+	},
+});

--- a/web/app/rows/view/MapRow.tsx
+++ b/web/app/rows/view/MapRow.tsx
@@ -1,6 +1,7 @@
 import type { RowConfig } from "../../types/row";
 import EVYText from "../design-system/EVYText";
 import { defineRow } from "../defineRow";
+import { RowLayout } from "../design-system/RowLayout";
 
 function MapPreview() {
 	return (
@@ -35,19 +36,14 @@ export default defineRow("MapRow", {
 	render: (row) => {
 		const { title, subtitle } = row.config.view.content;
 		return (
-			<div className="evy-p-2">
-				{title ? (
-					<p className="evy-text-md evy-mb-2">
-						<EVYText text={title} />
-					</p>
-				) : null}
+			<RowLayout title={title}>
 				<MapPreview />
 				{subtitle ? (
 					<p className="evy-text-sm evy-text-gray evy-mt-2">
 						<EVYText text={subtitle} />
 					</p>
 				) : null}
-			</div>
+			</RowLayout>
 		);
 	},
 });

--- a/web/app/rows/view/TextRow.tsx
+++ b/web/app/rows/view/TextRow.tsx
@@ -52,7 +52,7 @@ export default defineRow("TextRow", {
 		const textStyle = lineClampStyle(maxLinesValue(row.config.view.max_lines));
 
 		return (
-			<div className="evy-flex evy-flex-col evy-gap-1 evy-px-3 evy-py-2">
+			<div className="evy-flex evy-flex-col evy-gap-1 evy-p-2">
 				<div className="evy-flex evy-flex-row evy-items-center evy-gap-2">
 					{icon.trim() ? (
 						<span className="evy-shrink-0">

--- a/web/app/rows/view/TextRow.tsx
+++ b/web/app/rows/view/TextRow.tsx
@@ -1,19 +1,7 @@
-import type { CSSProperties } from "react";
-
 import type { RowConfig } from "../../types/row";
 import EVYText from "../design-system/EVYText";
+import { lineClampStyle } from "../design-system/lineClamp";
 import { defineRow } from "../defineRow";
-
-function lineClampStyle(lines: number): CSSProperties {
-	return {
-		display: "-webkit-box",
-		WebkitLineClamp: lines,
-		WebkitBoxOrient: "vertical",
-		overflow: "hidden",
-		overflowWrap: "anywhere",
-		wordBreak: "break-word",
-	};
-}
 
 function maxLinesValue(maxLines: string | undefined): number {
 	const parsedMaxLines = Number.parseInt(maxLines ?? "", 10);


### PR DESCRIPTION
## Summary

Add a `ListItem` view row that displays a thumbnail image alongside title and subtitle. Also standardizes container rows to use `RowLayout` for consistent padding and simplifies the `RowLayout` component by removing unused props.

## Major changes

- **New ListItem row** — Added `ListItemRow` type on iOS (`EVYListItemRow.swift`), web (`ListItemRow.tsx`), schema (`evy.schema.json`, `row-content.spec.json`), and docs (`evy_sdui.json`, `sdui/readme.md`). Displays a 52×52 rounded image with title (1 line) and subtitle (2 lines).
- **Web alignment** — `ListContainerRow`, `SelectSegmentContainerRow`, `PhotoGalleryRow`, and `MapRow` now all use `RowLayout` for consistent title/children layout. `ButtonRow` padding adjusted from `p-2` to `py-2`.
- **RowLayout simplification** — Removed unused `contentClassName` and `childrenClassName` props and the private `classNames` helper. Fixed empty padding div rendering when `fullWidthContent` is true but title is empty.
- **Shared utility** — Extracted `lineClampStyle` into `design-system/lineClamp.ts` and imported into both `TextRow` and `ListItemRow`.
- **iOS e2e** — Added `listItemRow` helper, aligned `visible` parameter defaults/convention with other row helpers, and added a decoding test for the new row type.
- **iOS project** — Added `EVYListItemRow.swift` to Xcode project and wired the `.listItem` case in `EVYRow`.

## Tests ran

- `bun run build` — passed
- `bun run lint` — passed (Biome, 0 issues)

## Risks & suggestions

None.