### PR TITLE
[FEAT] Support multiple function calls inside one iOS interpolation block

### DIFF
--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -346,6 +346,20 @@ private func parseText(
       editing)
   }
 
+  // Mixed interpolation blocks are text expressions, not prop paths. Unwrap them before
+  // function evaluation so `{formatDimension(width) x formatDimension(height)}` never
+  // reaches `parseProps` as `{20cm x 30cm}`.
+  if let expression = parseTextExpressionInterpolation(input.value) {
+    let parsedInner = try parseText(EVYValue(expression.inner, nil, nil), editing)
+    let parsedInput = input.value.replacingOccurrences(
+      of: expression.fullMatch,
+      with: parsedInner.toString()
+    )
+    return try parseText(
+      EVYValue(parsedInput, input.prefix, input.suffix),
+      editing)
+  }
+
   if let (match, funcName, funcArgs) =
     parseFunctionFromText(input.value)
     ?? parseFunctionInText(input.value)
@@ -422,6 +436,93 @@ private func parseProps(_ input: String) -> (Regex<AnyRegexOutput>.Match, String
     return (match, String(match.0.dropFirst().dropLast()))
   }
   return nil
+}
+
+private func parseTextExpressionInterpolation(_ input: String) -> (
+  fullMatch: String, inner: String
+)? {
+  for interpolation in interpolations(in: input) {
+    let inner = interpolation.inner.trimmingCharacters(in: .whitespacesAndNewlines)
+    if containsMixedFunctionTextExpression(inner) {
+      return interpolation
+    }
+  }
+
+  return nil
+}
+
+private func containsMixedFunctionTextExpression(_ input: String) -> Bool {
+  var remaining = input
+  var functionCount = 0
+
+  while let function = parseFunctionInText(remaining) {
+    functionCount += 1
+    remaining = remaining.replacingOccurrences(
+      of: function.match.0.description,
+      with: "",
+      options: [],
+      range: remaining.startIndex..<function.match.range.upperBound
+    )
+  }
+
+  let trimmedRemainder = remaining.trimmingCharacters(in: .whitespacesAndNewlines)
+  if functionCount > 1 {
+    return true
+  }
+
+  // A single function with a prop continuation, like `findFirst(items, id).value`,
+  // is still a prop expression. Anything else around the function is literal text.
+  return functionCount == 1 && !trimmedRemainder.isEmpty
+    && !isPropContinuation(trimmedRemainder)
+}
+
+private func isPropContinuation(_ input: String) -> Bool {
+  var remaining = input
+
+  while !remaining.isEmpty {
+    if remaining.first == "." {
+      remaining.removeFirst()
+      let segment = remaining.prefix { character in
+        character.isLetter || character.isNumber || character == "_"
+      }
+      guard !segment.isEmpty else { return false }
+      remaining.removeFirst(segment.count)
+      continue
+    }
+
+    guard remaining.first == "[", let closingIndex = remaining.firstIndex(of: "]") else {
+      return false
+    }
+    let indexValue = remaining[remaining.index(after: remaining.startIndex)..<closingIndex]
+    guard !indexValue.isEmpty, indexValue.allSatisfy(\.isNumber) else { return false }
+    remaining.removeSubrange(remaining.startIndex...closingIndex)
+  }
+
+  return true
+}
+
+private func interpolations(in input: String) -> [(fullMatch: String, inner: String)] {
+  var results: [(fullMatch: String, inner: String)] = []
+  var state = ParserScanState()
+  var startIndex: String.Index?
+
+  for index in input.indices {
+    let character = input[index]
+
+    if startIndex == nil, !state.isInString, state.isTopLevel, character == "{" {
+      startIndex = index
+    }
+
+    state.scan(character)
+
+    if let blockStartIndex = startIndex, !state.isInString, state.isTopLevel, character == "}" {
+      let innerStart = input.index(after: blockStartIndex)
+      results.append((String(input[blockStartIndex...index]), String(input[innerStart..<index])))
+      startIndex = nil
+    }
+  }
+
+  return results
 }
 
 private func parseComparisonFromText(_ input: String) -> (fullMatch: String, content: String)? {
@@ -680,14 +781,32 @@ private func appendWatchTargets(fromExpression expression: String, to paths: ino
     return
   }
 
-  if let functionCall = parseFunctionCall(cleaned) {
-    for argument in splitFunctionArguments(functionCall.functionArgs) {
-      appendWatchTargets(fromExpression: argument, to: &paths)
-    }
+  if appendWatchTargetsFromFunctions(in: cleaned, to: &paths) {
     return
   }
 
   appendUniqueWatchTarget(watchTargetOperand(cleaned), to: &paths)
+}
+
+@MainActor
+private func appendWatchTargetsFromFunctions(in text: String, to paths: inout [String]) -> Bool {
+  var remaining = text
+  var foundFunction = false
+
+  while let functionCall = parseFunctionInText(remaining) {
+    foundFunction = true
+    for argument in splitFunctionArguments(functionCall.functionArgs) {
+      appendWatchTargets(fromExpression: argument, to: &paths)
+    }
+    remaining = remaining.replacingOccurrences(
+      of: functionCall.match.0.description,
+      with: "",
+      options: [],
+      range: remaining.startIndex..<functionCall.match.range.upperBound
+    )
+  }
+
+  return foundFunction
 }
 
 #Preview {

--- a/ios/evy/Utils/interpreter.swift
+++ b/ios/evy/Utils/interpreter.swift
@@ -441,14 +441,9 @@ private func parseProps(_ input: String) -> (Regex<AnyRegexOutput>.Match, String
 private func parseTextExpressionInterpolation(_ input: String) -> (
   fullMatch: String, inner: String
 )? {
-  for interpolation in interpolations(in: input) {
-    let inner = interpolation.inner.trimmingCharacters(in: .whitespacesAndNewlines)
-    if containsMixedFunctionTextExpression(inner) {
-      return interpolation
-    }
+  interpolations(in: input).first {
+    containsMixedFunctionTextExpression($0.inner.trimmingCharacters(in: .whitespacesAndNewlines))
   }
-
-  return nil
 }
 
 private func containsMixedFunctionTextExpression(_ input: String) -> Bool {
@@ -457,23 +452,25 @@ private func containsMixedFunctionTextExpression(_ input: String) -> Bool {
 
   while let function = parseFunctionInText(remaining) {
     functionCount += 1
-    remaining = remaining.replacingOccurrences(
-      of: function.match.0.description,
-      with: "",
-      options: [],
-      range: remaining.startIndex..<function.match.range.upperBound
-    )
+    remaining = advancePastFunction(function.match, in: remaining)
   }
 
-  let trimmedRemainder = remaining.trimmingCharacters(in: .whitespacesAndNewlines)
-  if functionCount > 1 {
-    return true
-  }
+  if functionCount > 1 { return true }
 
   // A single function with a prop continuation, like `findFirst(items, id).value`,
   // is still a prop expression. Anything else around the function is literal text.
+  let trimmedRemainder = remaining.trimmingCharacters(in: .whitespacesAndNewlines)
   return functionCount == 1 && !trimmedRemainder.isEmpty
     && !isPropContinuation(trimmedRemainder)
+}
+
+private func advancePastFunction(_ match: Regex<AnyRegexOutput>.Match, in string: String) -> String
+{
+  string.replacingOccurrences(
+    of: match.0.description,
+    with: "",
+    range: string.startIndex..<match.range.upperBound
+  )
 }
 
 private func isPropContinuation(_ input: String) -> Bool {
@@ -798,12 +795,7 @@ private func appendWatchTargetsFromFunctions(in text: String, to paths: inout [S
     for argument in splitFunctionArguments(functionCall.functionArgs) {
       appendWatchTargets(fromExpression: argument, to: &paths)
     }
-    remaining = remaining.replacingOccurrences(
-      of: functionCall.match.0.description,
-      with: "",
-      options: [],
-      range: remaining.startIndex..<functionCall.match.range.upperBound
-    )
+    remaining = advancePastFunction(functionCall.match, in: remaining)
   }
 
   return foundFunction

--- a/ios/evyTests/interpreterTests.swift
+++ b/ios/evyTests/interpreterTests.swift
@@ -110,6 +110,14 @@ final class InterpreterTests: XCTestCase {
     )
   }
 
+  func testWatchTargetsExtractsAllFunctionsFromMixedInterpolation() {
+    XCTAssertEqual(
+      EVY.watchTargets(
+        for: "{formatDimension(item.dimensions.width) x formatDimension(item.dimensions.height)}"),
+      ["item.dimensions.width", "item.dimensions.height"]
+    )
+  }
+
   func testWatchTargetsExtractsAllDataFunctionArguments() {
     XCTAssertEqual(
       EVY.watchTargets(for: "{compare(item.width, item.height)}"),
@@ -184,6 +192,42 @@ final class InterpreterTests: XCTestCase {
     try store(.int(4231), at: key)
     let out = try parseTextFromText("{formatImperialLength(\(key))}")
     XCTAssertEqual(out.toString(), "13.88ft")
+  }
+
+  func testGetValueFromTextEvaluatesMultipleFunctionsInSingleBraceBlock() throws {
+    let itemKey = uniqueKey("item")
+    try store(
+      .dictionary([
+        "dimensions": .dictionary([
+          "width": .int(200),
+          "height": .int(300),
+        ])
+      ]),
+      at: itemKey)
+
+    let out = try EVY.getValueFromText(
+      "{formatDimension(\(itemKey).dimensions.width) x formatDimension(\(itemKey).dimensions.height)}"
+    )
+
+    XCTAssertEqual(out.toString(), "20cm x 30cm")
+  }
+
+  func testGetValueFromTextEvaluatesMultipleFunctionsInsideWrappedText() throws {
+    let itemKey = uniqueKey("item")
+    try store(
+      .dictionary([
+        "dimensions": .dictionary([
+          "width": .int(200),
+          "height": .int(300),
+        ])
+      ]),
+      at: itemKey)
+
+    let out = try EVY.getValueFromText(
+      "Size: {formatDimension(\(itemKey).dimensions.width) x formatDimension(\(itemKey).dimensions.height)}"
+    )
+
+    XCTAssertEqual(out.toString(), "Size: 20cm x 30cm")
   }
 
   func testFormatDurationHumanizesMilliseconds() throws {

--- a/ios/evyTests/interpreterTests.swift
+++ b/ios/evyTests/interpreterTests.swift
@@ -195,39 +195,23 @@ final class InterpreterTests: XCTestCase {
   }
 
   func testGetValueFromTextEvaluatesMultipleFunctionsInSingleBraceBlock() throws {
-    let itemKey = uniqueKey("item")
-    try store(
-      .dictionary([
-        "dimensions": .dictionary([
-          "width": .int(200),
-          "height": .int(300),
-        ])
-      ]),
-      at: itemKey)
-
-    let out = try EVY.getValueFromText(
-      "{formatDimension(\(itemKey).dimensions.width) x formatDimension(\(itemKey).dimensions.height)}"
+    let key = try storeDimensions(width: 200, height: 300)
+    XCTAssertEqual(
+      try EVY.getValueFromText(
+        "{formatDimension(\(key).dimensions.width) x formatDimension(\(key).dimensions.height)}"
+      ).toString(),
+      "20cm x 30cm"
     )
-
-    XCTAssertEqual(out.toString(), "20cm x 30cm")
   }
 
   func testGetValueFromTextEvaluatesMultipleFunctionsInsideWrappedText() throws {
-    let itemKey = uniqueKey("item")
-    try store(
-      .dictionary([
-        "dimensions": .dictionary([
-          "width": .int(200),
-          "height": .int(300),
-        ])
-      ]),
-      at: itemKey)
-
-    let out = try EVY.getValueFromText(
-      "Size: {formatDimension(\(itemKey).dimensions.width) x formatDimension(\(itemKey).dimensions.height)}"
+    let key = try storeDimensions(width: 200, height: 300)
+    XCTAssertEqual(
+      try EVY.getValueFromText(
+        "Size: {formatDimension(\(key).dimensions.width) x formatDimension(\(key).dimensions.height)}"
+      ).toString(),
+      "Size: 20cm x 30cm"
     )
-
-    XCTAssertEqual(out.toString(), "Size: 20cm x 30cm")
   }
 
   func testFormatDurationHumanizesMilliseconds() throws {
@@ -673,6 +657,19 @@ final class InterpreterTests: XCTestCase {
 
     XCTAssertEqual(result.value, "Good")
     XCTAssertEqual(countBefore, countAfter)
+  }
+
+  private func storeDimensions(width: Int, height: Int) throws -> String {
+    let key = uniqueKey("item")
+    try store(
+      .dictionary([
+        "dimensions": .dictionary([
+          "width": .int(width),
+          "height": .int(height),
+        ])
+      ]),
+      at: key)
+    return key
   }
 
   private func store(_ value: EVYJson, at key: String) throws {


### PR DESCRIPTION
## Summary

iOS SDUI text interpolation blocks with a single function like `{formatDimension(item.dimensions.width)}` worked, but blocks with multiple function calls mixed with literal text like `{formatDimension(item.dimensions.width) x formatDimension(item.dimensions.height)}` failed to resolve correctly.

The parser was treating the entire braced content as a prop path after evaluating functions inside it, causing `{20cm x 30cm}` to be looked up as a data key instead of being kept as the final text output.

## Major changes

### Parser (`ios/evy/Utils/interpreter.swift`)
- Added `parseTextExpressionInterpolation` to unwrap mixed function/literal interpolation blocks before `parseProps` can consume them as data paths
- Added structural detection via `containsMixedFunctionTextExpression` and `isPropContinuation` so expressions like `{findFirst(items, id).value}` stay on the prop path
- Added `advancePastFunction` helper to de-duplicate function-match advancement shared between the text expression detector and the watch-target extractor
- Updated watch-target extraction (`appendWatchTargetsFromFunctions`) to collect every function argument in mixed expressions, not just the first one

### ListItem row (`ios/evy/UI/EVYRow.swift`)
- Added the `.listItem` case to the payload switch to fix a build-blocking exhaustive switch error from the generated type

### Tests (`ios/evyTests/interpreterTests.swift`)
- Three new tests covering multiple functions in a single brace block, with wrapper text, and watch-target extraction
- Extracted `storeDimensions(width:height:)` helper to share fixture setup

## Tests ran
- All 48 `InterpreterTests` pass on iPhone 17 / iOS 26.5 simulator
- `xcodebuild build` succeeds for the iOS app target
- Full iOS test suite: all unit tests pass; UI/e2e tests fail due to lack of backend services (pre-existing)
- E2E runner (`./run-e2e.sh --skip-ios`) fails at the Docker API health check (pre-existing infra issue, not code-related)

## Risks
- The structural detection uses a `isPropContinuation` check that covers `.property` and `[index]` suffixes. If a future function return value needs a different kind of postfix, the check would need updating
- No hardcoded function-name list: the detector infers from the presence of any function-call-shaped token, which keeps it automatically aligned with the function dispatch, but is slightly broader than the original opt-in set

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784303617&installation_id=127792561&pr_number=217&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F217&signature=70c0b8e4af6163f336d0e314d0a1c7ed4da2bcc9b29cb86ee21e86809a846c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->