### PR TITLE
[REFACTOR] Remove hardcoded key guards and flatten row definitions

### DIFF
--- a/api/e2e/e2e.test.ts
+++ b/api/e2e/e2e.test.ts
@@ -115,14 +115,9 @@ describe("API E2E Tests", () => {
 				source: "",
 				visible: "true",
 				actions: [],
-				view: {
-					content: {
-						title: "Hello",
-						text: "World",
-						expandLabel: "Read more",
-					},
-					max_lines: "3",
-				},
+				title: "Hello",
+				text: "World",
+				expandLabel: "Read more",
 			};
 
 			const testPage: UI_Page = {

--- a/api/src/tests/data.test.ts
+++ b/api/src/tests/data.test.ts
@@ -36,16 +36,15 @@ import {
 type ValidatedRow = UI_Row;
 type ValidatedPage = UI_Page;
 
-type RowInput = Omit<ValidatedRow, "id" | "view" | "source" | "visible"> & {
+type RowInput = Omit<
+	ValidatedRow,
+	"id" | "source" | "visible" | "child" | "children"
+> & {
 	id?: string;
 	source?: string;
 	visible?: string;
-	view: Omit<ValidatedRow["view"], "content"> & {
-		content: Omit<ValidatedRow["view"]["content"], "children" | "child"> & {
-			children?: RowInput[];
-			child?: RowInput;
-		};
-	};
+	children?: RowInput[];
+	child?: RowInput;
 };
 
 type PageInput = Omit<ValidatedPage, "id" | "rows" | "footer"> & {
@@ -107,22 +106,12 @@ function ensureRowIds(rows: RowInput[]): RowInput[] {
 			id: crypto.randomUUID(),
 			source: row.source ?? "",
 			visible: row.visible ?? "true",
-			view: {
-				...row.view,
-				content: {
-					...row.view.content,
-				},
-			},
 		};
-		if (row.view.content.children) {
-			rowWithId.view.content.children = ensureRowIds(
-				row.view.content.children,
-			);
+		if (row.children) {
+			rowWithId.children = ensureRowIds(row.children);
 		}
-		if (row.view.content.child) {
-			rowWithId.view.content.child = ensureRowIds([
-				row.view.content.child,
-			])[0];
+		if (row.child) {
+			rowWithId.child = ensureRowIds([row.child])[0];
 		}
 		return rowWithId;
 	});
@@ -241,14 +230,9 @@ describe("create", () => {
 					rows: [
 						{
 							type: "TextExpand",
-							view: {
-								content: {
-									title: "Hello",
-									text: "World",
-									expandLabel: "Read more",
-								},
-								max_lines: "3",
-							},
+							title: "Hello",
+							text: "World",
+							expandLabel: "Read more",
 							actions: [],
 						},
 					],
@@ -430,12 +414,8 @@ describe("update", () => {
 					rows: [
 						{
 							type: "Button",
-							view: {
-								content: {
-									title: "",
-									label: "Click me",
-								},
-							},
+							title: "",
+							label: "Click me",
 							actions: [
 								{ condition: "", false: "", true: "{close()}" },
 							],
@@ -804,9 +784,7 @@ describe("create SDUI validation", () => {
 							rows: [
 								{
 									type: "InvalidRowType",
-									view: {
-										content: { title: "Test" },
-									},
+									title: "Test",
 								},
 							],
 						},
@@ -826,37 +804,24 @@ describe("create SDUI validation", () => {
 						{
 							type: "ColumnContainer",
 							actions: [],
-							view: {
-								content: {
-									title: "Container",
-									children: [
-										{
-											type: "Input",
-											view: {
-												content: {
-													title: "Input 1",
-													value: "",
-													placeholder: "Enter text",
-												},
-											},
-											destination: "{field}",
-											actions: [],
-										},
-										{
-											type: "Input",
-											view: {
-												content: {
-													title: "Input 2",
-													value: "",
-													placeholder:
-														"Enter more text",
-												},
-											},
-											actions: [],
-										},
-									],
+							title: "Container",
+							children: [
+								{
+									type: "Input",
+									title: "Input 1",
+									value: "",
+									placeholder: "Enter text",
+									destination: "{field}",
+									actions: [],
 								},
-							},
+								{
+									type: "Input",
+									title: "Input 2",
+									value: "",
+									placeholder: "Enter more text",
+									actions: [],
+								},
+							],
 						},
 					],
 				},
@@ -882,9 +847,8 @@ describe("create SDUI validation", () => {
 					rows: [],
 					footer: {
 						type: "Button",
-						view: {
-							content: { title: "", label: "Submit" },
-						},
+						title: "",
+						label: "Submit",
 						actions: [
 							{
 								condition: "",

--- a/api/src/tests/validation.test.ts
+++ b/api/src/tests/validation.test.ts
@@ -152,11 +152,7 @@ describe("validateFlowData", () => {
 								type: "Text",
 								source: "",
 								actions: [],
-								view: {
-									content: {
-										title: "Always visible",
-									},
-								},
+								title: "Always visible",
 							},
 						],
 					},
@@ -184,11 +180,7 @@ describe("validateFlowData", () => {
 							actions: [],
 							visible:
 								"{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_methods.cash == true}",
-							view: {
-								content: {
-									title: "Cash accepted",
-								},
-							},
+							title: "Cash accepted",
 						},
 					],
 				},

--- a/docs/evy/data.md
+++ b/docs/evy/data.md
@@ -189,8 +189,9 @@ end_time: string             (HH:mm, exclusive, e.g. "19:00")
 timeslot_interval_minutes: integer   (e.g. 30)
 label_interval_minutes: integer      (e.g. 60)
 header_format: string        (date format pattern, e.g. "EEE d")
-primary: string              (binding to primary selection array)
-secondary: string            (binding to read-only secondary context array)
+timeslot_format: string      (time format pattern, e.g. "HH:mm")
+
+Calendar rows store the editable primary selection array through row-level `destination` and read the contextual secondary selection array through row-level `source`.
 ```
 
 #### transfer_options

--- a/docs/evy/evy_sdui.json
+++ b/docs/evy/evy_sdui.json
@@ -8,33 +8,25 @@
 				{
 					"id": "96d3efe4-ea20-4a81-9ccb-64d6b57646e9",
 					"type": "Search",
-					"view": {
-						"content": {
-							"child": {
-								"id": "d5922ca1-fc26-430a-81ed-fd343c13dab1",
-								"type": "ListItem",
-								"view": {
-									"content": {
-										"title": "{$datum.title}",
-										"subtitle": "{formatCurrency($datum.price)}",
-										"image": "{$datum.photo_ids.0}"
-									}
-								},
-								"source": "",
-								"actions": [
-									{
-										"true": "{navigate(74a49d4b-2176-4925-857a-e29e2991f1bd,82cae120-c7b1-4c29-bd42-e1521320b109,{id: $datum.id})}",
-										"false": "",
-										"condition": ""
-									}
-								],
-								"destination": "",
-								"visible": "true"
-							},
-							"title": "",
-							"placeholder": "Search anything"
-						}
+					"child": {
+						"id": "d5922ca1-fc26-430a-81ed-fd343c13dab1",
+						"type": "ListItem",
+						"title": "{$datum.title}",
+						"subtitle": "{formatCurrency($datum.price)}",
+						"image": "{$datum.photo_ids.0}",
+						"source": "",
+						"actions": [
+							{
+								"true": "{navigate(74a49d4b-2176-4925-857a-e29e2991f1bd,82cae120-c7b1-4c29-bd42-e1521320b109,{id: $datum.id})}",
+								"false": "",
+								"condition": ""
+							}
+						],
+						"destination": "",
+						"visible": "true"
 					},
+					"title": "",
+					"placeholder": "Search anything",
 					"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd}",
 					"actions": [],
 					"destination": "",
@@ -45,12 +37,8 @@
 			"footer": {
 				"id": "cc86c53a-170d-4800-8897-8f99f3697053",
 				"type": "Button",
-				"view": {
-					"content": {
-						"label": "Sell something",
-						"title": ""
-					}
-				},
+				"label": "Sell something",
+				"title": "",
 				"source": "",
 				"actions": [
 					{

--- a/docs/evy/functions.md
+++ b/docs/evy/functions.md
@@ -129,7 +129,7 @@ Variable: "2024-01-19T12:42:52.000Z"
 Outputs: Jan
 ```
 
-Input is an ISO 8601 / RFC 3339 string or a local ISO datetime string without a timezone (e.g. `"2024-01-19T12:42:52"`). Calendar and TimeslotPicker row content use this through parser format strings such as `{formatDatetime($datum, "EEE d")}` and `{formatDatetime($datum, "HH:mm")}`.
+Input is an ISO 8601 / RFC 3339 string or a local ISO datetime string without a timezone (e.g. `"2024-01-19T12:42:52"`). TimeslotPicker row content uses parser format strings such as `{formatDatetime($datum, "EEE d")}` and `{formatDatetime($datum, "HH:mm")}`. Calendar row content uses plain date/time patterns such as `EEE d` and `HH:mm`; legacy parser format strings remain supported during migration.
 
 Supported format tokens:
 

--- a/docs/evy/sdui.md
+++ b/docs/evy/sdui.md
@@ -48,19 +48,17 @@ Rows are what are put into pages. They are the building block of the EVY server-
     "id": "uuid",
     "type": "Button" | "Calendar" | "ColumnContainer" | "Heading" | "Text" | ... ,
 
-    "view": {
-        "content": {
-            // Required. Header of the row; empty string means no header.
-            "title": "string",
-            // Layout: "children" (array of rows), "child" (single row), "segments" (array of strings).
-            // Optional array of children rows to display
-            "children": [ROW],
-            // Optional single child row to display
-            "child": ROW,
-            ...
-        },
-        "max_lines": "string"    // optional (e.g. TextExpand)
-    },
+    // Required. Header of the row; empty string means no header.
+    "title": "string",
+    // Row-type-specific attributes live at the row root, e.g. label, text, subtitle, placeholder, format, etc.
+    "label": "string",
+    "text": "string",
+    // Layout: "children" (array of rows), "child" (single row), "segments" (array of strings).
+    // Optional array of children rows to display
+    "children": [ROW],
+    // Optional single child row to display
+    "child": ROW,
+
     // Where the row reads option/list/entity data from (required string; use "" if unused).
     "source": "string",
     // Where input data is stored in a draft. Use canonical resource IDs such as "{[resource_id].title}".

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -600,7 +600,7 @@
 													{
 														"id": "22222222-2222-4222-8222-222222222208",
 														"type": "Calendar",
-														"source": "",
+														"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
 														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
 														"actions": [],
 														"view": {
@@ -610,10 +610,8 @@
 																"end_time": "19:00",
 																"timeslot_interval_minutes": 30,
 																"label_interval_minutes": 60,
-																"header_format": "{formatDatetime($datum, \"EEE d\")}",
-																"timeslot_format": "{formatDatetime($datum, \"HH:mm\")}",
-																"primary": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
-																"secondary": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}"
+																"header_format": "EEE d",
+																"timeslot_format": "HH:mm"
 															}
 														},
 														"visible": "true"
@@ -707,7 +705,7 @@
 													{
 														"id": "22222222-2222-4222-8222-222222222215",
 														"type": "Calendar",
-														"source": "",
+														"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
 														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
 														"actions": [],
 														"view": {
@@ -717,10 +715,8 @@
 																"end_time": "19:00",
 																"timeslot_interval_minutes": 30,
 																"label_interval_minutes": 60,
-																"header_format": "{formatDatetime($datum, \"EEE d\")}",
-																"timeslot_format": "{formatDatetime($datum, \"HH:mm\")}",
-																"primary": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
-																"secondary": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}"
+																"header_format": "EEE d",
+																"timeslot_format": "HH:mm"
 															}
 														},
 														"visible": "true"

--- a/docs/services/service_sdui.json
+++ b/docs/services/service_sdui.json
@@ -14,11 +14,7 @@
 						"destination": "",
 						"actions": [],
 						"visible": "true",
-						"view": {
-							"content": {
-								"title": ""
-							}
-						}
+						"title": ""
 					},
 					{
 						"id": "8d5e3bb5-8fcf-45f4-ae3d-516ed0706e30",
@@ -27,12 +23,8 @@
 						"destination": "",
 						"actions": [],
 						"visible": "true",
-						"view": {
-							"content": {
-								"title": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}",
-								"label": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}"
-							}
-						}
+						"title": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}",
+						"label": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}"
 					},
 					{
 						"id": "61d8b13a-6e19-4251-84bf-94771af07e6c",
@@ -41,12 +33,8 @@
 						"destination": "",
 						"actions": [],
 						"visible": "true",
-						"view": {
-							"content": {
-								"title": "Condition",
-								"subtitle": "{findFirst(cc2e6c74-a53a-4ed1-97a7-14aa9b9a3e3f, item.condition_id).value}"
-							}
-						}
+						"title": "Condition",
+						"subtitle": "{findFirst(cc2e6c74-a53a-4ed1-97a7-14aa9b9a3e3f, item.condition_id).value}"
 					},
 					{
 						"id": "b402e0e2-62a1-4eab-81ad-c9b522f5ff5a",
@@ -55,12 +43,8 @@
 						"destination": "",
 						"actions": [],
 						"visible": "true",
-						"view": {
-							"content": {
-								"title": "Selling reason",
-								"subtitle": "{findFirst(e9ec5573-bd2f-4ad1-b24f-44a1bf8314e8, item.selling_reason_id).value}"
-							}
-						}
+						"title": "Selling reason",
+						"subtitle": "{findFirst(e9ec5573-bd2f-4ad1-b24f-44a1bf8314e8, item.selling_reason_id).value}"
 					},
 					{
 						"id": "f22cb07b-d4eb-45bc-9d3e-528361564fd2",
@@ -69,12 +53,8 @@
 						"destination": "",
 						"actions": [],
 						"visible": "true",
-						"view": {
-							"content": {
-								"title": "Dimensions",
-								"subtitle": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.dimensions.width) (w) x formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.dimensions.height) (h) x formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.dimensions.length) (l)}"
-							}
-						}
+						"title": "Dimensions",
+						"subtitle": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.dimensions.width) (w) x formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.dimensions.height) (h) x formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.dimensions.length) (l)}"
 					},
 					{
 						"id": "1f90a201-c24a-408f-b4e1-88624e90d2c1",
@@ -83,12 +63,8 @@
 						"destination": "",
 						"actions": [],
 						"visible": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_methods.app == true}",
-						"view": {
-							"content": {
-								"title": "Card",
-								"subtitle": "EVY Buyer protection"
-							}
-						}
+						"title": "Card",
+						"subtitle": "EVY Buyer protection"
 					},
 					{
 						"id": "3444bbac-3f6a-4380-91c5-d4ef6545e7f1",
@@ -97,12 +73,8 @@
 						"destination": "",
 						"actions": [],
 						"visible": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_methods.cash == true}",
-						"view": {
-							"content": {
-								"title": "Cash",
-								"subtitle": "In person"
-							}
-						}
+						"title": "Cash",
+						"subtitle": "In person"
 					},
 					{
 						"id": "ec3bef23-6d74-43eb-adde-8d498d9ed70e",
@@ -111,122 +83,90 @@
 						"destination": "",
 						"actions": [],
 						"visible": "true",
-						"view": {
-							"content": {
+						"title": "",
+						"segments": ["Pickup", "Delivery", "Shipping"],
+						"children": [
+							{
+								"id": "256c223c-71df-42f5-b12f-5267517d87cd",
+								"type": "ListContainer",
+								"source": "",
+								"destination": "",
+								"actions": [],
+								"visible": "true",
 								"title": "",
-								"segments": ["Pickup", "Delivery", "Shipping"],
 								"children": [
 									{
-										"id": "256c223c-71df-42f5-b12f-5267517d87cd",
-										"type": "ListContainer",
+										"id": "0b02c2c0-6e19-49d5-9138-f60062a1f6d4",
+										"type": "Map",
 										"source": "",
 										"destination": "",
 										"actions": [],
 										"visible": "true",
-										"view": {
-											"content": {
-												"title": "",
-												"children": [
-													{
-														"id": "0b02c2c0-6e19-49d5-9138-f60062a1f6d4",
-														"type": "Map",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"visible": "true",
-														"view": {
-															"content": {
-																"title": "",
-																"location": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.transfer_options.pickup.address.location}",
-																"subtitle": "{formatAddress(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.transfer_options.pickup.address)}"
-															}
-														}
-													},
-													{
-														"id": "197531fd-1de3-4d4d-8e03-026b37892611",
-														"type": "TimeslotPicker",
-														"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
-														"destination": "",
-														"actions": [],
-														"visible": "true",
-														"view": {
-															"content": {
-																"title": "",
-																"start_time": "07:00",
-																"end_time": "19:00",
-																"timeslot_interval_minutes": 30,
-																"label_interval_minutes": 60,
-																"header_format": "{formatDatetime($datum, \"EEE\")}",
-																"header_subtitle": "{formatDatetime($datum, \"MMM do\")}",
-																"timeslot_format": "{formatDatetime($datum, \"HH:mm\")}"
-															}
-														}
-													}
-												]
-											}
-										}
+										"title": "",
+										"location": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.transfer_options.pickup.address.location}",
+										"subtitle": "{formatAddress(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.transfer_options.pickup.address)}"
 									},
 									{
-										"id": "0fa00e83-881b-4ecb-b7d3-958d8eaf807c",
-										"type": "ListContainer",
-										"source": "",
+										"id": "197531fd-1de3-4d4d-8e03-026b37892611",
+										"type": "TimeslotPicker",
+										"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
 										"destination": "",
 										"actions": [],
 										"visible": "true",
-										"view": {
-											"content": {
-												"title": "",
-												"children": [
-													{
-														"id": "357d3351-93e6-47bd-91ab-3616fd70b8aa",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"visible": "true",
-														"view": {
-															"content": {
-																"title": "",
-																"subtitle": "Buyer will drop off"
-															}
-														}
-													}
-												]
-											}
-										}
-									},
+										"title": "",
+										"start_time": "07:00",
+										"end_time": "19:00",
+										"timeslot_interval_minutes": 30,
+										"label_interval_minutes": 60,
+										"header_format": "{formatDatetime($datum, \"EEE\")}",
+										"header_subtitle": "{formatDatetime($datum, \"MMM do\")}",
+										"timeslot_format": "{formatDatetime($datum, \"HH:mm\")}"
+									}
+								]
+							},
+							{
+								"id": "0fa00e83-881b-4ecb-b7d3-958d8eaf807c",
+								"type": "ListContainer",
+								"source": "",
+								"destination": "",
+								"actions": [],
+								"visible": "true",
+								"title": "",
+								"children": [
 									{
-										"id": "3ef805de-1386-4f2d-b0f6-54130dc1ba8d",
-										"type": "ListContainer",
+										"id": "357d3351-93e6-47bd-91ab-3616fd70b8aa",
+										"type": "Text",
 										"source": "",
 										"destination": "",
 										"actions": [],
 										"visible": "true",
-										"view": {
-											"content": {
-												"title": "",
-												"children": [
-													{
-														"id": "4aac26f8-7c51-4c09-a6ac-910e5636cbb5",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"visible": "true",
-														"view": {
-															"content": {
-																"title": "",
-																"subtitle": "Delivered to your door"
-															}
-														}
-													}
-												]
-											}
-										}
+										"title": "",
+										"subtitle": "Buyer will drop off"
+									}
+								]
+							},
+							{
+								"id": "3ef805de-1386-4f2d-b0f6-54130dc1ba8d",
+								"type": "ListContainer",
+								"source": "",
+								"destination": "",
+								"actions": [],
+								"visible": "true",
+								"title": "",
+								"children": [
+									{
+										"id": "4aac26f8-7c51-4c09-a6ac-910e5636cbb5",
+										"type": "Text",
+										"source": "",
+										"destination": "",
+										"actions": [],
+										"visible": "true",
+										"title": "",
+										"subtitle": "Delivered to your door"
 									}
 								]
 							}
-						}
+						]
 					}
 				]
 			}
@@ -245,15 +185,11 @@
 						"source": "",
 						"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.photo_ids}",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "",
-								"subtitle": "{count(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.photo_ids)}/10 - Choose your listing's main photo first.",
-								"icon": "::image-plus::",
-								"content": "Add photos",
-								"photos": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.photo_ids}"
-							}
-						},
+						"title": "",
+						"subtitle": "{count(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.photo_ids)}/10 - Choose your listing's main photo first.",
+						"icon": "::image-plus::",
+						"content": "Add photos",
+						"photos": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.photo_ids}",
 						"visible": "true"
 					},
 					{
@@ -262,13 +198,9 @@
 						"source": "",
 						"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "A row title ::star::",
-								"placeholder": "My iPhone ::star:: 20",
-								"value": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}"
-							}
-						},
+						"title": "A row title ::star::",
+						"placeholder": "My iPhone ::star:: 20",
+						"value": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}",
 						"visible": "true"
 					},
 					{
@@ -277,13 +209,9 @@
 						"source": "",
 						"destination": "{buildCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "Price",
-								"placeholder": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}",
-								"value": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}"
-							}
-						},
+						"title": "Price",
+						"placeholder": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}",
+						"value": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.price)}",
 						"visible": "true"
 					},
 					{
@@ -292,13 +220,9 @@
 						"source": "{cc2e6c74-a53a-4ed1-97a7-14aa9b9a3e3f}",
 						"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.condition}",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "Condition",
-								"placeholder": "Choose one",
-								"format": "{$datum.value}"
-							}
-						},
+						"title": "Condition",
+						"placeholder": "Choose one",
+						"format": "{$datum.value}",
 						"visible": "true"
 					},
 					{
@@ -307,13 +231,9 @@
 						"source": "{e9ec5573-bd2f-4ad1-b24f-44a1bf8314e8}",
 						"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.selling_reason}",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "Selling Reason",
-								"placeholder": "Choose one",
-								"format": "{$datum.value}"
-							}
-						},
+						"title": "Selling Reason",
+						"placeholder": "Choose one",
+						"format": "{$datum.value}",
 						"visible": "true"
 					},
 					{
@@ -322,58 +242,42 @@
 						"source": "",
 						"destination": "",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "Dimensions (width x height x depth)",
-								"children": [
-									{
-										"id": "b66e136d-828d-4ed0-ae27-cdc48f7cbffd",
-										"type": "Input",
-										"source": "",
-										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.width}",
-										"actions": [],
-										"view": {
-											"content": {
-												"title": "",
-												"placeholder": "Width",
-												"value": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.width)}"
-											}
-										},
-										"visible": "true"
-									},
-									{
-										"id": "09a9f654-1c2c-42f8-9a6a-4608fc248478",
-										"type": "Input",
-										"source": "",
-										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.height}",
-										"actions": [],
-										"view": {
-											"content": {
-												"title": "",
-												"placeholder": "Height",
-												"value": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.height)}"
-											}
-										},
-										"visible": "true"
-									},
-									{
-										"id": "7484ce1a-0771-45d2-a1cf-8b1336cfd018",
-										"type": "Input",
-										"source": "",
-										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.length}",
-										"actions": [],
-										"view": {
-											"content": {
-												"title": "",
-												"placeholder": "Length",
-												"value": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.length)}"
-											}
-										},
-										"visible": "true"
-									}
-								]
+						"title": "Dimensions (width x height x depth)",
+						"children": [
+							{
+								"id": "b66e136d-828d-4ed0-ae27-cdc48f7cbffd",
+								"type": "Input",
+								"source": "",
+								"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.width}",
+								"actions": [],
+								"title": "",
+								"placeholder": "Width",
+								"value": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.width)}",
+								"visible": "true"
+							},
+							{
+								"id": "09a9f654-1c2c-42f8-9a6a-4608fc248478",
+								"type": "Input",
+								"source": "",
+								"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.height}",
+								"actions": [],
+								"title": "",
+								"placeholder": "Height",
+								"value": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.height)}",
+								"visible": "true"
+							},
+							{
+								"id": "7484ce1a-0771-45d2-a1cf-8b1336cfd018",
+								"type": "Input",
+								"source": "",
+								"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.length}",
+								"actions": [],
+								"title": "",
+								"placeholder": "Length",
+								"value": "{formatDimension(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.length)}",
+								"visible": "true"
 							}
-						},
+						],
 						"visible": "true"
 					}
 				],
@@ -425,12 +329,8 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,06b21b52-0845-468a-ace1-170a3b05f3a2)}"
 						}
 					],
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"title": "",
+					"label": "Next",
 					"visible": "true"
 				}
 			},
@@ -443,13 +343,9 @@
 						"source": "",
 						"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.description}",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "",
-								"value": "",
-								"placeholder": "Write a short description of your product"
-							}
-						},
+						"title": "",
+						"value": "",
+						"placeholder": "Write a short description of your product",
 						"visible": "true"
 					}
 				],
@@ -466,12 +362,8 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,26dae81a-4122-4b5c-8396-a72a319ccd8b)}"
 						}
 					],
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"title": "",
+					"label": "Next",
 					"visible": "true"
 				}
 			},
@@ -484,338 +376,250 @@
 						"source": "",
 						"destination": "",
 						"actions": [],
-						"view": {
-							"content": {
+						"title": "",
+						"segments": ["Pickup", "Delivery", "Shipping"],
+						"children": [
+							{
+								"id": "22222222-2222-4222-8222-222222222201",
+								"type": "ListContainer",
+								"source": "",
+								"destination": "",
+								"actions": [],
 								"title": "",
-								"segments": ["Pickup", "Delivery", "Shipping"],
 								"children": [
 									{
-										"id": "22222222-2222-4222-8222-222222222201",
-										"type": "ListContainer",
+										"id": "22222222-2222-4222-8222-222222222202",
+										"type": "Text",
 										"source": "",
 										"destination": "",
 										"actions": [],
-										"view": {
-											"content": {
-												"title": "",
-												"children": [
-													{
-														"id": "22222222-2222-4222-8222-222222222202",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"subtitle": "Allow buyers to pick up the item"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "586ffa1a-639b-475e-a0b5-1fbe51083274",
-														"type": "TextAction",
-														"source": "",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_address}",
-														"actions": [
-															{
-																"true": "{show()}",
-																"false": "",
-																"condition": ""
-															}
-														],
-														"view": {
-															"content": {
-																"title": "Where",
-																"subtitle": "{formatAddress(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_address)}",
-																"action": "Change",
-																"child": {
-																	"id": "3bb1bad9-a193-4eef-825e-da6f63a1a38e",
-																	"type": "Search",
-																	"view": {
-																		"content": {
-																			"child": {
-																				"id": "e27d87b7-aa2c-4672-aaac-9e1222928f45",
-																				"type": "Text",
-																				"view": {
-																					"content": {
-																						"title": "{$datum.title}",
-																						"subtitle": "{formatCurrency($datum.price)}"
-																					}
-																				},
-																				"source": "",
-																				"actions": [
-																					{
-																						"true": "{navigate(74a49d4b-2176-4925-857a-e29e2991f1bd,82cae120-c7b1-4c29-bd42-e1521320b109,{id: $datum.id})}",
-																						"false": "",
-																						"condition": ""
-																					}
-																				],
-																				"destination": "",
-																				"visible": "true"
-																			},
-																			"title": "",
-																			"placeholder": "Search anything"
-																		}
-																	},
-																	"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd}",
-																	"actions": [],
-																	"destination": "",
-																	"visible": "true"
-																}
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222206",
-														"type": "Input",
-														"source": "",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.address_instructions}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"placeholder": "Additional information",
-																"value": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.address_instructions}"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222207",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "When",
-																"subtitle": "When are you available for buyers to inspect or pick up this item"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222208",
-														"type": "Calendar",
-														"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"start_time": "07:00",
-																"end_time": "19:00",
-																"timeslot_interval_minutes": 30,
-																"label_interval_minutes": 60,
-																"header_format": "EEE d",
-																"timeslot_format": "HH:mm"
-															}
-														},
-														"visible": "true"
-													}
-												]
+										"title": "",
+										"subtitle": "Allow buyers to pick up the item",
+										"visible": "true"
+									},
+									{
+										"id": "586ffa1a-639b-475e-a0b5-1fbe51083274",
+										"type": "TextAction",
+										"source": "",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_address}",
+										"actions": [
+											{
+												"true": "{show()}",
+												"false": "",
+												"condition": ""
 											}
+										],
+										"title": "Where",
+										"subtitle": "{formatAddress(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_address)}",
+										"action": "Change",
+										"child": {
+											"id": "3bb1bad9-a193-4eef-825e-da6f63a1a38e",
+											"type": "Search",
+											"child": {
+												"id": "e27d87b7-aa2c-4672-aaac-9e1222928f45",
+												"type": "Text",
+												"title": "{$datum.title}",
+												"subtitle": "{formatCurrency($datum.price)}",
+												"source": "",
+												"actions": [
+													{
+														"true": "{navigate(74a49d4b-2176-4925-857a-e29e2991f1bd,82cae120-c7b1-4c29-bd42-e1521320b109,{id: $datum.id})}",
+														"false": "",
+														"condition": ""
+													}
+												],
+												"destination": "",
+												"visible": "true"
+											},
+											"title": "",
+											"placeholder": "Search anything",
+											"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd}",
+											"actions": [],
+											"destination": "",
+											"visible": "true"
 										},
 										"visible": "true"
 									},
 									{
-										"id": "22222222-2222-4222-8222-222222222209",
-										"type": "ListContainer",
+										"id": "22222222-2222-4222-8222-222222222206",
+										"type": "Input",
 										"source": "",
-										"destination": "",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.address_instructions}",
 										"actions": [],
-										"view": {
-											"content": {
-												"title": "",
-												"children": [
-													{
-														"id": "22222222-2222-4222-8222-222222222210",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"subtitle": "Deliver directly to the buyer"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222211",
-														"type": "Input",
-														"source": "",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_fee}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "Surcharge",
-																"placeholder": "Do you want to charge for delivery?",
-																"value": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_fee)}"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222212",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "How far",
-																"subtitle": "How long can you travel to deliver this item"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222213",
-														"type": "InlinePicker",
-														"source": "{e82e1baa-6d33-4649-b495-4e10a4d1d8bf}",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.distance}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"format": "{$datum.value}"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222214",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "When",
-																"subtitle": "When are you available to deliver this item"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222215",
-														"type": "Calendar",
-														"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"start_time": "07:00",
-																"end_time": "19:00",
-																"timeslot_interval_minutes": 30,
-																"label_interval_minutes": 60,
-																"header_format": "EEE d",
-																"timeslot_format": "HH:mm"
-															}
-														},
-														"visible": "true"
-													}
-												]
-											}
-										},
+										"title": "",
+										"placeholder": "Additional information",
+										"value": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.address_instructions}",
 										"visible": "true"
 									},
 									{
-										"id": "22222222-2222-4222-8222-222222222216",
-										"type": "ListContainer",
+										"id": "22222222-2222-4222-8222-222222222207",
+										"type": "Text",
 										"source": "",
 										"destination": "",
 										"actions": [],
-										"view": {
-											"content": {
-												"title": "",
-												"children": [
-													{
-														"id": "22222222-2222-4222-8222-222222222217",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"subtitle": "Postal shipping at the buyer's expense"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222218",
-														"type": "Input",
-														"source": "",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.shipping_source_postal_code}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "Where from",
-																"placeholder": "Postal code you will be shipping from",
-																"value": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.shipping_source_postal_code}"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222219",
-														"type": "Text",
-														"source": "",
-														"destination": "",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "Where to",
-																"subtitle": "Select how far you are willing to ship"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222220",
-														"type": "InlinePicker",
-														"source": "{2532b561-3b14-458b-9039-307e99c4a4ba}",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.shipping_destination_areas}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "",
-																"format": "{$datum.value}"
-															}
-														},
-														"visible": "true"
-													},
-													{
-														"id": "22222222-2222-4222-8222-222222222221",
-														"type": "Input",
-														"source": "",
-														"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.weight}",
-														"actions": [],
-														"view": {
-															"content": {
-																"title": "Weight (kg)",
-																"placeholder": "Weight",
-																"value": "{formatWeight(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.weight)}"
-															}
-														},
-														"visible": "true"
-													}
-												]
-											}
-										},
+										"title": "When",
+										"subtitle": "When are you available for buyers to inspect or pick up this item",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222208",
+										"type": "Calendar",
+										"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
+										"actions": [],
+										"title": "",
+										"start_time": "07:00",
+										"end_time": "19:00",
+										"timeslot_interval_minutes": 30,
+										"label_interval_minutes": 60,
+										"header_format": "EEE d",
+										"timeslot_format": "HH:mm",
 										"visible": "true"
 									}
-								]
+								],
+								"visible": "true"
+							},
+							{
+								"id": "22222222-2222-4222-8222-222222222209",
+								"type": "ListContainer",
+								"source": "",
+								"destination": "",
+								"actions": [],
+								"title": "",
+								"children": [
+									{
+										"id": "22222222-2222-4222-8222-222222222210",
+										"type": "Text",
+										"source": "",
+										"destination": "",
+										"actions": [],
+										"title": "",
+										"subtitle": "Deliver directly to the buyer",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222211",
+										"type": "Input",
+										"source": "",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_fee}",
+										"actions": [],
+										"title": "Surcharge",
+										"placeholder": "Do you want to charge for delivery?",
+										"value": "{formatCurrency(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_fee)}",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222212",
+										"type": "Text",
+										"source": "",
+										"destination": "",
+										"actions": [],
+										"title": "How far",
+										"subtitle": "How long can you travel to deliver this item",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222213",
+										"type": "InlinePicker",
+										"source": "{e82e1baa-6d33-4649-b495-4e10a4d1d8bf}",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.distance}",
+										"actions": [],
+										"title": "",
+										"format": "{$datum.value}",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222214",
+										"type": "Text",
+										"source": "",
+										"destination": "",
+										"actions": [],
+										"title": "When",
+										"subtitle": "When are you available to deliver this item",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222215",
+										"type": "Calendar",
+										"source": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.pickup_selection}",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.delivery_selection}",
+										"actions": [],
+										"title": "",
+										"start_time": "07:00",
+										"end_time": "19:00",
+										"timeslot_interval_minutes": 30,
+										"label_interval_minutes": 60,
+										"header_format": "EEE d",
+										"timeslot_format": "HH:mm",
+										"visible": "true"
+									}
+								],
+								"visible": "true"
+							},
+							{
+								"id": "22222222-2222-4222-8222-222222222216",
+								"type": "ListContainer",
+								"source": "",
+								"destination": "",
+								"actions": [],
+								"title": "",
+								"children": [
+									{
+										"id": "22222222-2222-4222-8222-222222222217",
+										"type": "Text",
+										"source": "",
+										"destination": "",
+										"actions": [],
+										"title": "",
+										"subtitle": "Postal shipping at the buyer's expense",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222218",
+										"type": "Input",
+										"source": "",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.shipping_source_postal_code}",
+										"actions": [],
+										"title": "Where from",
+										"placeholder": "Postal code you will be shipping from",
+										"value": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.shipping_source_postal_code}",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222219",
+										"type": "Text",
+										"source": "",
+										"destination": "",
+										"actions": [],
+										"title": "Where to",
+										"subtitle": "Select how far you are willing to ship",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222220",
+										"type": "InlinePicker",
+										"source": "{2532b561-3b14-458b-9039-307e99c4a4ba}",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.shipping_destination_areas}",
+										"actions": [],
+										"title": "",
+										"format": "{$datum.value}",
+										"visible": "true"
+									},
+									{
+										"id": "22222222-2222-4222-8222-222222222221",
+										"type": "Input",
+										"source": "",
+										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.weight}",
+										"actions": [],
+										"title": "Weight (kg)",
+										"placeholder": "Weight",
+										"value": "{formatWeight(dc28ed59-298e-493c-8ff3-3e60f2ebccbd.weight)}",
+										"visible": "true"
+									}
+								],
+								"visible": "true"
 							}
-						},
+						],
 						"visible": "true"
 					}
 				],
@@ -832,12 +636,8 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,25a3269b-344c-477d-89c8-b2f5426a5d91)}"
 						}
 					],
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"title": "",
+					"label": "Next",
 					"visible": "true"
 				}
 			},
@@ -850,12 +650,8 @@
 						"source": "",
 						"destination": "",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "",
-								"subtitle": "Payment will be made by the buyers on pickup"
-							}
-						},
+						"title": "",
+						"subtitle": "Payment will be made by the buyers on pickup",
 						"visible": "true"
 					},
 					{
@@ -864,41 +660,29 @@
 						"source": "",
 						"destination": "",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "",
-								"children": [
-									{
-										"id": "33333333-3333-4333-8333-333333333301",
-										"type": "TextSelect",
-										"source": "",
-										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_cash}",
-										"actions": [],
-										"view": {
-											"content": {
-												"title": "Accept cash",
-												"text": "Let buyers know you will accept cash on pickup"
-											}
-										},
-										"visible": "true"
-									},
-									{
-										"id": "33333333-3333-4333-8333-333333333302",
-										"type": "TextSelect",
-										"source": "",
-										"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_app}",
-										"actions": [],
-										"view": {
-											"content": {
-												"title": "Accept app payments",
-												"text": "Benefit from EVY seller protection when accepting payments through the app on pickup\\n- Cards are verified before the purchase\\n- Payment is transferred immediately when both buyer and seller confirm using a temporary code"
-											}
-										},
-										"visible": "true"
-									}
-								]
+						"title": "",
+						"children": [
+							{
+								"id": "33333333-3333-4333-8333-333333333301",
+								"type": "TextSelect",
+								"source": "",
+								"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_cash}",
+								"actions": [],
+								"title": "Accept cash",
+								"text": "Let buyers know you will accept cash on pickup",
+								"visible": "true"
+							},
+							{
+								"id": "33333333-3333-4333-8333-333333333302",
+								"type": "TextSelect",
+								"source": "",
+								"destination": "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_app}",
+								"actions": [],
+								"title": "Accept app payments",
+								"text": "Benefit from EVY seller protection when accepting payments through the app on pickup\\n- Cards are verified before the purchase\\n- Payment is transferred immediately when both buyer and seller confirm using a temporary code",
+								"visible": "true"
 							}
-						},
+						],
 						"visible": "true"
 					}
 				],
@@ -915,12 +699,8 @@
 							"true": "{navigate(ca47e6c5-da19-4491-8422-adb40d9e8a27,857362ad-856f-465b-85a3-94bc8bb686cd)}"
 						}
 					],
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Next"
-						}
-					},
+					"title": "",
+					"label": "Next",
 					"visible": "true"
 				}
 			},
@@ -933,12 +713,8 @@
 						"source": "",
 						"destination": "",
 						"actions": [],
-						"view": {
-							"content": {
-								"title": "",
-								"subtitle": "EVY is all about Data privacy. Your identity and profile information remains encrypted on your phone and inaccessible to anyone but you. However, the following information about your listing will be public:\n\n* Title & description\n* Photos\n* Condition & selling reason\n* Price\n* Dimension\n* Pickup address & schedule\n* Delivery schedule"
-							}
-						},
+						"title": "",
+						"subtitle": "EVY is all about Data privacy. Your identity and profile information remains encrypted on your phone and inaccessible to anyone but you. However, the following information about your listing will be public:\n\n* Title & description\n* Photos\n* Condition & selling reason\n* Price\n* Dimension\n* Pickup address & schedule\n* Delivery schedule",
 						"visible": "true"
 					}
 				],
@@ -955,12 +731,8 @@
 							"true": "{create(66b092ae-7cd8-4d67-95b7-30b03568fd90,dc28ed59-298e-493c-8ff3-3e60f2ebccbd)}"
 						}
 					],
-					"view": {
-						"content": {
-							"title": "",
-							"label": "Submit"
-						}
-					},
+					"title": "",
+					"label": "Submit",
 					"visible": "true"
 				}
 			}

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -333,22 +333,18 @@ class E2ETestBase: XCTestCase {
               "destination": "",
               "actions": [],
               "visible": "true",
-              "view": [
-                "content": [
-                  "title": "",
-                  "children": [
-                    Self.buttonRow(
-                      id: "441c1433-446b-4682-854d-5d795ef52709",
-                      label: buttonLabel,
-                      action: "{navigate(\(viewFlowId),\(viewPageId))}"
-                    ),
-                    Self.buttonRow(
-                      id: "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
-                      label: "Create",
-                      action: "{navigate(\(createFlowId),\(createPageId))}"
-                    ),
-                  ],
-                ]
+              "title": "",
+              "children": [
+                Self.buttonRow(
+                  id: "441c1433-446b-4682-854d-5d795ef52709",
+                  label: buttonLabel,
+                  action: "{navigate(\(viewFlowId),\(viewPageId))}"
+                ),
+                Self.buttonRow(
+                  id: "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
+                  label: "Create",
+                  action: "{navigate(\(createFlowId),\(createPageId))}"
+                ),
               ],
             ]
           ],
@@ -364,23 +360,23 @@ class E2ETestBase: XCTestCase {
     subtitle: String = "",
     visible: String = "true"
   ) -> [String: Any] {
-    let (rowType, view): (String, [String: Any]) =
-      text.isEmpty
-      ? ("Text", ["content": ["title": title, "subtitle": subtitle, "label": ""]])
-      : (
-        "TextExpand",
-        ["content": ["title": title, "text": text, "expandLabel": "Read more"], "max_lines": "3"]
-      )
-
-    return [
+    var row: [String: Any] = [
       "id": id,
-      "type": rowType,
+      "type": text.isEmpty ? "Text" : "TextExpand",
       "source": "",
       "destination": "",
       "actions": [],
       "visible": visible,
-      "view": view,
+      "title": title,
     ]
+    if text.isEmpty {
+      row["subtitle"] = subtitle
+      row["label"] = ""
+    } else {
+      row["text"] = text
+      row["expandLabel"] = "Read more"
+    }
+    return row
   }
 
   static func listItemRow(
@@ -397,13 +393,9 @@ class E2ETestBase: XCTestCase {
       "destination": "",
       "actions": [],
       "visible": visible,
-      "view": [
-        "content": [
-          "title": title,
-          "subtitle": subtitle,
-          "image": image,
-        ]
-      ],
+      "title": title,
+      "subtitle": subtitle,
+      "image": image,
     ]
   }
 
@@ -420,13 +412,9 @@ class E2ETestBase: XCTestCase {
       "type": "Input",
       "source": "",
       "visible": visible,
-      "view": [
-        "content": [
-          "title": title,
-          "value": value,
-          "placeholder": placeholder,
-        ]
-      ],
+      "title": title,
+      "value": value,
+      "placeholder": placeholder,
       "destination": destination,
       "actions": [],
     ]
@@ -444,12 +432,8 @@ class E2ETestBase: XCTestCase {
       "source": "",
       "destination": "",
       "visible": visible,
-      "view": [
-        "content": [
-          "title": "",
-          "label": label,
-        ]
-      ],
+      "title": "",
+      "label": label,
       "actions": [
         [
           "condition": "",
@@ -1001,23 +985,19 @@ final class WebSocketE2ETests: E2ETestBase {
               "destination": "",
               "actions": [],
               "visible": "true",
-              "view": [
-                "content": [
-                  "title": "",
-                  "children": [
-                    Self.buttonRow(
-                      id: "441c1433-446b-4682-854d-5d795ef52709",
-                      label: buttonLabel,
-                      action: viewAction
-                    ),
-                    Self.buttonRow(
-                      id: "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
-                      label: "Create",
-                      action:
-                        "{navigate(\(E2EFlowIds.webSocketCreateFlow),\(E2EFlowIds.webSocketCreatePage))}"
-                    ),
-                  ],
-                ]
+              "title": "",
+              "children": [
+                Self.buttonRow(
+                  id: "441c1433-446b-4682-854d-5d795ef52709",
+                  label: buttonLabel,
+                  action: viewAction
+                ),
+                Self.buttonRow(
+                  id: "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
+                  label: "Create",
+                  action:
+                    "{navigate(\(E2EFlowIds.webSocketCreateFlow),\(E2EFlowIds.webSocketCreatePage))}"
+                ),
               ],
             ]
           ],
@@ -1032,9 +1012,7 @@ final class WebSocketE2ETests: E2ETestBase {
       var homePage = pages.first,
       var rows = homePage["rows"] as? [[String: Any]],
       var firstRow = rows.first,
-      var rowView = firstRow["view"] as? [String: Any],
-      var rowContent = rowView["content"] as? [String: Any],
-      var children = rowContent["children"] as? [[String: Any]],
+      var children = firstRow["children"] as? [[String: Any]],
       var firstButton = children.first,
       var actions = firstButton["actions"] as? [[String: Any]],
       var firstAction = actions.first
@@ -1046,9 +1024,7 @@ final class WebSocketE2ETests: E2ETestBase {
     actions[0] = firstAction
     firstButton["actions"] = actions
     children[0] = firstButton
-    rowContent["children"] = children
-    rowView["content"] = rowContent
-    firstRow["view"] = rowView
+    firstRow["children"] = children
     rows[0] = firstRow
     homePage["rows"] = rows
     pages[0] = homePage

--- a/ios/evy/ContentView.swift
+++ b/ios/evy/ContentView.swift
@@ -37,6 +37,7 @@ extension EnvironmentValues {
 }
 
 private let DEFAULT_HOME_FLOW_ID = "f267c629-2594-4770-8cec-d5324ebb4058"
+private let sduiResourceKey = "sdui"
 
 private var HOME_FLOW_ID: String {
   let configuredHomeFlowId = ProcessInfo.processInfo.environment["HOME_FLOW_ID"] ?? ""
@@ -245,7 +246,7 @@ struct ContentView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .evyDataChanged)) { notification in
       guard let notifKey = notification.object as? String,
-        notifKey == "sdui"
+        notifKey == sduiResourceKey
       else { return }
 
       try? loadFlowsFromStore()

--- a/ios/evy/Core/EVY+Preview.swift
+++ b/ios/evy/Core/EVY+Preview.swift
@@ -70,11 +70,8 @@ enum EVYPreviewMockData {
         "end_time": "19:00",
         "timeslot_interval_minutes": 30,
         "label_interval_minutes": 60,
-        "header_format": "{formatDatetime($datum, \"EEE d\")}",
-        "header_subtitle": "{formatDatetime($datum, \"MMM do\")}",
-        "timeslot_format": "{formatDatetime($datum, \"HH:mm\")}",
-        "primary": "{pickup_selection}",
-        "secondary": "{delivery_selection}"
+        "header_format": "EEE d",
+        "timeslot_format": "HH:mm"
     }
     """#
 

--- a/ios/evy/Core/EVY+Preview.swift
+++ b/ios/evy/Core/EVY+Preview.swift
@@ -61,6 +61,10 @@ enum EVYPreviewMockData {
     ]
     """
 
+  static let calendarPreviewSource = "{delivery_selection}"
+  static let calendarPreviewDestination = "{pickup_selection}"
+  static let calendarPreviewSourceVariable = "delivery_selection"
+  static let calendarPreviewDestinationVariable = "pickup_selection"
   static let calendarPickupSelection = "[\"2026-06-03T09:00:00\",\"2026-06-03T09:30:00\"]"
   static let calendarDeliverySelection = "[\"2026-06-03T14:00:00\"]"
   static let calendarContentJSON = #"""

--- a/ios/evy/Core/EVY+QueryParams.swift
+++ b/ios/evy/Core/EVY+QueryParams.swift
@@ -6,6 +6,8 @@
 import Foundation
 
 extension EVY {
+  static let entityIdQueryKey = "id"
+
   static func cacheQueryParams(_ query: [String: [String]], forPageId pageId: String) {
     activeCacheScopeId = pageId
     resolveQueryParams(query)
@@ -15,7 +17,7 @@ extension EVY {
     guard let scopeId = activeCacheScopeId else { return }
 
     for (queryKey, ids) in query {
-      if queryKey == "id",
+      if queryKey == EVY.entityIdQueryKey,
         storeResolvedEntityQueryParam(scopeId: scopeId, queryKey: nil, ids: ids)
       {
         continue

--- a/ios/evy/Data/EVYDatumRowFormatter.swift
+++ b/ios/evy/Data/EVYDatumRowFormatter.swift
@@ -46,15 +46,7 @@ final class EVYDatumRowFormatter {
     return (try? EVY.formatData(json: datum, format: stringValue)) ?? stringValue
   }
 
-  private static func formatDatumReferencesInJSONValue(
-    _ value: Any,
-    datum: EVYJson,
-    path: [String] = []
-  ) -> Any {
-    if path.contains("actions") {
-      return value
-    }
-
+  private static func formatDatumReferencesInJSONValue(_ value: Any, datum: EVYJson) -> Any {
     switch value {
     case let stringValue as String:
       return resolveDatumReferences(in: stringValue, datum: datum)
@@ -62,16 +54,12 @@ final class EVYDatumRowFormatter {
       var formatted: [String: Any] = [:]
       formatted.reserveCapacity(dictionaryValue.count)
       for (key, nestedValue) in dictionaryValue {
-        formatted[key] = formatDatumReferencesInJSONValue(
-          nestedValue,
-          datum: datum,
-          path: path + [key]
-        )
+        formatted[key] = formatDatumReferencesInJSONValue(nestedValue, datum: datum)
       }
       return formatted
     case let arrayValue as [Any]:
       return arrayValue.map { nestedValue in
-        formatDatumReferencesInJSONValue(nestedValue, datum: datum, path: path)
+        formatDatumReferencesInJSONValue(nestedValue, datum: datum)
       }
     default:
       return value
@@ -91,14 +79,12 @@ final class EVYDatumRowFormatter {
       var root = Self.formatDatumReferencesInJSONValue(
         deepCopyJSONValue(rootPrototype),
         datum: datum
-      ) as? [String: Any],
-      let view = root["view"] as? [String: Any],
-      let content = view["content"] as? [String: Any]
+      ) as? [String: Any]
     else {
       throw EVYDatumRowFormattingError.invalidTemplate
     }
     let searchableValues =
-      Self.extractAllStrings(from: content)
+      Self.extractAllStrings(from: root)
       .filter { !$0.isEmpty }
     root["id"] = UUID().uuidString
     let out = try JSONSerialization.data(withJSONObject: root)

--- a/ios/evy/Data/Models/EVYDraft.swift
+++ b/ios/evy/Data/Models/EVYDraft.swift
@@ -84,6 +84,7 @@ enum EVYDraft {
 
   enum Scope {
     static let fallbackUnscoped = "app:unscoped"
+    private static let browseKey = "browse"
 
     static func entityKey(fromScopeId scopeId: String?) -> String? {
       guard let scopeId else { return nil }
@@ -97,7 +98,7 @@ enum EVYDraft {
 
       let flowId = String(trimmedScopeId[..<range.lowerBound])
       let key = String(trimmedScopeId[range.upperBound...])
-      if flowId.isEmpty || key.isEmpty || key == "browse" { return nil }
+      if flowId.isEmpty || key.isEmpty || key == Self.browseKey { return nil }
       return key
     }
   }

--- a/ios/evy/UI/EVYActionRunner.swift
+++ b/ios/evy/UI/EVYActionRunner.swift
@@ -88,7 +88,7 @@ enum EVYActionRunner {
       case "close":
         navigate(.close)
       case "show":
-        if let child = row?.view.content.child {
+        if let child = row?.child {
           show(child)
         }
       case "highlight_required":

--- a/ios/evy/UI/EVYRow.swift
+++ b/ios/evy/UI/EVYRow.swift
@@ -91,7 +91,7 @@ struct EVYRow: View, Identifiable {
   private func rowView(for payload: UI_RowPayload) -> some View {
     switch payload {
     case .button(let v, _, _, _): EVYButtonRow(view: v, action: runActions)
-    case .calendar(let v, _, _, _): EVYCalendarRow(view: v)
+    case .calendar(let v, let s, let d, _): EVYCalendarRow(view: v, source: s, destination: d)
     case .columnContainer(let v, _, _, _): EVYColumnContainerRow(view: v)
     case .dropdown(let v, let s, let d, _): EVYDropdownRow(view: v, source: s, destination: d)
     case .heading(let v, _, _, _): EVYHeadingRow(view: v)

--- a/ios/evy/UI/Rows/Action/EVYButtonRow.swift
+++ b/ios/evy/UI/Rows/Action/EVYButtonRow.swift
@@ -17,7 +17,7 @@ struct EVYButtonRow: View {
   }
 
   var body: some View {
-    EVYButton(label: view.content.label, action: action)
+    EVYButton(label: view.label, action: action)
       .frame(maxWidth: .infinity, alignment: .center)
       .padding(.horizontal, Constants.majorPadding)
       .padding(.top, Constants.minorPadding)
@@ -33,12 +33,8 @@ struct EVYButtonRow: View {
         "type": "Button",
         "source": "",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Preview Action",
-            "label": "Tap me"
-          }
-        }
+        "title": "Preview Action",
+        "label": "Tap me"
       }
       """,
     failureMessage: "Unable to build button row preview"

--- a/ios/evy/UI/Rows/Container/EVYColumnContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYColumnContainerRow.swift
@@ -17,13 +17,13 @@ struct EVYColumnContainerRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
           .padding(.horizontal, Constants.majorPadding)
       }
       HStack(alignment: .top) {
-        ForEach(view.content.children, id: \.id) { child in
+        ForEach(view.children, id: \.id) { child in
           EVYRow(row: child)
         }
       }
@@ -39,39 +39,27 @@ struct EVYColumnContainerRow: View {
         "type": "ColumnContainer",
         "source": "",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Column Container Preview",
-            "children": [
-              {
-                "id": "column-child-1",
-                "type": "Text",
-                "source": "",
-                "actions": [],
-                "view": {
-                  "content": {
-                    "title": "First Child",
-                    "subtitle": "This is the first column item",
-                    "icon": "::star::"
-                  }
-                }
-              },
-              {
-                "id": "column-child-2",
-                "type": "Text",
-                "source": "",
-                "actions": [],
-                "view": {
-                  "content": {
-                    "title": "Second Child",
-                    "subtitle": "This is the second column item",
-                    "icon": ""
-                  }
-                }
-              }
-            ]
+        "title": "Column Container Preview",
+        "children": [
+          {
+            "id": "column-child-1",
+            "type": "Text",
+            "source": "",
+            "actions": [],
+            "title": "First Child",
+            "subtitle": "This is the first column item",
+            "icon": "::star::"
+          },
+          {
+            "id": "column-child-2",
+            "type": "Text",
+            "source": "",
+            "actions": [],
+            "title": "Second Child",
+            "subtitle": "This is the second column item",
+            "icon": ""
           }
-        }
+        ]
       }
       """,
     failureMessage: "Unable to build column container row preview"

--- a/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYListContainerRow.swift
@@ -26,7 +26,7 @@ struct EVYListContainerRow: View {
     self.view = view
     self.source = source
 
-    let childTemplate = view.content.child
+    let childTemplate = view.child
     dynamicRows = EVYState(
       textToWatch: source,
       setter: {
@@ -59,15 +59,15 @@ struct EVYListContainerRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
           .padding(.horizontal, Constants.majorPadding)
       }
       ForEach(dynamicRows.value) { dynamicRow in
         EVYRow(row: dynamicRow.row)
       }
-      ForEach(view.content.children, id: \.id) { child in
+      ForEach(view.children, id: \.id) { child in
         EVYRow(row: child)
       }
     }
@@ -82,39 +82,27 @@ struct EVYListContainerRow: View {
         "type": "ListContainer",
         "source": "{items}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "List Container Preview",
-            "child": {
-              "id": "list-child-template",
-              "type": "Text",
-              "source": "",
-              "actions": [],
-              "view": {
-                "content": {
-                  "title": "{$datum.title}",
-                  "subtitle": "",
-                  "icon": ""
-                }
-              }
-            },
-            "children": [
-              {
-                "id": "list-extra-child",
-                "type": "Text",
-                "source": "",
-                "actions": [],
-                "view": {
-                  "content": {
-                    "title": "Extra row",
-                    "subtitle": "Static child below dynamic rows",
-                    "icon": ""
-                  }
-                }
-              }
-            ]
+        "title": "List Container Preview",
+        "child": {
+          "id": "list-child-template",
+          "type": "Text",
+          "source": "",
+          "actions": [],
+          "title": "{$datum.title}",
+          "subtitle": "",
+          "icon": ""
+        },
+        "children": [
+          {
+            "id": "list-extra-child",
+            "type": "Text",
+            "source": "",
+            "actions": [],
+            "title": "Extra row",
+            "subtitle": "Static child below dynamic rows",
+            "icon": ""
           }
-        }
+        ]
       }
       """,
     failureMessage: "Unable to build list container row preview"

--- a/ios/evy/UI/Rows/Container/EVYSelectSegmentContainerRow.swift
+++ b/ios/evy/UI/Rows/Container/EVYSelectSegmentContainerRow.swift
@@ -18,13 +18,13 @@ struct EVYSelectSegmentContainerRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
           .padding(.horizontal, Constants.majorPadding)
       }
       Picker("", selection: $selected) {
-        ForEach(Array(view.content.segments.enumerated()), id: \.offset) { index, segment in
+        ForEach(Array(view.segments.enumerated()), id: \.offset) { index, segment in
           Text(segment).tag(index)
         }
       }
@@ -32,8 +32,8 @@ struct EVYSelectSegmentContainerRow: View {
       .padding(.horizontal, Constants.majorPadding)
       .padding(.bottom, Constants.majorPadding)
 
-      if selected < view.content.children.count {
-        EVYRow(row: view.content.children[selected])
+      if selected < view.children.count {
+        EVYRow(row: view.children[selected])
       }
     }
   }
@@ -47,40 +47,28 @@ struct EVYSelectSegmentContainerRow: View {
         "type": "SelectSegmentContainer",
         "source": "",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Select Segment Preview",
-            "segments": ["Tab One", "Tab Two"],
-            "children": [
-              {
-                "id": "segment-tab-1",
-                "type": "Text",
-                "source": "",
-                "actions": [],
-                "view": {
-                  "content": {
-                    "title": "First Tab Content",
-                    "subtitle": "Content for the first tab",
-                    "icon": ""
-                  }
-                }
-              },
-              {
-                "id": "segment-tab-2",
-                "type": "Text",
-                "source": "",
-                "actions": [],
-                "view": {
-                  "content": {
-                    "title": "Second Tab Content",
-                    "subtitle": "Content for the second tab",
-                    "icon": ""
-                  }
-                }
-              }
-            ]
+        "title": "Select Segment Preview",
+        "segments": ["Tab One", "Tab Two"],
+        "children": [
+          {
+            "id": "segment-tab-1",
+            "type": "Text",
+            "source": "",
+            "actions": [],
+            "title": "First Tab Content",
+            "subtitle": "Content for the first tab",
+            "icon": ""
+          },
+          {
+            "id": "segment-tab-2",
+            "type": "Text",
+            "source": "",
+            "actions": [],
+            "title": "Second Tab Content",
+            "subtitle": "Content for the second tab",
+            "icon": ""
           }
-        }
+        ]
       }
       """,
     failureMessage: "Unable to build select segment row preview"

--- a/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
@@ -8,9 +8,13 @@ import SwiftUI
 struct EVYCalendarRow: View {
 
   private let view: CalendarRowViewData
+  private let source: String
+  private let destination: String
 
-  init(view: CalendarRowViewData) {
+  init(view: CalendarRowViewData, source: String, destination: String) {
     self.view = view
+    self.source = source
+    self.destination = destination
   }
 
   var body: some View {
@@ -19,7 +23,7 @@ struct EVYCalendarRow: View {
         EVYTextView(view.content.title)
           .padding(.vertical, Constants.padding)
       }
-      EVYCalendar(content: view.content)
+      EVYCalendar(content: view.content, source: source, destination: destination)
     }
     .padding(.horizontal, Constants.majorPadding)
   }
@@ -59,8 +63,8 @@ private struct EVYCalendarRowPreview: View {
       {
         "id": "preview-calendar-row",
         "type": "Calendar",
-        "source": "",
-        "destination": "",
+        "source": "{delivery_selection}",
+        "destination": "{pickup_selection}",
         "actions": [],
         "view": {
           "content": \(EVYPreviewMockData.calendarContentJSON)

--- a/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYCalendarRow.swift
@@ -19,11 +19,11 @@ struct EVYCalendarRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
-      EVYCalendar(content: view.content, source: source, destination: destination)
+      EVYCalendar(content: view, source: source, destination: destination)
     }
     .padding(.horizontal, Constants.majorPadding)
   }
@@ -43,12 +43,12 @@ private struct EVYCalendarRowPreview: View {
     let primaryData = EVYPreviewMockData.calendarPickupSelection.data(using: .utf8)
     let secondaryData = EVYPreviewMockData.calendarDeliverySelection.data(using: .utf8)
     EVY.ensureDraftExists(
-      variableName: "pickup_selection",
+      variableName: EVYPreviewMockData.calendarPreviewDestinationVariable,
       initialData: primaryData,
       scopeId: previewScopeId
     )
     EVY.ensureDraftExists(
-      variableName: "delivery_selection",
+      variableName: EVYPreviewMockData.calendarPreviewSourceVariable,
       initialData: secondaryData,
       scopeId: previewScopeId
     )
@@ -63,12 +63,16 @@ private struct EVYCalendarRowPreview: View {
       {
         "id": "preview-calendar-row",
         "type": "Calendar",
-        "source": "{delivery_selection}",
-        "destination": "{pickup_selection}",
+        "source": "\(EVYPreviewMockData.calendarPreviewSource)",
+        "destination": "\(EVYPreviewMockData.calendarPreviewDestination)",
         "actions": [],
-        "view": {
-          "content": \(EVYPreviewMockData.calendarContentJSON)
-        }
+        "title": "",
+        "start_time": "07:00",
+        "end_time": "19:00",
+        "timeslot_interval_minutes": 30,
+        "label_interval_minutes": 60,
+        "header_format": "EEE d",
+        "timeslot_format": "HH:mm"
       }
       """
     return EVYPreviewMockData.decodeRow(from: json)

--- a/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYDropdownRow.swift
@@ -21,15 +21,15 @@ struct EVYDropdownRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYDropdown(
-        title: view.content.title,
-        placeholder: view.content.placeholder,
+        title: view.title,
+        placeholder: view.placeholder,
         data: source,
-        format: view.content.format,
+        format: view.format,
         destination: destination
       )
     }
@@ -46,13 +46,9 @@ struct EVYDropdownRow: View {
         "source": "{conditions}",
         "destination": "{item.condition}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Condition",
-            "format": "{$datum.value}",
-            "placeholder": "Select a condition"
-          }
-        }
+        "title": "Condition",
+        "format": "{$datum.value}",
+        "placeholder": "Select a condition"
       }
       """,
     failureMessage: "Unable to build dropdown row preview"

--- a/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInlinePickerRow.swift
@@ -21,14 +21,14 @@ struct EVYInlinePickerRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYInlinePicker(
-        title: view.content.title,
+        title: view.title,
         data: source,
-        format: view.content.format,
+        format: view.format,
         destination: destination
       )
     }
@@ -45,12 +45,8 @@ struct EVYInlinePickerRow: View {
         "source": "{durations}",
         "destination": "{item.duration}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Duration",
-            "format": "{$datum.value}"
-          }
-        }
+        "title": "Duration",
+        "format": "{$datum.value}"
       }
       """,
     failureMessage: "Unable to build inline picker row preview"

--- a/ios/evy/UI/Rows/Edit/EVYInputRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYInputRow.swift
@@ -21,14 +21,14 @@ struct EVYInputRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYTextField(
-        input: view.content.value,
+        input: view.value,
         destination: destination,
-        placeholder: view.content.placeholder,
+        placeholder: view.placeholder,
         isInteractive: isInteractive
       )
     }
@@ -45,13 +45,9 @@ struct EVYInputRow: View {
         "source": "",
         "destination": "{item.title}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Item title",
-            "value": "{item.title}",
-            "placeholder": "Enter a title"
-          }
-        }
+        "title": "Item title",
+        "value": "{item.title}",
+        "placeholder": "Enter a title"
       }
       """,
     failureMessage: "Unable to build input row preview"

--- a/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSearchRow.swift
@@ -19,14 +19,14 @@ struct EVYSearchRow: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYSearch(
         source: source,
-        placeholder: view.content.placeholder,
-        resultTemplate: view.content.child
+        placeholder: view.placeholder,
+        resultTemplate: view.child
       )
     }
     .padding(.horizontal, Constants.majorPadding)
@@ -73,25 +73,17 @@ private struct EVYSearchRowPreview: View {
         "source": "{items}",
         "destination": "",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Search preview",
-            "placeholder": "Search items...",
-            "child": {
-              "id": "preview-search-result-template",
-              "type": "Text",
-              "source": "",
-              "destination": "",
-              "actions": [],
-              "view": {
-                "content": {
-                  "title": "{$datum.title}",
-                  "subtitle": "{$datum.category}",
-                  "icon": "::search::"
-                }
-              }
-            }
-          }
+        "title": "Search preview",
+        "placeholder": "Search items...",
+        "child": {
+          "id": "preview-search-result-template",
+          "type": "Text",
+          "source": "",
+          "destination": "",
+          "actions": [],
+          "title": "{$datum.title}",
+          "subtitle": "{$datum.category}",
+          "icon": "::search::"
         }
       }
       """

--- a/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYSelectPhotoRow.swift
@@ -18,11 +18,11 @@ struct EVYSelectPhotoRow: View {
 
   var body: some View {
     EVYSelectPhoto(
-      title: view.content.title,
-      subtitle: view.content.subtitle,
-      icon: view.content.icon,
-      content: view.content.content,
-      data: view.content.photos,
+      title: view.title,
+      subtitle: view.subtitle,
+      icon: view.icon,
+      content: view.content,
+      data: view.photos,
       destination: destination
     )
     .padding(.horizontal, Constants.majorPadding)
@@ -38,15 +38,11 @@ struct EVYSelectPhotoRow: View {
         "source": "",
         "destination": "{item.photo_ids}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Photos",
-            "icon": "::image-plus::",
-            "subtitle": "Add photos of your item",
-            "content": "Add up to 10 photos",
-            "photos": "{item.photo_ids}"
-          }
-        }
+        "title": "Photos",
+        "icon": "::image-plus::",
+        "subtitle": "Add photos of your item",
+        "content": "Add up to 10 photos",
+        "photos": "{item.photo_ids}"
       }
       """,
     failureMessage: "Unable to build select photo row preview"

--- a/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextAreaRow.swift
@@ -19,14 +19,14 @@ struct EVYTextAreaRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYTextField(
-        input: view.content.value,
+        input: view.value,
         destination: destination,
-        placeholder: view.content.placeholder,
+        placeholder: view.placeholder,
         multiLine: true
       )
     }
@@ -43,13 +43,9 @@ struct EVYTextAreaRow: View {
         "source": "",
         "destination": "{item.description}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Description",
-            "value": "{item.description}",
-            "placeholder": "Describe your item in detail"
-          }
-        }
+        "title": "Description",
+        "value": "{item.description}",
+        "placeholder": "Describe your item in detail"
       }
       """,
     failureMessage: "Unable to build text area row preview"

--- a/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTextSelectRow.swift
@@ -31,7 +31,7 @@ struct EVYTextSelectRow: View {
     let temporaryScopeId = EVYDraft.createMergeScopeId(flowId: "temporary", entityKey: temporaryId)
 
     guard
-      (try? EVY.updateValue(view.content.text, at: temporaryId, scopeId: temporaryScopeId)) != nil,
+      (try? EVY.updateValue(view.text, at: temporaryId, scopeId: temporaryScopeId)) != nil,
       let binding = try? EVY.draftStore.binding(
         fromParsedProps: temporaryId, scopeId: temporaryScopeId),
       let draft = EVY.draftStore.draftIfPresent(binding: binding),
@@ -42,8 +42,8 @@ struct EVYTextSelectRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYSelectItem(
@@ -69,12 +69,8 @@ struct EVYTextSelectRow: View {
         "source": "",
         "destination": "{item.condition}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Selling reason",
-            "text": "reason-1"
-          }
-        }
+        "title": "Selling reason",
+        "text": "reason-1"
       }
       """,
     failureMessage: "Unable to build text select row preview"

--- a/ios/evy/UI/Rows/Edit/EVYTimeslotPickerRow.swift
+++ b/ios/evy/UI/Rows/Edit/EVYTimeslotPickerRow.swift
@@ -17,11 +17,11 @@ struct EVYTimeslotPickerRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
-      EVYTimeslotPicker(content: view.content, source: source)
+      EVYTimeslotPicker(content: view, source: source)
     }
     .padding(.horizontal, Constants.majorPadding)
   }
@@ -57,9 +57,13 @@ private struct EVYTimeslotPickerRowPreview: View {
         "source": "{pickup_selection}",
         "destination": "",
         "actions": [],
-        "view": {
-          "content": \(EVYPreviewMockData.calendarContentJSON)
-        }
+        "title": "",
+        "start_time": "07:00",
+        "end_time": "19:00",
+        "timeslot_interval_minutes": 30,
+        "label_interval_minutes": 60,
+        "header_format": "EEE d",
+        "timeslot_format": "HH:mm"
       }
       """
     return EVYPreviewMockData.decodeRow(from: json)

--- a/ios/evy/UI/Rows/View/EVYHeadingRow.swift
+++ b/ios/evy/UI/Rows/View/EVYHeadingRow.swift
@@ -9,7 +9,7 @@ struct EVYHeadingRow: View {
   }
 
   var body: some View {
-    let content = view.content
+    let content = view
 
     HStack(alignment: .center, spacing: 8) {
       VStack(alignment: .leading) {

--- a/ios/evy/UI/Rows/View/EVYInputListRow.swift
+++ b/ios/evy/UI/Rows/View/EVYInputListRow.swift
@@ -19,14 +19,14 @@ struct EVYInputListRow: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYInputList(
         data: source,
-        format: view.content.format,
-        placeholder: view.content.placeholder
+        format: view.format,
+        placeholder: view.placeholder
       )
     }
     .padding(.horizontal, Constants.majorPadding)
@@ -41,13 +41,9 @@ struct EVYInputListRow: View {
         "type": "InputList",
         "source": "{tags}",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Tags",
-            "format": "{$datum}",
-            "placeholder": "Add tags to improve search"
-          }
-        }
+        "title": "Tags",
+        "format": "{$datum}",
+        "placeholder": "Add tags to improve search"
       }
       """,
     failureMessage: "Unable to build input list row preview"

--- a/ios/evy/UI/Rows/View/EVYListItemRow.swift
+++ b/ios/evy/UI/Rows/View/EVYListItemRow.swift
@@ -14,7 +14,7 @@ struct EVYListItemRow: View {
   }
 
   private var imageId: String {
-    (try? EVY.getDataFromText(view.content.image).toString()) ?? view.content.image
+    (try? EVY.getDataFromText(view.image).toString()) ?? view.image
   }
 
   var body: some View {
@@ -24,13 +24,13 @@ struct EVYListItemRow: View {
         .clipShape(RoundedRectangle(cornerRadius: 4))
 
       VStack(alignment: .leading, spacing: 2) {
-        if !view.content.title.isEmpty {
-          EVYTextView(view.content.title)
+        if !view.title.isEmpty {
+          EVYTextView(view.title)
             .lineLimit(1)
             .truncationMode(.tail)
         }
-        if !view.content.subtitle.isEmpty {
-          EVYTextView(view.content.subtitle, style: .info)
+        if !view.subtitle.isEmpty {
+          EVYTextView(view.subtitle, style: .info)
             .lineLimit(2)
             .truncationMode(.tail)
         }
@@ -50,13 +50,9 @@ struct EVYListItemRow: View {
         "destination": "",
         "actions": [],
         "visible": "true",
-        "view": {
-          "content": {
-            "title": "Red mountain bike",
-            "subtitle": "Great condition · $120",
-            "image": ""
-          }
-        }
+        "title": "Red mountain bike",
+        "subtitle": "Great condition · $120",
+        "image": ""
       }
       """,
     failureMessage: "Unable to build list item row preview"

--- a/ios/evy/UI/Rows/View/EVYMapRow.swift
+++ b/ios/evy/UI/Rows/View/EVYMapRow.swift
@@ -14,18 +14,18 @@ struct EVYMapRow: View {
   }
 
   private var resolvedLocation: EVYJson {
-    (try? EVY.getDataFromText(view.content.location)) ?? .string(view.content.location)
+    (try? EVY.getDataFromText(view.location)) ?? .string(view.location)
   }
 
   var body: some View {
     VStack(alignment: .leading, spacing: Constants.padding) {
-      if !view.content.title.isEmpty {
-        EVYTextView(view.content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .padding(.vertical, Constants.padding)
       }
       EVYMap(location: resolvedLocation)
-      if !view.content.subtitle.isEmpty {
-        EVYTextView(view.content.subtitle, style: .info)
+      if !view.subtitle.isEmpty {
+        EVYTextView(view.subtitle, style: .info)
           .frame(maxWidth: .infinity, alignment: .leading)
       }
     }
@@ -42,13 +42,9 @@ struct EVYMapRow: View {
         "source": "",
         "destination": "",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "Pickup location",
-            "location": "{address.location}",
-            "subtitle": "Meet near the main entrance"
-          }
-        }
+        "title": "Pickup location",
+        "location": "{address.location}",
+        "subtitle": "Meet near the main entrance"
       }
       """,
     failureMessage: "Unable to build map row preview"

--- a/ios/evy/UI/Rows/View/EVYPhotoGalleryRow.swift
+++ b/ios/evy/UI/Rows/View/EVYPhotoGalleryRow.swift
@@ -24,7 +24,7 @@ struct EVYPhotoGalleryRow: View {
   }
 
   var body: some View {
-    EVYPhotoGallery(title: view.content.title, imageIds: imageIds)
+    EVYPhotoGallery(title: view.title, imageIds: imageIds)
   }
 }
 
@@ -37,7 +37,7 @@ struct EVYPhotoGalleryRow: View {
         "source": "",
         "destination": "",
         "actions": [],
-        "view": { "content": { "title": "Photo Gallery" } }
+        "title": "Photo Gallery"
       }
       """,
     failureMessage: "Unable to build photo gallery row preview"

--- a/ios/evy/UI/Rows/View/EVYTextActionRow.swift
+++ b/ios/evy/UI/Rows/View/EVYTextActionRow.swift
@@ -14,7 +14,7 @@ struct EVYTextActionRow: View {
   }
 
   var body: some View {
-    let content = view.content
+    let content = view
 
     HStack(alignment: .center, spacing: 8) {
       VStack(alignment: .leading) {
@@ -49,13 +49,9 @@ struct EVYTextActionRow: View {
         "destination": "",
         "actions": [],
         "visible": "true",
-        "view": {
-          "content": {
-            "title": "Pickup location",
-            "subtitle": "123 Main St, Sydney",
-            "action": "Change"
-          }
-        }
+        "title": "Pickup location",
+        "subtitle": "123 Main St, Sydney",
+        "action": "Change"
       }
       """,
     failureMessage: "Unable to build text action row preview"

--- a/ios/evy/UI/Rows/View/EVYTextExpandRow.swift
+++ b/ios/evy/UI/Rows/View/EVYTextExpandRow.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct EVYTextExpandRow: View {
 
   private let view: TextExpandRowViewData
+  private let collapsedLineCount = 3
 
   @State private var expanded = false
   @State private var canExpand = false
@@ -16,30 +17,24 @@ struct EVYTextExpandRow: View {
     self.view = view
   }
 
-  private var maxLines: Int {
-    Int(view.max_lines) ?? 3
-  }
-
   var body: some View {
-    let content = view.content
-
     VStack(alignment: .leading, spacing: 4) {
-      if !content.title.isEmpty {
-        EVYTextView(content.title)
+      if !view.title.isEmpty {
+        EVYTextView(view.title)
           .frame(maxWidth: .infinity, alignment: .leading)
           .lineLimit(1)
           .truncationMode(.tail)
       }
 
-      if !content.text.isEmpty {
-        EVYTextView(content.text)
+      if !view.text.isEmpty {
+        EVYTextView(view.text)
           .frame(maxWidth: .infinity, alignment: .leading)
-          .lineLimit(expanded ? nil : maxLines)
+          .lineLimit(expanded ? nil : collapsedLineCount)
           .truncationMode(.tail)
           .background {
             if !expanded {
               ViewThatFits(in: .vertical) {
-                EVYTextView(content.text)
+                EVYTextView(view.text)
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .hidden()
                 Color.clear.onAppear {
@@ -50,11 +45,11 @@ struct EVYTextExpandRow: View {
           }
       }
 
-      if canExpand && !expanded && !content.expandLabel.isEmpty {
+      if canExpand && !expanded && !view.expandLabel.isEmpty {
         Button {
           expanded = true
         } label: {
-          EVYTextView(content.expandLabel, style: .action)
+          EVYTextView(view.expandLabel, style: .action)
         }
         .buttonStyle(.plain)
       }
@@ -73,14 +68,9 @@ struct EVYTextExpandRow: View {
         "destination": "",
         "actions": [],
         "visible": "true",
-        "view": {
-          "content": {
-            "title": "About this item",
-            "text": "This is a longer description that may be truncated when it exceeds the maximum number of lines configured for this row.",
-            "expandLabel": "Read more"
-          },
-          "max_lines": "3"
-        }
+        "title": "About this item",
+        "text": "This is a longer description that may be truncated when it exceeds the maximum number of lines configured for this row.",
+        "expandLabel": "Read more"
       }
       """,
     failureMessage: "Unable to build text expand row preview"

--- a/ios/evy/UI/Rows/View/EVYTextRow.swift
+++ b/ios/evy/UI/Rows/View/EVYTextRow.swift
@@ -16,7 +16,7 @@ struct EVYTextRow: View {
   }
 
   var body: some View {
-    let content = view.content
+    let content = view
 
     HStack(alignment: .center, spacing: 8) {
       VStack(alignment: .leading) {

--- a/ios/evy/UI/Views/EVYCalendar.swift
+++ b/ios/evy/UI/Views/EVYCalendar.swift
@@ -88,14 +88,14 @@ struct EVYCalendarViewState: Equatable {
 }
 
 struct EVYCalendar: View {
-  private let content: CalendarRowContent
+  private let content: CalendarRowViewData
   private let source: String
   private let destination: String
   private let calendarState: EVYState<EVYCalendarViewState>
 
   @State private var scrollOffset = CGPoint.zero
 
-  init(content: CalendarRowContent, source: String, destination: String) {
+  init(content: CalendarRowViewData, source: String, destination: String) {
     self.content = content
     self.source = source
     self.destination = destination
@@ -106,25 +106,15 @@ struct EVYCalendar: View {
   }
 
   private static func buildCalendarData(
-    content: CalendarRowContent,
+    content: CalendarRowViewData,
     source: String,
     destination: String
   ) -> EVYCalendarViewState {
     let primarySelections = EVYDatetime.readTimeslots(destination)
     let secondarySelections = EVYDatetime.readTimeslots(source)
 
-    let intervalMinutes =
-      content.timeslot_interval_minutes > 0 ? content.timeslot_interval_minutes : 30
-    let labelIntervalMinutes =
-      content.label_interval_minutes > 0 ? content.label_interval_minutes : 60
-
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: content.start_time,
-      endTime: content.end_time,
-      intervalMinutes: intervalMinutes,
-      labelIntervalMinutes: labelIntervalMinutes,
-      headerFormat: content.header_format,
-      timeslotFormat: content.timeslot_format,
+      row: content,
       primarySelections: primarySelections,
       secondarySelections: secondarySelections
     )
@@ -284,12 +274,12 @@ private struct EVYCalendarPreview: View {
     let previewScopeId = EVYDraft.createMergeScopeId(flowId: "preview", entityKey: "item")
     EVY.draftStore.activeScopeId = previewScopeId
     EVY.ensureDraftExists(
-      variableName: "pickup_selection",
+      variableName: EVYPreviewMockData.calendarPreviewDestinationVariable,
       initialData: EVYPreviewMockData.calendarPickupSelection.data(using: .utf8),
       scopeId: previewScopeId
     )
     EVY.ensureDraftExists(
-      variableName: "delivery_selection",
+      variableName: EVYPreviewMockData.calendarPreviewSourceVariable,
       initialData: EVYPreviewMockData.calendarDeliverySelection.data(using: .utf8),
       scopeId: previewScopeId
     )
@@ -297,10 +287,12 @@ private struct EVYCalendarPreview: View {
 
   var body: some View {
     if let data = EVYPreviewMockData.calendarContentJSON.data(using: .utf8),
-      let content = try? JSONDecoder().decode(CalendarRowContent.self, from: data)
+      let content = try? JSONDecoder().decode(CalendarRowViewData.self, from: data)
     {
       EVYCalendar(
-        content: content, source: "{delivery_selection}", destination: "{pickup_selection}")
+        content: content,
+        source: EVYPreviewMockData.calendarPreviewSource,
+        destination: EVYPreviewMockData.calendarPreviewDestination)
     } else {
       Text("Unable to build calendar preview")
     }

--- a/ios/evy/UI/Views/EVYCalendar.swift
+++ b/ios/evy/UI/Views/EVYCalendar.swift
@@ -89,21 +89,29 @@ struct EVYCalendarViewState: Equatable {
 
 struct EVYCalendar: View {
   private let content: CalendarRowContent
+  private let source: String
+  private let destination: String
   private let calendarState: EVYState<EVYCalendarViewState>
 
   @State private var scrollOffset = CGPoint.zero
 
-  init(content: CalendarRowContent) {
+  init(content: CalendarRowContent, source: String, destination: String) {
     self.content = content
+    self.source = source
+    self.destination = destination
     calendarState = EVYState(
-      watches: [content.primary, content.secondary],
-      setter: { Self.buildCalendarData(content: content) }
+      watches: [destination, source],
+      setter: { Self.buildCalendarData(content: content, source: source, destination: destination) }
     )
   }
 
-  private static func buildCalendarData(content: CalendarRowContent) -> EVYCalendarViewState {
-    let primarySelections = EVYDatetime.readTimeslots(content.primary)
-    let secondarySelections = EVYDatetime.readTimeslots(content.secondary)
+  private static func buildCalendarData(
+    content: CalendarRowContent,
+    source: String,
+    destination: String
+  ) -> EVYCalendarViewState {
+    let primarySelections = EVYDatetime.readTimeslots(destination)
+    let secondarySelections = EVYDatetime.readTimeslots(source)
 
     let intervalMinutes =
       content.timeslot_interval_minutes > 0 ? content.timeslot_interval_minutes : 30
@@ -221,12 +229,12 @@ struct EVYCalendar: View {
   }
 
   private func readPrimarySelections() -> [String] {
-    EVYDatetime.readTimeslots(content.primary)
+    EVYDatetime.readTimeslots(destination)
   }
 
   private func writePrimarySelections(_ selections: [String]) {
     guard let data = try? JSONEncoder().encode(selections) else { return }
-    try? EVY.updateData(data, at: content.primary)
+    try? EVY.updateData(data, at: destination)
   }
 
   var body: some View {
@@ -291,7 +299,8 @@ private struct EVYCalendarPreview: View {
     if let data = EVYPreviewMockData.calendarContentJSON.data(using: .utf8),
       let content = try? JSONDecoder().decode(CalendarRowContent.self, from: data)
     {
-      EVYCalendar(content: content)
+      EVYCalendar(
+        content: content, source: "{delivery_selection}", destination: "{pickup_selection}")
     } else {
       Text("Unable to build calendar preview")
     }

--- a/ios/evy/UI/Views/EVYSearch.swift
+++ b/ios/evy/UI/Views/EVYSearch.swift
@@ -136,13 +136,9 @@ private struct EVYSearchPreview: View {
         "source": "",
         "destination": "",
         "actions": [],
-        "view": {
-          "content": {
-            "title": "{$datum.title}",
-            "subtitle": "{$datum.category}",
-            "icon": ""
-          }
-        }
+        "title": "{$datum.title}",
+        "subtitle": "{$datum.category}",
+        "icon": ""
       }
       """
 

--- a/ios/evy/UI/Views/EVYTimeslotPicker.swift
+++ b/ios/evy/UI/Views/EVYTimeslotPicker.swift
@@ -59,7 +59,7 @@ struct EVYTimeslotPicker: View {
   @State private var selectedGroupIndex: Int = 0
   @State private var tabViewHeight: CGFloat = 0
 
-  init(content: TimeslotPickerRowContent, source: String) {
+  init(content: TimeslotPickerRowViewData, source: String) {
     timeslotDates = EVYState(
       watches: [source],
       setter: { Self.buildDates(content: content, source: source) }
@@ -68,12 +68,10 @@ struct EVYTimeslotPicker: View {
 
   @MainActor
   private static func buildDates(
-    content: TimeslotPickerRowContent, source: String
+    content: TimeslotPickerRowViewData, source: String
   ) -> [EVYTimeslotDate] {
     EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: content.header_format,
-      headerSubtitle: content.header_subtitle,
-      timeslotFormat: content.timeslot_format,
+      row: content,
       selections: EVYDatetime.readTimeslots(source)
     )
   }
@@ -163,7 +161,7 @@ private struct EVYTimeslotPickerPreview: View {
 
   var body: some View {
     if let data = EVYPreviewMockData.calendarContentJSON.data(using: .utf8),
-      let content = try? JSONDecoder().decode(TimeslotPickerRowContent.self, from: data)
+      let content = try? JSONDecoder().decode(TimeslotPickerRowViewData.self, from: data)
     {
       EVYTimeslotPicker(content: content, source: "{pickup_selection}")
     }

--- a/ios/evy/Utils/EVYDatetime.swift
+++ b/ios/evy/Utils/EVYDatetime.swift
@@ -8,9 +8,7 @@ import Foundation
 @MainActor
 enum EVYDatetime {
   static func buildTimeslotPickerDates(
-    headerFormat: String,
-    headerSubtitle: String,
-    timeslotFormat: String,
+    row: TimeslotPickerRowViewData,
     selections: [String]
   ) -> [EVYTimeslotDate] {
     guard !selections.isEmpty else { return [] }
@@ -29,10 +27,10 @@ enum EVYDatetime {
       let dateTimes = (dateToDateTimes[dateStr] ?? []).sorted()
       guard let firstDateTime = dateTimes.first else { return nil }
       return EVYTimeslotDate(
-        header: format(firstDateTime, format: headerFormat),
-        subtitle: format(firstDateTime, format: headerSubtitle),
+        header: format(firstDateTime, format: row.header_format),
+        subtitle: format(firstDateTime, format: row.header_subtitle),
         timeslots: dateTimes.map {
-          EVYTimeslot(timeslot: format($0, format: timeslotFormat), available: true)
+          EVYTimeslot(timeslot: format($0, format: row.timeslot_format), available: true)
         }
       )
     }
@@ -43,6 +41,7 @@ enum EVYDatetime {
   }
 
   static func formatCalendarValue(_ value: String, patternOrExpression: String) -> String {
+    // TODO: remove after migration
     if patternOrExpression.contains("$datum") {
       return format(value, format: patternOrExpression)
     }
@@ -61,19 +60,15 @@ enum EVYDatetime {
   }
 
   static func buildCalendarSlots(
-    startTime: String,
-    endTime: String,
-    intervalMinutes: Int,
-    labelIntervalMinutes: Int,
-    headerFormat: String,
-    timeslotFormat: String,
+    row: CalendarRowViewData,
     primarySelections: [String],
     secondarySelections: [String]
   ) -> [EVYCalendarSlot] {
-    guard intervalMinutes > 0 else { return [] }
+    let intervalMinutes = row.timeslot_interval_minutes > 0 ? row.timeslot_interval_minutes : 30
+    let labelIntervalMinutes = row.label_interval_minutes > 0 ? row.label_interval_minutes : 60
 
-    let startParts = startTime.split(separator: ":").compactMap { Int($0) }
-    let endParts = endTime.split(separator: ":").compactMap { Int($0) }
+    let startParts = row.start_time.split(separator: ":").compactMap { Int($0) }
+    let endParts = row.end_time.split(separator: ":").compactMap { Int($0) }
     guard startParts.count >= 2, endParts.count >= 2 else { return [] }
 
     let startMinutes = startParts[0] * 60 + startParts[1]
@@ -112,7 +107,8 @@ enum EVYDatetime {
     var slots: [EVYCalendarSlot] = []
 
     for (x, dateStr) in uniqueDates.enumerated() {
-      let header = formatCalendarValue("\(dateStr)T00:00:00", patternOrExpression: headerFormat)
+      let header = formatCalendarValue(
+        "\(dateStr)T00:00:00", patternOrExpression: row.header_format)
 
       for y in 0..<numSlots {
         let slotTotalMinutes = startMinutes + y * intervalMinutes
@@ -124,7 +120,7 @@ enum EVYDatetime {
         let elapsedMinutes = y * intervalMinutes
         let timeLabel: String
         if labelIntervalMinutes > 0 && elapsedMinutes % labelIntervalMinutes == 0 {
-          timeLabel = formatCalendarValue(dateTimeISO, patternOrExpression: timeslotFormat)
+          timeLabel = formatCalendarValue(dateTimeISO, patternOrExpression: row.timeslot_format)
         } else {
           timeLabel = ""
         }

--- a/ios/evy/Utils/EVYDatetime.swift
+++ b/ios/evy/Utils/EVYDatetime.swift
@@ -42,6 +42,14 @@ enum EVYDatetime {
     (try? EVY.formatDataOrToString(json: .string(value), format: format)) ?? value
   }
 
+  static func formatCalendarValue(_ value: String, patternOrExpression: String) -> String {
+    if patternOrExpression.contains("$datum") {
+      return format(value, format: patternOrExpression)
+    }
+    let expression = "{formatDatetime($datum, \"\(patternOrExpression)\")}"
+    return format(value, format: expression)
+  }
+
   static func readTimeslots(_ source: String) -> [String] {
     if let json = try? EVY.getDataFromText(source),
       let data = json.toString().data(using: .utf8)
@@ -104,7 +112,7 @@ enum EVYDatetime {
     var slots: [EVYCalendarSlot] = []
 
     for (x, dateStr) in uniqueDates.enumerated() {
-      let header = format("\(dateStr)T00:00:00", format: headerFormat)
+      let header = formatCalendarValue("\(dateStr)T00:00:00", patternOrExpression: headerFormat)
 
       for y in 0..<numSlots {
         let slotTotalMinutes = startMinutes + y * intervalMinutes
@@ -116,7 +124,7 @@ enum EVYDatetime {
         let elapsedMinutes = y * intervalMinutes
         let timeLabel: String
         if labelIntervalMinutes > 0 && elapsedMinutes % labelIntervalMinutes == 0 {
-          timeLabel = format(dateTimeISO, format: timeslotFormat)
+          timeLabel = formatCalendarValue(dateTimeISO, patternOrExpression: timeslotFormat)
         } else {
           timeLabel = ""
         }
@@ -143,7 +151,8 @@ enum EVYDatetime {
     format formatPattern: String
   ) -> String {
     let timeWithSeconds = timeString.count == 5 ? "\(timeString):00" : timeString
-    return format("\(dateString)T\(timeWithSeconds)", format: formatPattern)
+    return formatCalendarValue(
+      "\(dateString)T\(timeWithSeconds)", patternOrExpression: formatPattern)
   }
 
   private static func localCalendarDayStart(for date: Date) -> Date {

--- a/ios/evy/Utils/forEachRow.swift
+++ b/ios/evy/Utils/forEachRow.swift
@@ -16,10 +16,10 @@ func forEachRow(in page: UI_Page, visitor: (UI_Row) -> Void) {
 
 private func visit(_ row: UI_Row, visitor: (UI_Row) -> Void) {
   visitor(row)
-  for child in row.view.content.children ?? [] {
+  for child in row.children ?? [] {
     visit(child, visitor: visitor)
   }
-  if let child = row.view.content.child {
+  if let child = row.child {
     visit(child, visitor: visitor)
   }
 }

--- a/ios/evyTests/ContentViewTests.swift
+++ b/ios/evyTests/ContentViewTests.swift
@@ -66,27 +66,20 @@ final class ContentViewTests: XCTestCase {
                 "type": "Button",
                 "source": "",
                 "destination": "",
-                "view": [
-                  "content": [
-                    "title": "",
-                    "label": "Parent button",
-                    "child": [
-                      "id": "text-child",
-                      "type": "Text",
-                      "source": "",
-                      "destination": "",
-                      "view": [
-                        "content": [
-                          "title": "Child title",
-                          "text": "Child body",
-                        ],
-                        "max_lines": "",
-                      ],
-                      "actions": [],
-                    ],
-                  ]
+                "title": "",
+                "label": "Parent button",
+                "child": [
+                  "id": "text-child",
+                  "type": "Text",
+                  "source": "",
+                  "destination": "",
+                  "title": "Child title",
+                  "text": "Child body",
+                  "actions": [],
+                  "visible": "true",
                 ],
                 "actions": [],
+                "visible": "true",
               ]
             ],
           ]
@@ -98,7 +91,7 @@ final class ContentViewTests: XCTestCase {
     let flows = try JSONDecoder().decode([UI_Flow].self, from: data)
     let rootRow = try XCTUnwrap(flows.first?.pages.first?.rows.first)
 
-    XCTAssertEqual(rootRow.view.content.child?.id, "text-child")
+    XCTAssertEqual(rootRow.child?.id, "text-child")
 
     var visitedIds: [String] = []
     if let page = flows.first?.pages.first {
@@ -109,7 +102,7 @@ final class ContentViewTests: XCTestCase {
     guard case .button(let viewData, _, _, _) = try UI_RowPayload.from(row: rootRow) else {
       return XCTFail("Expected Button payload")
     }
-    XCTAssertEqual(viewData.content.child?.id, "text-child")
+    XCTAssertEqual(viewData.child?.id, "text-child")
   }
 
   func testSyncStateResetsStoredTimestampWhenStorageVersionChanges() {
@@ -137,13 +130,9 @@ final class ContentViewTests: XCTestCase {
       "source": "",
       "destination": "",
       "actions": [],
-      "view": [
-        "content": [
-          "title": "Test title",
-          "subtitle": "Test subtitle",
-          "image": "",
-        ]
-      ],
+      "title": "Test title",
+      "subtitle": "Test subtitle",
+      "image": "",
     ]
 
     let data = try JSONSerialization.data(withJSONObject: json)
@@ -151,36 +140,28 @@ final class ContentViewTests: XCTestCase {
     guard case .listItem(let viewData, _, _, _) = try UI_RowPayload.from(row: row) else {
       return XCTFail("Expected .listItem payload")
     }
-    XCTAssertEqual(viewData.content.title, "Test title")
-    XCTAssertEqual(viewData.content.subtitle, "Test subtitle")
+    XCTAssertEqual(viewData.title, "Test title")
+    XCTAssertEqual(viewData.subtitle, "Test subtitle")
   }
 
-  func testDatumRowFormatterSearchesAllContentStrings() throws {
+  func testDatumRowFormatterSearchesFlatContentStrings() throws {
     let row = try decodeRow([
       "id": "search-result-template",
       "type": "ListItem",
       "source": "",
       "destination": "",
       "actions": [],
-      "view": [
-        "content": [
-          "title": "Item title",
-          "subtitle": "Sydney",
-          "segments": ["first", "second"],
-          "child": [
-            "id": "search-result-child",
-            "type": "Button",
-            "source": "",
-            "destination": "",
-            "actions": [],
-            "view": [
-              "content": [
-                "title": "",
-                "label": "Inner label",
-              ]
-            ],
-          ],
-        ]
+      "title": "Item title",
+      "subtitle": "Sydney",
+      "segments": ["first", "second"],
+      "child": [
+        "id": "search-result-child",
+        "type": "Button",
+        "source": "",
+        "destination": "",
+        "actions": [],
+        "title": "",
+        "label": "Inner label",
       ],
     ])
     let formatter = try EVYDatumRowFormatter(template: row)
@@ -199,13 +180,9 @@ final class ContentViewTests: XCTestCase {
       "source": "",
       "destination": "",
       "actions": [],
-      "view": [
-        "content": [
-          "title": "{$datum.title}",
-          "subtitle": "{formatCurrency($datum.price)}",
-          "image": "{$datum.photo_ids.0}",
-        ]
-      ],
+      "title": "{$datum.title}",
+      "subtitle": "{formatCurrency($datum.price)}",
+      "image": "{$datum.photo_ids.0}",
     ])
     let formatter = try EVYDatumRowFormatter(template: row)
     let datum = EVYJson.dictionary([
@@ -220,9 +197,9 @@ final class ContentViewTests: XCTestCase {
     guard case .listItem(let viewData, _, _, _) = try UI_RowPayload.from(row: formattedRow) else {
       return XCTFail("Expected .listItem payload")
     }
-    XCTAssertEqual(viewData.content.title, "Visible item")
-    XCTAssertEqual(viewData.content.subtitle, "$10.00")
-    XCTAssertEqual(viewData.content.image, "photo-1")
+    XCTAssertEqual(viewData.title, "Visible item")
+    XCTAssertEqual(viewData.subtitle, "$10.00")
+    XCTAssertEqual(viewData.image, "photo-1")
   }
 
   private func decodeRow(_ json: [String: Any]) throws -> UI_Row {
@@ -244,12 +221,8 @@ final class ContentViewTests: XCTestCase {
                 "id": "home-button",
                 "type": "Button",
                 "source": "",
-                "view": [
-                  "content": [
-                    "title": "",
-                    "label": "Create",
-                  ]
-                ],
+                "title": "",
+                "label": "Create",
                 "actions": [
                   [
                     "condition": "",
@@ -274,13 +247,9 @@ final class ContentViewTests: XCTestCase {
                 "id": "title-row",
                 "type": "Input",
                 "source": "",
-                "view": [
-                  "content": [
-                    "title": "Title",
-                    "value": "",
-                    "placeholder": "Enter a title",
-                  ]
-                ],
+                "title": "Title",
+                "value": "",
+                "placeholder": "Enter a title",
                 "destination": "{\(MarketplaceTestFixture.itemsResourceId).title}",
                 "actions": [],
               ]
@@ -289,12 +258,8 @@ final class ContentViewTests: XCTestCase {
               "id": "submit-button",
               "type": "Button",
               "source": "",
-              "view": [
-                "content": [
-                  "title": "",
-                  "label": "Submit",
-                ]
-              ],
+              "title": "",
+              "label": "Submit",
               "actions": [
                 [
                   "condition": "",

--- a/ios/evyTests/EVYActionRunnerTests.swift
+++ b/ios/evyTests/EVYActionRunnerTests.swift
@@ -276,7 +276,7 @@ final class EVYActionRunnerTests: XCTestCase {
     XCTAssertEqual(route.query["items"], ["$datum.id"])
   }
 
-  func testDatumRowFormatterDoesNotResolveDatumInActions() throws {
+  func testDatumRowFormatterResolvesDatumReferencesInActions() throws {
     let actionString = "{navigate(flowX,pageY,{id: $datum.id})}"
     let row = try decodeRow(
       content: """
@@ -294,7 +294,7 @@ final class EVYActionRunnerTests: XCTestCase {
 
     let formattedRow = try formatter.formattedResult(datum: datum).row
 
-    XCTAssertEqual(formattedRow.view.content.title, "Resolved Title")
+    XCTAssertEqual(formattedRow.title, "Resolved Title")
     XCTAssertEqual(formattedRow.actions.first?.true, actionString)
   }
 
@@ -309,8 +309,10 @@ final class EVYActionRunnerTests: XCTestCase {
             "type": "Text",
             "source": "",
             "destination": "",
-            "view": { "content": { "title": "Child", "text": "Body" }, "max_lines": "" },
-            "actions": []
+            "title": "Child",
+            "text": "Body",
+            "actions": [],
+            "visible": "true"
           }
         }
         """
@@ -331,13 +333,16 @@ final class EVYActionRunnerTests: XCTestCase {
   ) throws -> UI_Row {
     let actionsData = try JSONEncoder().encode(actions)
     let actionsJson = try XCTUnwrap(String(data: actionsData, encoding: .utf8))
+    let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+    let rowAttributes = String(trimmedContent.dropFirst().dropLast())
     let json = """
       {
         "id": "parent-row",
         "type": "Button",
         "source": "",
         "destination": "",
-        "view": { "content": \(content) },
+        "visible": "true",
+        \(rowAttributes),
         "actions": \(actionsJson)
       }
       """

--- a/ios/evyTests/EVYCalendarTests.swift
+++ b/ios/evyTests/EVYCalendarTests.swift
@@ -9,8 +9,8 @@ import XCTest
 
 @MainActor
 final class EVYCalendarTests: XCTestCase {
-  private let headerFormat = "{formatDatetime($datum, \"EEE d\")}"
-  private let timeslotFormat = "{formatDatetime($datum, \"H:mm\")}"
+  private let headerFormat = "EEE d"
+  private let timeslotFormat = "H:mm"
 
   private func todayPlus(_ days: Int) -> String {
     let date = Calendar.current.date(byAdding: .day, value: days, to: Date())!
@@ -65,19 +65,27 @@ final class EVYCalendarTests: XCTestCase {
     XCTAssertEqual(labelledSlots.map { $0.timeLabel }, ["7:00", "8:00"])
   }
 
-  func testTimeLabelFormattedWithTimeslotFormatExpression() {
+  func testTimeLabelFormattedWithPlainTimeslotFormat() {
     let slots = EVYDatetime.buildCalendarSlots(
       startTime: "09:00",
       endTime: "11:00",
       intervalMinutes: 60,
       labelIntervalMinutes: 60,
       headerFormat: headerFormat,
-      timeslotFormat: "{formatDatetime($datum, \"h:mm a\")}",
+      timeslotFormat: "h:mm a",
       primarySelections: ["2026-05-20T09:00:00"],
       secondarySelections: []
     )
     let labelledSlots = slots.filter { $0.x == 0 && !$0.timeLabel.isEmpty }
     XCTAssertEqual(labelledSlots.map { $0.timeLabel }, ["9:00 AM", "10:00 AM"])
+  }
+
+  func testCalendarFormatValueSupportsLegacyExpression() {
+    let formatted = EVYDatetime.formatCalendarValue(
+      "2026-06-03T09:00:00",
+      patternOrExpression: "{formatDatetime($datum, \"EEE d\")}"
+    )
+    XCTAssertEqual(formatted, "Wed 3")
   }
 
   func testPrimarySelectionIsDetectedCorrectly() {

--- a/ios/evyTests/EVYCalendarTests.swift
+++ b/ios/evyTests/EVYCalendarTests.swift
@@ -17,14 +17,30 @@ final class EVYCalendarTests: XCTestCase {
     return date.formatted(.iso8601.year().month().day())
   }
 
+  private func calendarRow(
+    startTime: String = "07:00",
+    endTime: String = "19:00",
+    timeslotIntervalMinutes: Int = 30,
+    labelIntervalMinutes: Int = 60,
+    headerFormat: String? = nil,
+    timeslotFormat: String? = nil
+  ) -> CalendarRowViewData {
+    let jsonObject: [String: Any] = [
+      "title": "",
+      "start_time": startTime,
+      "end_time": endTime,
+      "timeslot_interval_minutes": timeslotIntervalMinutes,
+      "label_interval_minutes": labelIntervalMinutes,
+      "header_format": headerFormat ?? self.headerFormat,
+      "timeslot_format": timeslotFormat ?? self.timeslotFormat,
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: jsonObject)
+    return try! JSONDecoder().decode(CalendarRowViewData.self, from: data)
+  }
+
   func testSlotCountFor12HourRangeAt30MinIntervals() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "07:00",
-      endTime: "19:00",
-      intervalMinutes: 30,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(),
       primarySelections: [],
       secondarySelections: []
     )
@@ -33,12 +49,7 @@ final class EVYCalendarTests: XCTestCase {
 
   func testStaleSelectionsAppearAsExtraColumns() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "11:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "09:00", endTime: "11:00", timeslotIntervalMinutes: 60),
       primarySelections: [],
       secondarySelections: [
         "2026-05-20T09:00:00",
@@ -52,12 +63,7 @@ final class EVYCalendarTests: XCTestCase {
 
   func testTimeLabelAppearsEveryLabelInterval() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "07:00",
-      endTime: "09:00",
-      intervalMinutes: 30,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "07:00", endTime: "09:00"),
       primarySelections: ["2026-05-20T07:00:00"],
       secondarySelections: []
     )
@@ -67,12 +73,12 @@ final class EVYCalendarTests: XCTestCase {
 
   func testTimeLabelFormattedWithPlainTimeslotFormat() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "11:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: "h:mm a",
+      row: calendarRow(
+        startTime: "09:00",
+        endTime: "11:00",
+        timeslotIntervalMinutes: 60,
+        timeslotFormat: "h:mm a"
+      ),
       primarySelections: ["2026-05-20T09:00:00"],
       secondarySelections: []
     )
@@ -80,6 +86,7 @@ final class EVYCalendarTests: XCTestCase {
     XCTAssertEqual(labelledSlots.map { $0.timeLabel }, ["9:00 AM", "10:00 AM"])
   }
 
+  // TODO: remove after migration
   func testCalendarFormatValueSupportsLegacyExpression() {
     let formatted = EVYDatetime.formatCalendarValue(
       "2026-06-03T09:00:00",
@@ -90,12 +97,7 @@ final class EVYCalendarTests: XCTestCase {
 
   func testPrimarySelectionIsDetectedCorrectly() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "11:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "09:00", endTime: "11:00", timeslotIntervalMinutes: 60),
       primarySelections: ["2026-06-03T09:00:00"],
       secondarySelections: []
     )
@@ -106,12 +108,7 @@ final class EVYCalendarTests: XCTestCase {
 
   func testSecondarySelectionIsDetectedCorrectly() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "11:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "09:00", endTime: "11:00", timeslotIntervalMinutes: 60),
       primarySelections: [],
       secondarySelections: ["2026-06-03T10:00:00"]
     )
@@ -123,12 +120,7 @@ final class EVYCalendarTests: XCTestCase {
 
   func testHeaderFormattingForKnownDate() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "10:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "09:00", endTime: "10:00", timeslotIntervalMinutes: 60),
       primarySelections: ["2026-06-03T09:00:00"],
       secondarySelections: []
     )
@@ -137,52 +129,33 @@ final class EVYCalendarTests: XCTestCase {
 
   func testInvalidTimeRangeProducesZeroSlots() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "10:00",
-      endTime: "09:00",
-      intervalMinutes: 30,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "10:00", endTime: "09:00"),
       primarySelections: [],
       secondarySelections: []
     )
     XCTAssertEqual(slots.count, 0)
   }
 
-  func testZeroIntervalReturnsEmpty() {
+  func testZeroIntervalUsesDefaultInterval() {
     let slots = EVYDatetime.buildCalendarSlots(
-      startTime: "07:00",
-      endTime: "19:00",
-      intervalMinutes: 0,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
-      primarySelections: ["2026-06-03T09:00:00"],
+      row: calendarRow(timeslotIntervalMinutes: 0),
+      primarySelections: [],
       secondarySelections: []
     )
-    XCTAssertTrue(slots.isEmpty)
+    XCTAssertEqual(slots.count, 7 * 24)
   }
 
   func testColumnCountIsStableWhenPrimarySelectionChanges() {
+    let row = calendarRow(startTime: "09:00", endTime: "10:00", timeslotIntervalMinutes: 60)
     let baselineSlots = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "10:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: row,
       primarySelections: [],
       secondarySelections: []
     )
     let baselineColumns = Set(baselineSlots.map { $0.x }).count
 
     let afterSelect = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "10:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: row,
       primarySelections: ["\(todayPlus(2))T09:00:00"],
       secondarySelections: []
     )
@@ -194,12 +167,7 @@ final class EVYCalendarTests: XCTestCase {
 
   func testColumnCountIsStableWhenSecondarySelectionChanges() {
     let withinWindow = EVYDatetime.buildCalendarSlots(
-      startTime: "09:00",
-      endTime: "10:00",
-      intervalMinutes: 60,
-      labelIntervalMinutes: 60,
-      headerFormat: headerFormat,
-      timeslotFormat: timeslotFormat,
+      row: calendarRow(startTime: "09:00", endTime: "10:00", timeslotIntervalMinutes: 60),
       primarySelections: [],
       secondarySelections: ["\(todayPlus(3))T09:00:00"]
     )

--- a/ios/evyTests/EVYTimeslotPickerTests.swift
+++ b/ios/evyTests/EVYTimeslotPickerTests.swift
@@ -13,11 +13,28 @@ final class EVYTimeslotPickerTests: XCTestCase {
   private let headerSubtitle = "{formatDatetime($datum, \"MMM do\")}"
   private let timeslotFormat = "{formatDatetime($datum, \"HH:mm\")}"
 
+  private func timeslotPickerRow(
+    headerFormat: String? = nil,
+    headerSubtitle: String? = nil,
+    timeslotFormat: String? = nil
+  ) -> TimeslotPickerRowViewData {
+    let jsonObject: [String: Any] = [
+      "title": "",
+      "start_time": "07:00",
+      "end_time": "19:00",
+      "timeslot_interval_minutes": 30,
+      "label_interval_minutes": 60,
+      "header_format": headerFormat ?? self.headerFormat,
+      "header_subtitle": headerSubtitle ?? self.headerSubtitle,
+      "timeslot_format": timeslotFormat ?? self.timeslotFormat,
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: jsonObject)
+    return try! JSONDecoder().decode(TimeslotPickerRowViewData.self, from: data)
+  }
+
   func testEmptySelectionsProducesNoDates() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: []
     )
     XCTAssertTrue(dates.isEmpty)
@@ -25,9 +42,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testSingleDayGroupedCorrectly() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: ["2026-06-03T09:00:00", "2026-06-03T09:30:00"]
     )
     XCTAssertEqual(dates.count, 1)
@@ -36,9 +51,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testMultipleDaysSortedChronologically() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: [
         "2026-06-05T11:00:00",
         "2026-06-03T09:00:00",
@@ -51,9 +64,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testTimeslotTimeFormattedAsHHmm() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: ["2026-06-03T09:30:00"]
     )
     XCTAssertEqual(dates.first?.timeslots.first?.timeslot, "09:30")
@@ -61,9 +72,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testTimeslotFormattedWithTimeslotFormatExpression() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: "{formatDatetime($datum, \"h:mm a\")}",
+      row: timeslotPickerRow(timeslotFormat: "{formatDatetime($datum, \"h:mm a\")}"),
       selections: ["2026-06-03T09:30:00"]
     )
     XCTAssertEqual(dates.first?.timeslots.first?.timeslot, "9:30 AM")
@@ -71,9 +80,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testHeaderFormattedWithHeaderFormat() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: ["2026-06-03T09:00:00"]
     )
     XCTAssertEqual(dates.first?.header, "Wed")
@@ -81,9 +88,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testHeaderSubtitleFormattedWithHeaderSubtitle() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: ["2026-06-03T09:00:00"]
     )
     XCTAssertEqual(dates.first?.subtitle, "Jun 3rd")
@@ -91,9 +96,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testAllTimeslotsAreAvailable() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: [
         "2026-06-03T09:00:00",
         "2026-06-03T09:30:00",
@@ -106,9 +109,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testInvalidSelectionStringSkipped() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: ["not-a-date", "2026-06-03T09:00:00", "short"]
     )
     XCTAssertEqual(dates.count, 1)
@@ -117,9 +118,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testDaysWithNoSelectionsAreExcluded() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: [
         "2026-06-03T09:00:00",
         "2026-06-05T11:00:00",
@@ -132,9 +131,7 @@ final class EVYTimeslotPickerTests: XCTestCase {
 
   func testTimeslotsWithinOneDaySortedChronologically() {
     let dates = EVYDatetime.buildTimeslotPickerDates(
-      headerFormat: headerFormat,
-      headerSubtitle: headerSubtitle,
-      timeslotFormat: timeslotFormat,
+      row: timeslotPickerRow(),
       selections: [
         "2026-06-03T14:00:00",
         "2026-06-03T09:00:00",

--- a/scripts/generate-drizzle.ts
+++ b/scripts/generate-drizzle.ts
@@ -430,21 +430,41 @@ async function main(): Promise<void> {
 	validateConfigSemantic(schema, config);
 
 	const defs = schema.$defs ?? {};
+	const tableOrder = [
+		"DATA_EVY_Device",
+		"DATA_EVY_Service",
+		"DATA_EVY_Organization",
+		"DATA_EVY_ServiceProvider",
+		"DATA_EVY_ServiceResource",
+		"DATA_EVY_Flow",
+		"DATA_EVY_File",
+	];
+	const hasNumberColumns = tableOrder.some((defKey) => {
+		const tableConfig = config.tables?.[defKey];
+		const def = defs[defKey];
+		if (!tableConfig || !def?.properties) return false;
+		return Object.values(def.properties).some(
+			(prop) => prop.type === "number",
+		);
+	});
+	const pgCoreImports = [
+		"pgTable",
+		"pgEnum",
+		"uuid",
+		"varchar",
+		"text",
+		"integer",
+		...(hasNumberColumns ? ["numeric"] : []),
+		"boolean",
+		"jsonb",
+		"uniqueIndex",
+	];
 	const lines: string[] = [
 		"/* eslint-disable */",
 		"/** Generated from types/schema/data - do not edit. */",
 		"",
 		"import {",
-		"	pgTable,",
-		"	pgEnum,",
-		"	uuid,",
-		"	varchar,",
-		"	text,",
-		"	integer,",
-		"	numeric,",
-		"	boolean,",
-		"	jsonb,",
-		"	uniqueIndex,",
+		...pgCoreImports.map((importName) => `\t${importName},`),
 		'} from "drizzle-orm/pg-core";',
 		'import { relations } from "drizzle-orm";',
 		'import type { UI_Flow } from "evy-types/sdui/evy";',
@@ -460,16 +480,6 @@ async function main(): Promise<void> {
 		);
 		lines.push("");
 	}
-
-	const tableOrder = [
-		"DATA_EVY_Device",
-		"DATA_EVY_Service",
-		"DATA_EVY_Organization",
-		"DATA_EVY_ServiceProvider",
-		"DATA_EVY_ServiceResource",
-		"DATA_EVY_Flow",
-		"DATA_EVY_File",
-	];
 
 	for (const defKey of tableOrder) {
 		const tableConfig = config.tables?.[defKey];

--- a/scripts/generate-swift-sdui.ts
+++ b/scripts/generate-swift-sdui.ts
@@ -21,7 +21,6 @@ const ROW_SPEC_PATH = join(SCHEMA_DIR, "sdui", "row-content.spec.json");
 type RowSpec = Record<
 	string,
 	{
-		view?: Record<string, string>;
 		content: Record<string, string>;
 	}
 >;
@@ -111,9 +110,6 @@ function swiftTypeForSchemaProp(
 	return { swiftType: "String", isOptional: !required };
 }
 
-/** Known definition names that must be classes (recursive refs). */
-const CLASS_DEFS = new Set(["UI_Row", "UI_RowView", "UI_RowContent"]);
-
 function emitUIEnums(rowSpec: RowSpec): string {
 	const rowTypes = getRowTypesFromSpec(rowSpec);
 	const rowEnumCases: string[] = [];
@@ -139,62 +135,118 @@ ${rowEnumCases.join("\n")}
 function buildShapeOverrides(): Map<string, string> {
 	const m = new Map<string, string>();
 	m.set("UI_Row.type", "EVYRowType");
-	m.set("UI_Row.view", "UI_RowView");
 	return m;
 }
 
-/** Emit property line(s) for one property. */
-function emitUIRowClass(): string {
+function collectRowAttributeEntries(rowSpec: RowSpec): [string, string][] {
+	const entries = new Map<string, string>();
+	for (const spec of Object.values(rowSpec)) {
+		for (const [key, value] of Object.entries(
+			withUniversalChildContent(spec.content),
+		)) {
+			entries.set(key, value);
+		}
+	}
+	return [...entries.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
+
+function swiftDefaultValueForSpecType(specType: string): string {
+	switch (specType) {
+		case "integer":
+			return "0";
+		case "[UI_Row]":
+		case "[String]":
+			return "[]";
+		case "UI_Row":
+			return "nil";
+		default:
+			return '""';
+	}
+}
+
+/** Emit flattened UI_Row with defaults for optional row attributes. */
+function emitUIRowClass(rowSpec: RowSpec): string {
+	const entries = collectRowAttributeEntries(rowSpec);
+	const attributeFields = entries.map(
+		([key, value]) =>
+			`    public let ${swiftIdentifier(key)}: ${swiftTypeForSpecType(value)}`,
+	);
+	const initParams = [
+		"id: String",
+		"type: EVYRowType",
+		'source: String = ""',
+		'destination: String = ""',
+		"actions: [UI_RowAction] = []",
+		'visible: String = ""',
+		...entries.map(
+			([key, value]) =>
+				`${swiftIdentifier(key)}: ${swiftTypeForSpecType(value)} = ${swiftDefaultValueForSpecType(value)}`,
+		),
+	];
+	const attributeAssignments = entries.map(
+		([key]) =>
+			`        self.${swiftIdentifier(key)} = ${swiftIdentifier(key)}`,
+	);
+	const codingKeyCases = [
+		"        case id",
+		"        case type",
+		"        case source",
+		"        case destination",
+		"        case actions",
+		"        case visible",
+		...entries.map(([key]) => `        case ${swiftIdentifier(key)}`),
+	];
+	const decodeLines = entries.map(([key, value]) =>
+		emitRowContentDecodeLine(key, value),
+	);
+	const encodeLines = entries.map(([key, value]) =>
+		emitRowContentEncodeLine(key, value),
+	);
+
 	return `// MARK: - UI_Row
 public final class UI_Row: Codable {
     public let id: String
     public let type: EVYRowType
-    public let view: UI_RowView
     public let source: String
     public let destination: String
     public let actions: [UI_RowAction]
     public let visible: String
+${attributeFields.join("\n")}
 
-    public init(id: String, type: EVYRowType, view: UI_RowView, source: String, destination: String, actions: [UI_RowAction], visible: String) {
+    public init(${initParams.join(", ")}) {
         self.id = id
         self.type = type
-        self.view = view
         self.source = source
         self.destination = destination
         self.actions = actions
         self.visible = visible
+${attributeAssignments.join("\n")}
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id
-        case type
-        case view
-        case source
-        case destination
-        case actions
-        case visible
+${codingKeyCases.join("\n")}
     }
 
     public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(String.self, forKey: .id)
-        type = try container.decode(EVYRowType.self, forKey: .type)
-        view = try container.decode(UI_RowView.self, forKey: .view)
-        source = try container.decode(String.self, forKey: .source)
-        destination = try container.decodeIfPresent(String.self, forKey: .destination) ?? ""
-        actions = try container.decodeIfPresent([UI_RowAction].self, forKey: .actions) ?? []
-        visible = try container.decodeIfPresent(String.self, forKey: .visible) ?? ""
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        type = try c.decode(EVYRowType.self, forKey: .type)
+        source = try c.decodeIfPresent(String.self, forKey: .source) ?? ""
+        destination = try c.decodeIfPresent(String.self, forKey: .destination) ?? ""
+        actions = try c.decodeIfPresent([UI_RowAction].self, forKey: .actions) ?? []
+        visible = try c.decodeIfPresent(String.self, forKey: .visible) ?? ""
+${decodeLines.join("\n")}
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(id, forKey: .id)
-        try container.encode(type, forKey: .type)
-        try container.encode(view, forKey: .view)
-        try container.encode(source, forKey: .source)
-        try container.encode(destination, forKey: .destination)
-        try container.encode(actions, forKey: .actions)
-        try container.encode(visible, forKey: .visible)
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(type, forKey: .type)
+        try c.encode(source, forKey: .source)
+        try c.encode(destination, forKey: .destination)
+        try c.encode(actions, forKey: .actions)
+        try c.encode(visible, forKey: .visible)
+${encodeLines.join("\n")}
     }
 }
 `;
@@ -223,11 +275,12 @@ function emitShapeFromDef(
 	defName: string,
 	def: SchemaObject,
 	overrides: Map<string, string>,
+	rowSpec: RowSpec,
 ): string {
 	const props = (def.properties ?? {}) as Record<string, unknown>;
 	const required = (def.required ?? []) as string[];
 	if (defName === "UI_Row") {
-		return emitUIRowClass();
+		return emitUIRowClass(rowSpec);
 	}
 	const lines: string[] = [];
 	for (const [propName, propSchema] of Object.entries(props)) {
@@ -241,13 +294,7 @@ function emitShapeFromDef(
 			),
 		);
 	}
-	const useClass = CLASS_DEFS.has(defName);
-	const useFinalClass = defName === "UI_Row";
-	const keyword = useFinalClass
-		? "final class"
-		: useClass
-			? "class"
-			: "struct";
+	const keyword = defName === "UI_Row" ? "final class" : "struct";
 	const initParams = lines
 		.map((l) => {
 			const match = /public let (`?\w+`?): ([\w[\]?]+)/.exec(l);
@@ -264,7 +311,7 @@ function emitShapeFromDef(
 		})
 		.filter(Boolean);
 	let initBlock = "";
-	if (useClass && initParams.length > 0) {
+	if (defName === "UI_Row" && initParams.length > 0) {
 		initBlock = `
 
     public init(${initParams.join(", ")}) {
@@ -280,38 +327,7 @@ ${initBlock}
 `;
 }
 
-/** Emit UI_RowView from the inline view object under UI_Row. */
-function emitRowViewFromSchema(
-	schema: SchemaObject,
-	overrides: Map<string, string>,
-): string {
-	const defs = schema.$defs as Record<string, unknown>;
-	const rowDef = defs?.UI_Row as SchemaObject;
-	const viewSchema = (rowDef?.properties as Record<string, unknown>)
-		?.view as SchemaObject;
-	const required = (viewSchema?.required ?? []) as string[];
-	const props = (viewSchema?.properties ?? {}) as Record<string, unknown>;
-	const lines: string[] = [];
-	for (const [propName, propSchema] of Object.entries(props)) {
-		const { swiftType, isOptional } = swiftTypeForSchemaProp(
-			propSchema,
-			"UI_RowView",
-			propName,
-			required,
-			overrides,
-		);
-		lines.push(
-			`    public let ${propName}: ${swiftType}${isOptional ? "?" : ""}`,
-		);
-	}
-	return `// MARK: - UI_RowView (class to allow recursive reference)
-public class UI_RowView: Codable {
-${lines.join("\n")}
-}
-`;
-}
-
-function emitUIShapes(schema: SchemaObject): string {
+function emitUIShapes(schema: SchemaObject, rowSpec: RowSpec): string {
 	const overrides = buildShapeOverrides();
 	const defs = (schema.$defs ?? {}) as Record<string, unknown>;
 
@@ -336,23 +352,13 @@ ${flowLines.join("\n")}
 }
 `;
 
-	// $defs in order: Page, Row, RowView (synthetic), RowContent, RowAction
-	const defOrder = [
-		"UI_Page",
-		"UI_Row",
-		"UI_RowView",
-		"UI_RowContent",
-		"UI_RowAction",
-	];
+	// $defs in order: Page, Row, RowAction
+	const defOrder = ["UI_Page", "UI_Row", "UI_RowAction"];
 	const defBlocks: string[] = [];
 	for (const name of defOrder) {
-		if (name === "UI_RowView") {
-			defBlocks.push(emitRowViewFromSchema(schema, overrides));
-			continue;
-		}
 		const def = defs[name] as SchemaObject | undefined;
 		if (!def) continue;
-		defBlocks.push(emitShapeFromDef(name, def, overrides));
+		defBlocks.push(emitShapeFromDef(name, def, overrides, rowSpec));
 	}
 
 	return `// Generated from types/schema/sdui/evy.schema.json - do not edit.
@@ -407,24 +413,28 @@ function withUniversalChildContent(
 	};
 }
 
-function emitRowContentStruct(
+function emitRowViewDataStruct(
 	rowType: string,
-	content: Record<string, string>,
+	spec: { content: Record<string, string> },
 ): string {
-	const contentName = `${rowType}RowContent`;
-	const entries = Object.entries(withUniversalChildContent(content));
+	const viewDataName = `${rowType}RowViewData`;
+	const entries = Object.entries(withUniversalChildContent(spec.content));
 	const fieldLines = entries.map(
-		([k, v]) =>
-			`    public let ${swiftIdentifier(k)}: ${swiftTypeForSpecType(v)}`,
+		([key, value]) =>
+			`    public let ${swiftIdentifier(key)}: ${swiftTypeForSpecType(value)}`,
 	);
 	const codingKeyCases = entries.map(
-		([k]) => `        case ${swiftIdentifier(k)}`,
+		([key]) => `        case ${swiftIdentifier(key)}`,
 	);
-	const decodeLines = entries.map(([k, v]) => emitRowContentDecodeLine(k, v));
-	const encodeLines = entries.map(([k, v]) => emitRowContentEncodeLine(k, v));
+	const decodeLines = entries.map(([key, value]) =>
+		emitRowContentDecodeLine(key, value),
+	);
+	const encodeLines = entries.map(([key, value]) =>
+		emitRowContentEncodeLine(key, value),
+	);
 
-	return `// MARK: - ${contentName}
-public struct ${contentName}: Codable {
+	return `// MARK: - ${viewDataName}
+public struct ${viewDataName}: Codable {
 ${fieldLines.join("\n")}
 
     private enum CodingKeys: String, CodingKey {
@@ -443,69 +453,13 @@ ${encodeLines.join("\n")}
 }`;
 }
 
-function emitRowViewDataStruct(
-	rowType: string,
-	spec: { view?: Record<string, string> },
-): string {
-	const viewDataName = `${rowType}RowViewData`;
-	const contentName = `${rowType}RowContent`;
-
-	if (!spec.view || Object.keys(spec.view).length === 0) {
-		return `// MARK: - ${viewDataName}
-public struct ${viewDataName}: Codable {
-    public let content: ${contentName}
-}`;
-	}
-
-	const viewEntries = Object.entries(spec.view);
-	const viewFieldLines = viewEntries.map(
-		([k]) => `    public let ${swiftIdentifier(k)}: String`,
-	);
-	const codingKeyCases = [
-		"        case content",
-		...viewEntries.map(([k]) => `        case ${swiftIdentifier(k)}`),
-	];
-	const decodeViewLines = viewEntries.map(
-		([k]) =>
-			`        ${swiftIdentifier(k)} = try c.decodeIfPresent(String.self, forKey: .${swiftIdentifier(k)}) ?? ""`,
-	);
-	const encodeViewLines = viewEntries.map(
-		([k]) =>
-			`        try c.encode(${swiftIdentifier(k)}, forKey: .${swiftIdentifier(k)})`,
-	);
-
-	return `// MARK: - ${viewDataName}
-public struct ${viewDataName}: Codable {
-    public let content: ${contentName}
-${viewFieldLines.join("\n")}
-
-    private enum CodingKeys: String, CodingKey {
-${codingKeyCases.join("\n")}
-    }
-
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        content = try c.decode(${contentName}.self, forKey: .content)
-${decodeViewLines.join("\n")}
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encode(content, forKey: .content)
-${encodeViewLines.join("\n")}
-    }
-}`;
-}
-
 function emitUIRowPayloads(rowSpec: RowSpec): string {
 	const rowTypes = getRowTypesFromSpec(rowSpec);
 
-	const contentStructs: string[] = [];
 	const viewDataStructs: string[] = [];
 	for (const rowType of rowTypes) {
 		const spec = rowSpec[rowType];
 		if (!spec) continue;
-		contentStructs.push(emitRowContentStruct(rowType, spec.content));
 		viewDataStructs.push(emitRowViewDataStruct(rowType, spec));
 	}
 
@@ -526,7 +480,7 @@ function emitUIRowPayloads(rowSpec: RowSpec): string {
 		const viewDataName = `${rowType}RowViewData`;
 		const enumCase = rowTypeToEnumCase(rowType);
 		fromRowCases.push(`        case .${enumCase}:
-            let viewData = try JSONDecoder().decode(${viewDataName}.self, from: JSONEncoder().encode(row.view))
+            let viewData = try JSONDecoder().decode(${viewDataName}.self, from: JSONEncoder().encode(row))
             return .${enumCase}(viewData, row.source, row.destination, row.actions)`);
 	}
 
@@ -535,9 +489,7 @@ function emitUIRowPayloads(rowSpec: RowSpec): string {
 
 import Foundation
 
-// MARK: - Per-row content and view data structs
-
-${contentStructs.join("\n\n")}
+// MARK: - Per-row view data structs
 
 ${viewDataStructs.join("\n\n")}
 
@@ -567,7 +519,7 @@ async function main(): Promise<void> {
 	);
 	await writeFile(
 		join(OUT_SWIFT, "UIShapes.swift"),
-		emitUIShapes(schema),
+		emitUIShapes(schema, rowSpec),
 		"utf-8",
 	);
 	await writeFile(

--- a/types/schema/sdui/evy.schema.json
+++ b/types/schema/sdui/evy.schema.json
@@ -49,7 +49,7 @@
 		"UI_Row": {
 			"type": "object",
 			"additionalProperties": false,
-			"required": ["id", "type", "view", "source", "actions", "visible"],
+			"required": ["id", "type", "source", "actions", "visible", "title"],
 			"properties": {
 				"id": {
 					"type": "string",
@@ -81,19 +81,6 @@
 						"TimeslotPicker"
 					]
 				},
-				"view": {
-					"type": "object",
-					"additionalProperties": false,
-					"required": ["content"],
-					"properties": {
-						"content": {
-							"$ref": "#/$defs/UI_RowContent"
-						},
-						"max_lines": {
-							"type": "string"
-						}
-					}
-				},
 				"source": {
 					"type": "string"
 				},
@@ -109,13 +96,7 @@
 				},
 				"visible": {
 					"type": "string"
-				}
-			}
-		},
-		"UI_RowContent": {
-			"type": "object",
-			"required": ["title"],
-			"properties": {
+				},
 				"title": {
 					"type": "string"
 				},
@@ -194,8 +175,7 @@
 						"type": "string"
 					}
 				}
-			},
-			"additionalProperties": false
+			}
 		},
 		"UI_RowAction": {
 			"type": "object",

--- a/types/schema/sdui/evy.schema.json
+++ b/types/schema/sdui/evy.schema.json
@@ -164,12 +164,6 @@
 				"timeslot_format": {
 					"type": "string"
 				},
-				"primary": {
-					"type": "string"
-				},
-				"secondary": {
-					"type": "string"
-				},
 				"subtitle": {
 					"type": "string"
 				},

--- a/types/schema/sdui/row-content.spec.json
+++ b/types/schema/sdui/row-content.spec.json
@@ -33,9 +33,6 @@
 		}
 	},
 	"TextExpand": {
-		"view": {
-			"max_lines": "string"
-		},
 		"content": {
 			"title": "string",
 			"text": "string",

--- a/types/schema/sdui/row-content.spec.json
+++ b/types/schema/sdui/row-content.spec.json
@@ -100,9 +100,7 @@
 			"timeslot_interval_minutes": "integer",
 			"label_interval_minutes": "integer",
 			"header_format": "string",
-			"timeslot_format": "string",
-			"primary": "string",
-			"secondary": "string"
+			"timeslot_format": "string"
 		}
 	},
 	"PhotoGallery": {

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -187,7 +187,7 @@ function AppContent() {
 		? findRowInPages(activeLeafRowId, pages)
 		: undefined;
 	const isSearchParent = activeLeafRow?.config.type === "Search";
-	const activeLeafChild = activeLeafRow?.config.view.content.child;
+	const activeLeafChild = activeLeafRow?.config.child;
 	const childPages = useMemo(
 		() => buildActiveChildPages({ activeRowId, configStack, pages }),
 		[activeRowId, configStack, pages],

--- a/web/app/api/sync.ts
+++ b/web/app/api/sync.ts
@@ -1,5 +1,5 @@
 import type { UI_Flow as ServerFlow, SyncResponse } from "evy-types";
-import { EVY_CORE_SERVICE } from "evy-types/coreResources";
+import { EVY_CORE_RESOURCE, EVY_CORE_SERVICE } from "evy-types/coreResources";
 import { isServerFlow, wsClient } from "./wsClient";
 
 export type ServiceResource = {
@@ -18,7 +18,9 @@ const MAX_ATTRIBUTE_DEPTH = 5;
 
 function extractSduiFlows(response: SyncResponse): ServerFlow[] {
 	const sduiRow = response.data.find(
-		(row) => row.service === EVY_CORE_SERVICE && row.resource === "sdui",
+		(row) =>
+			row.service === EVY_CORE_SERVICE &&
+			row.resource === EVY_CORE_RESOURCE.SDUI,
 	);
 
 	const value = sduiRow?.value;
@@ -50,7 +52,7 @@ function extractServiceResources(response: SyncResponse): ServiceResource[] {
 	const row = response.data.find(
 		(row) =>
 			row.service === EVY_CORE_SERVICE &&
-			row.resource === "serviceResources",
+			row.resource === EVY_CORE_RESOURCE.SERVICE_RESOURCES,
 	);
 	if (!Array.isArray(row?.value)) return [];
 	return (row.value as unknown[]).filter(isServiceResource);

--- a/web/app/hooks/useDraggable.ts
+++ b/web/app/hooks/useDraggable.ts
@@ -186,8 +186,8 @@ export function useDraggable({
 				element,
 				canDrop: () => true,
 				getIsSticky: () =>
-					!!currentRow?.config.view.content.children?.length ||
-					!!currentRow?.config.view.content.child,
+					!!currentRow?.config.children?.length ||
+					!!currentRow?.config.child,
 				getData: ({ input, element: targetElement }) =>
 					attachClosestEdge(
 						{ rowId },
@@ -212,8 +212,8 @@ export function useDraggable({
 		);
 	}, [
 		allowedEdges,
-		currentRow?.config.view.content.child,
-		currentRow?.config.view.content.children?.length,
+		currentRow?.config.child,
+		currentRow?.config.children?.length,
 		dispatchDropIndicator,
 		isDraggable,
 		onDragEvent,

--- a/web/app/rows/EVYRow.tsx
+++ b/web/app/rows/EVYRow.tsx
@@ -8,11 +8,7 @@ export const UnknownRow = defineRow("UnknownRow", {
 		type: "Text",
 		actions: [],
 		source: "",
-		view: {
-			content: {
-				title: "Unknown row",
-			},
-		},
+		title: "Unknown row",
 	},
-	render: (row) => <RowLayout title={row.config.view.content.title} />,
+	render: (row) => <RowLayout title={row.config.title} />,
 });

--- a/web/app/rows/action/ButtonRow.tsx
+++ b/web/app/rows/action/ButtonRow.tsx
@@ -8,18 +8,14 @@ export default defineRow("ButtonRow", {
 		type: "Button",
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "",
-				label: "Button row text",
-			},
-		},
+		title: "",
+		label: "Button row text",
 		actions: [{ condition: "", false: "", true: "{close()}" }],
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div className="evy-py-2 evy-flex evy-justify-center">
-				<Button label={row.config.view.content.label} />
+				<Button label={row.config.label} />
 			</div>
 		</RowLayout>
 	),

--- a/web/app/rows/container/ColumnContainerRow.tsx
+++ b/web/app/rows/container/ColumnContainerRow.tsx
@@ -11,18 +11,14 @@ export default defineRow(typeName, {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Column container row title",
-				children: [],
-			},
-		},
+		title: "Column container row title",
+		children: [],
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div className="evy-flex">
 				<ContainerChildren
-					rows={row.config.view.content.children}
+					rows={row.config.children}
 					orientation="horizontal"
 					showIndicators
 					containerRowId={row.id}

--- a/web/app/rows/container/ListContainerRow.tsx
+++ b/web/app/rows/container/ListContainerRow.tsx
@@ -11,20 +11,16 @@ export default defineRow(typeName, {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "List container row title",
-				child: undefined,
-				children: [],
-			},
-		},
+		title: "List container row title",
+		child: undefined,
+		children: [],
 	} satisfies RowConfig,
 	render: (row) => {
-		const title = row.config.view.content.title;
+		const title = row.config.title;
 		return (
 			<RowLayout title={title} fullWidthContent>
 				<ContainerChildren
-					rows={row.config.view.content.children}
+					rows={row.config.children}
 					orientation="vertical"
 					showIndicators
 					containerRowId={row.id}

--- a/web/app/rows/container/SelectSegmentContainerRow.tsx
+++ b/web/app/rows/container/SelectSegmentContainerRow.tsx
@@ -30,13 +30,9 @@ export default defineRow(typeName, {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Select segment container row title",
-				segments: ["X", "Y", "Z"],
-				children: [],
-			},
-		},
+		title: "Select segment container row title",
+		segments: ["X", "Y", "Z"],
+		children: [],
 	} satisfies RowConfig,
 	Component: function SelectSegmentContainerRowInner({
 		rowId,
@@ -51,13 +47,13 @@ export default defineRow(typeName, {
 			return null;
 		}
 
-		const rawSegments = row.config.view.content.segments;
+		const rawSegments = row.config.segments;
 		const segments: string[] =
 			Array.isArray(rawSegments) &&
 			rawSegments.every((x): x is string => typeof x === "string")
 				? rawSegments
 				: [];
-		const rawChildren = row.config.view.content.children;
+		const rawChildren = row.config.children;
 		const children: Row[] = Array.isArray(rawChildren) ? rawChildren : [];
 
 		// Segment button handler: stop propagation so the click doesn't bubble to
@@ -88,7 +84,7 @@ export default defineRow(typeName, {
 
 		const selectedChild = children[visibleChildIndex];
 
-		const title = row.config.view.content.title;
+		const title = row.config.title;
 
 		return (
 			<RowLayout title={title} fullWidthContent>

--- a/web/app/rows/edit/CalendarRow.tsx
+++ b/web/app/rows/edit/CalendarRow.tsx
@@ -29,6 +29,12 @@ const mockTimeSlots = Array.from({ length: 8 }, (_, i) => {
 	return `2000-01-01T${h}:${m}:00`;
 });
 
+function calendarPreviewFormat(patternOrExpression: string): string {
+	return patternOrExpression.includes("$datum")
+		? patternOrExpression
+		: `{formatDatetime($datum, "${patternOrExpression}")}`;
+}
+
 const axisLabelStyle: React.CSSProperties = {
 	width: COLUMN_WIDTH,
 	height: ROW_HEIGHT,
@@ -78,7 +84,9 @@ function CalendarGrid({
 				{mockTimeSlots.map((datetime, i) => (
 					<div key={datetime} style={axisLabelStyle}>
 						{i % 2 === 0
-							? parseText(timeslotFormat, { datum: datetime })
+							? parseText(calendarPreviewFormat(timeslotFormat), {
+									datum: datetime,
+								})
 							: ""}
 					</div>
 				))}
@@ -88,7 +96,9 @@ function CalendarGrid({
 				<div className="evy-flex evy-flex-row">
 					{mockColumnDates.map((datetime) => (
 						<div key={datetime} style={axisLabelStyle}>
-							{parseText(headerFormat, { datum: datetime })}
+							{parseText(calendarPreviewFormat(headerFormat), {
+								datum: datetime,
+							})}
 						</div>
 					))}
 				</div>
@@ -111,7 +121,7 @@ export default defineRow("CalendarRow", {
 	config: {
 		type: "Calendar",
 		actions: [],
-		source: "",
+		source: `{${MARKETPLACE_RESOURCE.ITEMS}.delivery_selection}`,
 		visible: "true",
 		view: {
 			content: {
@@ -120,10 +130,8 @@ export default defineRow("CalendarRow", {
 				end_time: "19:00",
 				timeslot_interval_minutes: 30,
 				label_interval_minutes: 60,
-				header_format: '{formatDatetime($datum, "EEE d")}',
-				timeslot_format: '{formatDatetime($datum, "HH:mm")}',
-				primary: "{pickup_selection}",
-				secondary: "{delivery_selection}",
+				header_format: "EEE d",
+				timeslot_format: "HH:mm",
 			},
 		},
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.pickup_selection}`,

--- a/web/app/rows/edit/CalendarRow.tsx
+++ b/web/app/rows/edit/CalendarRow.tsx
@@ -29,7 +29,7 @@ const mockTimeSlots = Array.from({ length: 8 }, (_, i) => {
 	return `2000-01-01T${h}:${m}:00`;
 });
 
-function calendarPreviewFormat(patternOrExpression: string): string {
+function toCalendarExpression(patternOrExpression: string): string {
 	return patternOrExpression.includes("$datum")
 		? patternOrExpression
 		: `{formatDatetime($datum, "${patternOrExpression}")}`;
@@ -68,13 +68,7 @@ function CalendarCell({ col, row }: { col: number; row: number }) {
 	);
 }
 
-function CalendarGrid({
-	headerFormat,
-	timeslotFormat,
-}: {
-	headerFormat: string;
-	timeslotFormat: string;
-}) {
+function CalendarGrid({ config }: { config: RowConfig }) {
 	const parseText = useParseText();
 	return (
 		<div className="evy-flex evy-flex-row evy-overflow-hidden evy-mt-2">
@@ -84,9 +78,14 @@ function CalendarGrid({
 				{mockTimeSlots.map((datetime, i) => (
 					<div key={datetime} style={axisLabelStyle}>
 						{i % 2 === 0
-							? parseText(calendarPreviewFormat(timeslotFormat), {
-									datum: datetime,
-								})
+							? parseText(
+									toCalendarExpression(
+										config.timeslot_format ?? "",
+									),
+									{
+										datum: datetime,
+									},
+								)
 							: ""}
 					</div>
 				))}
@@ -96,9 +95,14 @@ function CalendarGrid({
 				<div className="evy-flex evy-flex-row">
 					{mockColumnDates.map((datetime) => (
 						<div key={datetime} style={axisLabelStyle}>
-							{parseText(calendarPreviewFormat(headerFormat), {
-								datum: datetime,
-							})}
+							{parseText(
+								toCalendarExpression(
+									config.header_format ?? "",
+								),
+								{
+									datum: datetime,
+								},
+							)}
 						</div>
 					))}
 				</div>
@@ -123,25 +127,18 @@ export default defineRow("CalendarRow", {
 		actions: [],
 		source: `{${MARKETPLACE_RESOURCE.ITEMS}.delivery_selection}`,
 		visible: "true",
-		view: {
-			content: {
-				title: "Calendar row title",
-				start_time: "07:00",
-				end_time: "19:00",
-				timeslot_interval_minutes: 30,
-				label_interval_minutes: 60,
-				header_format: "EEE d",
-				timeslot_format: "HH:mm",
-			},
-		},
+		title: "Calendar row title",
+		start_time: "07:00",
+		end_time: "19:00",
+		timeslot_interval_minutes: 30,
+		label_interval_minutes: 60,
+		header_format: "EEE d",
+		timeslot_format: "HH:mm",
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.pickup_selection}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
-			<CalendarGrid
-				headerFormat={row.config.view.content.header_format ?? ""}
-				timeslotFormat={row.config.view.content.timeslot_format ?? ""}
-			/>
+		<RowLayout title={row.config.title}>
+			<CalendarGrid config={row.config} />
 		</RowLayout>
 	),
 });

--- a/web/app/rows/edit/DropdownRow.tsx
+++ b/web/app/rows/edit/DropdownRow.tsx
@@ -10,20 +10,16 @@ export default defineRow("DropdownRow", {
 		actions: [],
 		source: `{${MARKETPLACE_RESOURCE.CONDITIONS}}`,
 		visible: "true",
-		view: {
-			content: {
-				title: "Dropdown row title",
-				placeholder: "placeholder",
-				format: "{$datum.value}",
-			},
-		},
+		title: "Dropdown row title",
+		placeholder: "placeholder",
+		format: "{$datum.value}",
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.condition}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<Dropdown
 				value={row.config.source}
-				placeholder={row.config.view.content.placeholder}
+				placeholder={row.config.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/InlinePickerRow.tsx
+++ b/web/app/rows/edit/InlinePickerRow.tsx
@@ -10,16 +10,12 @@ export default defineRow("InlinePickerRow", {
 		actions: [],
 		source: `{${MARKETPLACE_RESOURCE.DURATIONS}}`,
 		visible: "true",
-		view: {
-			content: {
-				title: "Inline picker row title",
-				format: "{$datum.value}",
-			},
-		},
+		title: "Inline picker row title",
+		format: "{$datum.value}",
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.distance}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div className="evy-p-2 evy-flex evy-gap-2">
 				<RadioButton label="1 min" selected={false} />
 				<RadioButton label="2 mins" selected />

--- a/web/app/rows/edit/InputRow.tsx
+++ b/web/app/rows/edit/InputRow.tsx
@@ -10,20 +10,16 @@ export default defineRow("InputRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Input row title",
-				placeholder: "placeholder",
-				value: "",
-			},
-		},
+		title: "Input row title",
+		placeholder: "placeholder",
+		value: "",
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.title}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<Input
-				value={row.config.view.content.value}
-				placeholder={row.config.view.content.placeholder}
+				value={row.config.value}
+				placeholder={row.config.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/PhotoGalleryRow.tsx
+++ b/web/app/rows/edit/PhotoGalleryRow.tsx
@@ -10,15 +10,11 @@ export default defineRow("PhotoGalleryRow", {
 		actions: [],
 		source: `{${MARKETPLACE_RESOURCE.ITEMS}.photo_ids}`,
 		visible: "true",
-		view: {
-			content: {
-				title: "Photo gallery row title",
-			},
-		},
+		title: "Photo gallery row title",
 		destination: "",
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title} fullWidthContent>
+		<RowLayout title={row.config.title} fullWidthContent>
 			<div
 				className="evy-relative evy-w-full evy-bg-gray-light evy-overflow-hidden evy-flex evy-items-center evy-justify-center"
 				style={{ aspectRatio: "4/3" }}

--- a/web/app/rows/edit/SearchRow.tsx
+++ b/web/app/rows/edit/SearchRow.tsx
@@ -22,11 +22,7 @@ const defaultSearchResultTemplateRow: Row = {
 		visible: "true",
 		destination: "",
 		actions: [],
-		view: {
-			content: {
-				...SEARCH_DEFAULT_RESULT_CONTENT,
-			},
-		},
+		...SEARCH_DEFAULT_RESULT_CONTENT,
 	},
 };
 
@@ -36,23 +32,19 @@ export default defineRow("SearchRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Search row title",
-				placeholder: "placeholder",
-				value: "",
-				child: defaultSearchResultTemplateRow,
-			},
-		},
+		title: "Search row title",
+		placeholder: "placeholder",
+		value: "",
+		child: defaultSearchResultTemplateRow,
 		destination: "{address}",
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div className="evy-relative">
 				<InlineIcon icon="::search::" alt="Search" />
 				<Input
 					value={row.config.source}
-					placeholder={row.config.view.content.placeholder}
+					placeholder={row.config.placeholder}
 				/>
 			</div>
 		</RowLayout>

--- a/web/app/rows/edit/SelectPhotoRow.tsx
+++ b/web/app/rows/edit/SelectPhotoRow.tsx
@@ -10,32 +10,28 @@ export default defineRow("SelectPhotoRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Select photo row title",
-				subtitle: "Photos: 0/10",
-				icon: "::image-plus::",
-				content: "Add photos",
-				photos: `{${MARKETPLACE_RESOURCE.ITEMS}.photo_ids}`,
-			},
-		},
+		title: "Select photo row title",
+		subtitle: "Photos: 0/10",
+		icon: "::image-plus::",
+		content: "Add photos",
+		photos: `{${MARKETPLACE_RESOURCE.ITEMS}.photo_ids}`,
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.photo_ids}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div
 				className="evy-rounded-md evy-border evy-text-sm"
 				style={{ padding: "var(--size-8)" }}
 			>
 				<div className="evy-flex evy-justify-center evy-text-center evy-flex-col">
-					<EVYText text={row.config.view.content.icon} />
+					<EVYText text={row.config.icon} />
 					<p className="evy-text-sm">
-						<EVYText text={row.config.view.content.content} />
+						<EVYText text={row.config.content} />
 					</p>
 				</div>
 			</div>
 			<p className="evy-text-sm">
-				<EVYText text={row.config.view.content.subtitle} />
+				<EVYText text={row.config.subtitle} />
 			</p>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/TextAreaRow.tsx
+++ b/web/app/rows/edit/TextAreaRow.tsx
@@ -10,20 +10,16 @@ export default defineRow("TextAreaRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Text area row title",
-				value: "",
-				placeholder: "placeholder",
-			},
-		},
+		title: "Text area row title",
+		value: "",
+		placeholder: "placeholder",
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.description}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<TextArea
-				value={row.config.view.content.value}
-				placeholder={row.config.view.content.placeholder}
+				value={row.config.value}
+				placeholder={row.config.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/edit/TextSelectRow.tsx
+++ b/web/app/rows/edit/TextSelectRow.tsx
@@ -11,19 +11,15 @@ export default defineRow("TextSelectRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Text select row title",
-				text: "placeholder",
-			},
-		},
+		title: "Text select row title",
+		text: "placeholder",
 		destination: `{${MARKETPLACE_RESOURCE.ITEMS}.payment_cash}`,
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div className="evy-flex evy-justify-between evy-gap-2">
 				<p className="evy-text-sm">
-					<EVYText text={row.config.view.content.text} />
+					<EVYText text={row.config.text} />
 				</p>
 				<Checkbox checked={false} />
 			</div>

--- a/web/app/rows/edit/TimeslotPickerRow.tsx
+++ b/web/app/rows/edit/TimeslotPickerRow.tsx
@@ -87,28 +87,18 @@ function SlotChip({
 	);
 }
 
-function DayColumn({
-	day,
-	headerFormat,
-	headerSubtitle,
-	timeslotFormat,
-}: {
-	day: MockDay;
-	headerFormat: string;
-	headerSubtitle: string;
-	timeslotFormat: string;
-}) {
+function DayColumn({ day, config }: { day: MockDay; config: RowConfig }) {
 	const parseText = useParseText();
 	return (
 		<div className="evy-flex evy-flex-col evy-items-center">
 			<div className="evy-text-center evy-mb-1">
 				<div className="evy-text-sm evy-text-gray evy-font-medium">
-					{parseText(headerFormat, {
+					{parseText(config.header_format ?? "", {
 						datum: day.representativeDatetime,
 					})}
 				</div>
 				<div className="evy-text-sm evy-text-gray">
-					{parseText(headerSubtitle, {
+					{parseText(config.header_subtitle ?? "", {
 						datum: day.representativeDatetime,
 					})}
 				</div>
@@ -118,7 +108,7 @@ function DayColumn({
 					<SlotChip
 						key={slot.datetime}
 						slot={slot}
-						timeslotFormat={timeslotFormat}
+						timeslotFormat={config.timeslot_format ?? ""}
 					/>
 				))}
 			</div>
@@ -132,30 +122,24 @@ export default defineRow("TimeslotPickerRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Timeslot picker row title",
-				start_time: "07:00",
-				end_time: "19:00",
-				timeslot_interval_minutes: 30,
-				label_interval_minutes: 60,
-				header_format: '{formatDatetime($datum, "EEE")}',
-				header_subtitle: '{formatDatetime($datum, "MMM do")}',
-				timeslot_format: '{formatDatetime($datum, "HH:mm")}',
-			},
-		},
+		title: "Timeslot picker row title",
+		start_time: "07:00",
+		end_time: "19:00",
+		timeslot_interval_minutes: 30,
+		label_interval_minutes: 60,
+		header_format: '{formatDatetime($datum, "EEE")}',
+		header_subtitle: '{formatDatetime($datum, "MMM do")}',
+		timeslot_format: '{formatDatetime($datum, "HH:mm")}',
 		destination: "",
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<div className="evy-flex evy-justify-center evy-gap-1 evy-mt-2">
 				{visibleDays.map((day) => (
 					<DayColumn
 						key={day.representativeDatetime}
 						day={day}
-						headerFormat={row.config.view.content.header_format}
-						headerSubtitle={row.config.view.content.header_subtitle}
-						timeslotFormat={row.config.view.content.timeslot_format}
+						config={row.config}
 					/>
 				))}
 			</div>

--- a/web/app/rows/view/HeadingRow.tsx
+++ b/web/app/rows/view/HeadingRow.tsx
@@ -9,15 +9,11 @@ export default defineRow("HeadingRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Heading row title",
-				label: "Label",
-			},
-		},
+		title: "Heading row title",
+		label: "Label",
 	} satisfies RowConfig,
 	render: (row) => {
-		const { title = "", label = "" } = row.config.view.content;
+		const { title = "", label = "" } = row.config;
 
 		return (
 			<div className="evy-flex evy-flex-row evy-items-center evy-gap-2 evy-p-2">

--- a/web/app/rows/view/InputListRow.tsx
+++ b/web/app/rows/view/InputListRow.tsx
@@ -9,19 +9,15 @@ export default defineRow("InputListRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Input list row title",
-				placeholder: "Search for tags",
-				format: "{$datum.value}",
-			},
-		},
+		title: "Input list row title",
+		placeholder: "Search for tags",
+		format: "{$datum.value}",
 	} satisfies RowConfig,
 	render: (row) => (
-		<RowLayout title={row.config.view.content.title}>
+		<RowLayout title={row.config.title}>
 			<Input
 				value={row.config.source}
-				placeholder={row.config.view.content.placeholder}
+				placeholder={row.config.placeholder}
 			/>
 		</RowLayout>
 	),

--- a/web/app/rows/view/ListItemRow.tsx
+++ b/web/app/rows/view/ListItemRow.tsx
@@ -9,20 +9,12 @@ export default defineRow("ListItemRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "List item title",
-				subtitle: "Subtitle",
-				image: "",
-			},
-		},
+		title: "List item title",
+		subtitle: "Subtitle",
+		image: "",
 	} satisfies RowConfig,
 	render: (row) => {
-		const {
-			title = "",
-			subtitle = "",
-			image = "",
-		} = row.config.view.content;
+		const { title = "", subtitle = "", image = "" } = row.config;
 
 		return (
 			<div className="evy-flex evy-flex-row evy-items-center evy-gap-2 evy-px-3 evy-py-2">

--- a/web/app/rows/view/MapRow.tsx
+++ b/web/app/rows/view/MapRow.tsx
@@ -26,16 +26,12 @@ export default defineRow("MapRow", {
 		source: "",
 		visible: "true",
 		destination: "",
-		view: {
-			content: {
-				title: "Map row title",
-				location: `{${MARKETPLACE_RESOURCE.ITEMS}.transfer_options.pickup.address.location}`,
-				subtitle: "Map row subtitle",
-			},
-		},
+		title: "Map row title",
+		location: `{${MARKETPLACE_RESOURCE.ITEMS}.transfer_options.pickup.address.location}`,
+		subtitle: "Map row subtitle",
 	} satisfies RowConfig,
 	render: (row) => {
-		const { title, subtitle } = row.config.view.content;
+		const { title, subtitle } = row.config;
 		return (
 			<RowLayout title={title}>
 				<MapPreview />

--- a/web/app/rows/view/TextActionRow.tsx
+++ b/web/app/rows/view/TextActionRow.tsx
@@ -9,20 +9,12 @@ export default defineRow("TextActionRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Text action title",
-				subtitle: "Subtitle",
-				action: "Change",
-			},
-		},
+		title: "Text action title",
+		subtitle: "Subtitle",
+		action: "Change",
 	} satisfies RowConfig,
 	render: (row) => {
-		const {
-			title = "",
-			subtitle = "",
-			action = "",
-		} = row.config.view.content;
+		const { title = "", subtitle = "", action = "" } = row.config;
 
 		return (
 			<div className="evy-flex evy-flex-row evy-items-center evy-gap-2 evy-p-2">

--- a/web/app/rows/view/TextExpandRow.tsx
+++ b/web/app/rows/view/TextExpandRow.tsx
@@ -6,12 +6,7 @@ import { defineRow } from "../defineRow";
 import EVYText from "../design-system/EVYText";
 import { lineClampStyle } from "../design-system/lineClamp";
 
-function maxLinesValue(maxLines: string | undefined): number {
-	const parsedMaxLines = Number.parseInt(maxLines ?? "", 10);
-	return Number.isFinite(parsedMaxLines) && parsedMaxLines > 0
-		? parsedMaxLines
-		: 3;
-}
+const TEXT_EXPAND_COLLAPSED_LINE_COUNT = 3;
 
 function TextExpandRowInner({ rowId }: { rowId: string }) {
 	const row = useRowById(rowId);
@@ -19,10 +14,9 @@ function TextExpandRowInner({ rowId }: { rowId: string }) {
 	const [expanded, setExpanded] = useState(false);
 	const [canExpand, setCanExpand] = useState(false);
 
-	const title = row?.config.view.content.title ?? "";
-	const text = row?.config.view.content.text ?? "";
-	const expandLabel = row?.config.view.content.expandLabel ?? "";
-	const maxLines = maxLinesValue(row?.config.view.max_lines);
+	const title = row?.config.title ?? "";
+	const text = row?.config.text ?? "";
+	const expandLabel = row?.config.expandLabel ?? "";
 
 	useLayoutEffect(() => {
 		const textElement = textRef.current;
@@ -54,7 +48,11 @@ function TextExpandRowInner({ rowId }: { rowId: string }) {
 				<p
 					ref={textRef}
 					className="evy-text-sm"
-					style={expanded ? undefined : lineClampStyle(maxLines)}
+					style={
+						expanded
+							? undefined
+							: lineClampStyle(TEXT_EXPAND_COLLAPSED_LINE_COUNT)
+					}
 				>
 					<EVYText text={text} />
 				</p>
@@ -78,14 +76,9 @@ export default defineRow("TextExpandRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Expandable text title",
-				text: "This is a longer text row that can be expanded when it spans more lines than the configured maximum.",
-				expandLabel: "Read more",
-			},
-			max_lines: "3",
-		},
+		title: "Expandable text title",
+		text: "This is a longer text row that can be expanded when it spans more lines than the configured maximum.",
+		expandLabel: "Read more",
 	} satisfies RowConfig,
 	Component: TextExpandRowInner,
 });

--- a/web/app/rows/view/TextRow.tsx
+++ b/web/app/rows/view/TextRow.tsx
@@ -9,20 +9,12 @@ export default defineRow("TextRow", {
 		actions: [],
 		source: "",
 		visible: "true",
-		view: {
-			content: {
-				title: "Text row title",
-				subtitle: "Subtitle",
-				label: "Label",
-			},
-		},
+		title: "Text row title",
+		subtitle: "Subtitle",
+		label: "Label",
 	} satisfies RowConfig,
 	render: (row) => {
-		const {
-			title = "",
-			subtitle = "",
-			label = "",
-		} = row.config.view.content;
+		const { title = "", subtitle = "", label = "" } = row.config;
 
 		return (
 			<div className="evy-flex evy-flex-row evy-items-center evy-gap-2 evy-p-2">

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -15,11 +15,9 @@ mockTextWithConfig.config = {
 	source: "",
 	visible: "true",
 	actions: [],
-	view: {
-		content: { title: "", text: "" },
-		max_lines: "",
-	},
-} as Row["config"];
+	title: "",
+	text: "",
+} satisfies RowConfig;
 
 mock.module("../../rows/baseRows", () => ({
 	baseRows: [mockTextWithConfig],
@@ -36,11 +34,9 @@ function textRow(id: string, text = "hello"): Row {
 			source: "",
 			visible: "true",
 			actions: [],
-			view: {
-				content: { title: "T", text },
-				max_lines: "",
-			},
-		} as Row["config"],
+			title: "T",
+			text,
+		} satisfies RowConfig,
 	};
 }
 
@@ -53,14 +49,10 @@ function containerRow(id: string, child: Row, children: Row[] = []): Row {
 			source: "",
 			visible: "true",
 			actions: [],
-			view: {
-				content: {
-					title: "Container",
-					child,
-					children,
-				},
-			},
-		} as Row["config"],
+			title: "Container",
+			child,
+			children,
+		} satisfies RowConfig,
 	};
 }
 
@@ -74,18 +66,14 @@ function calendarRow(id: string): Row {
 			destination: "{pickup_selection}",
 			visible: "true",
 			actions: [],
-			view: {
-				content: {
-					title: "Calendar",
-					start_time: "07:00",
-					end_time: "19:00",
-					timeslot_interval_minutes: 30,
-					label_interval_minutes: 60,
-					header_format: "EEE d",
-					timeslot_format: "HH:mm",
-				},
-			},
-		} as Row["config"],
+			title: "Calendar",
+			start_time: "07:00",
+			end_time: "19:00",
+			timeslot_interval_minutes: 30,
+			label_interval_minutes: 60,
+			header_format: "EEE d",
+			timeslot_format: "HH:mm",
+		} satisfies RowConfig,
 	};
 }
 
@@ -98,14 +86,10 @@ function selectSegmentRow(id: string): Row {
 			source: "",
 			visible: "true",
 			actions: [],
-			view: {
-				content: {
-					title: "Segments",
-					segments: ["X", "Y", "Z"],
-					children: [],
-				},
-			},
-		} as Row["config"],
+			title: "Segments",
+			segments: ["X", "Y", "Z"],
+			children: [],
+		} satisfies RowConfig,
 	};
 }
 
@@ -199,7 +183,7 @@ describe("pageReducer", () => {
 			configValue: "updated",
 		});
 		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
-		expect(row?.config.view.content.text).toBe("updated");
+		expect(row?.config.text).toBe("updated");
 	});
 
 	it("UPDATE_ROW keeps comma-containing string fields as strings", () => {
@@ -225,20 +209,7 @@ describe("pageReducer", () => {
 			configValue: "EEE d, HH:mm",
 		});
 		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
-		expect(row?.config.view.content.header_format).toBe("EEE d, HH:mm");
-	});
-
-	it("Calendar fixture uses row-level selection bindings", () => {
-		const row = calendarRow("row-1");
-		expect(row.config.source).toBe("{delivery_selection}");
-		expect(row.config.destination).toBe("{pickup_selection}");
-		expect(row.config.view.content.header_format).toBe("EEE d");
-		expect(row.config.view.content.timeslot_format).toBe("HH:mm");
-		expect(row.config.view.content).not.toHaveProperty("primary");
-		expect(row.config.view.content).not.toHaveProperty("secondary");
-		expect(row.config.view.content).not.toHaveProperty(
-			"secondary_timeslots",
-		);
+		expect(row?.config.header_format).toBe("EEE d, HH:mm");
 	});
 
 	it("UPDATE_ROW splits comma-separated values for array content fields", () => {
@@ -264,14 +235,10 @@ describe("pageReducer", () => {
 			configValue: "One, Two, Three",
 		});
 		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
-		expect(row?.config.view.content.segments).toEqual([
-			"One",
-			"Two",
-			"Three",
-		]);
+		expect(row?.config.segments).toEqual(["One", "Two", "Three"]);
 	});
 
-	it("UPDATE_ROW_ROOT sets source without changing view.content", () => {
+	it("UPDATE_ROW_ROOT sets source without changing row attributes", () => {
 		const state = initialState();
 		const before = state.flows[0].pages[0].rows.find(
 			(r) => r.id === "row-1",
@@ -284,7 +251,8 @@ describe("pageReducer", () => {
 		});
 		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
 		expect(row?.config.source).toBe("{items}");
-		expect(row?.config.view.content).toEqual(before?.config.view.content);
+		expect(row?.config.title).toEqual(before?.config.title);
+		expect(row?.config.text).toEqual(before?.config.text);
 	});
 
 	it("UPDATE_ROW_ROOT sets destination to empty string when value is empty string", () => {
@@ -341,13 +309,9 @@ describe("pageReducer", () => {
 				source: "",
 				visible: "true",
 				actions: [],
-				view: {
-					content: {
-						title: "",
-						children: [inner],
-					},
-				},
-			} as Row["config"],
+				title: "",
+				children: [inner],
+			} satisfies RowConfig,
 		};
 		const state = initialState({
 			flows: [
@@ -383,13 +347,9 @@ describe("pageReducer", () => {
 				source: "",
 				visible: "true",
 				actions: [],
-				view: {
-					content: {
-						title: "",
-						children: [inner],
-					},
-				},
-			} as Row["config"],
+				title: "",
+				children: [inner],
+			} satisfies RowConfig,
 		};
 		const state = initialState({
 			flows: [
@@ -613,9 +573,7 @@ describe("pageReducer", () => {
 			pageId: "page-1",
 			rowId: "foot-inner",
 		});
-		expect(
-			next.flows[0].pages[0].footer?.config.view.content.child,
-		).toBeUndefined();
+		expect(next.flows[0].pages[0].footer?.config.child).toBeUndefined();
 		expect(next.flows[0].pages[0].rows.length).toBe(0);
 	});
 
@@ -679,7 +637,7 @@ describe("pageReducer", () => {
 		const parentAfter = next.flows[0].pages[0].rows.find(
 			(r) => r.id === "parent",
 		);
-		expect(parentAfter?.config.view.content.child?.id).toBe(newId);
+		expect(parentAfter?.config.child?.id).toBe(newId);
 	});
 
 	it("ADD_ROW inserts palette row into footer container", () => {
@@ -710,7 +668,7 @@ describe("pageReducer", () => {
 			destinationContainer: { rowId: "footer-sheet", type: "children" },
 		});
 		const footAfter = next.flows[0].pages[0].footer;
-		expect(footAfter?.config.view.content.children?.[0].id).toBe(newId);
+		expect(footAfter?.config.children?.[0].id).toBe(newId);
 	});
 
 	it("ADD_ROW_AS_FOOTER adds palette row as page footer", () => {
@@ -854,13 +812,8 @@ describe("pageReducer", () => {
 		const footerAfter = next.flows[0].pages[0].footer;
 		expect(footerAfter).toBeDefined();
 		expect(footerAfter?.id).toBe("footer-root");
-		expect(footerAfter?.config.view.content.child?.id).toBe(
-			"footer-parent",
-		);
-		expect(
-			footerAfter?.config.view.content.child?.config.view.content.child
-				?.id,
-		).toBe(newId);
+		expect(footerAfter?.config.child?.id).toBe("footer-parent");
+		expect(footerAfter?.config.child?.config.child?.id).toBe(newId);
 
 		// Selection / config stack should reflect the new child chain.
 		// The path starts from the footer root (the page-level entry point).

--- a/web/app/state/reducers/pageReducer.test.ts
+++ b/web/app/state/reducers/pageReducer.test.ts
@@ -13,6 +13,7 @@ const mockTextWithConfig = MockTextBase as typeof MockTextBase & {
 mockTextWithConfig.config = {
 	type: "Text",
 	source: "",
+	visible: "true",
 	actions: [],
 	view: {
 		content: { title: "", text: "" },
@@ -33,6 +34,7 @@ function textRow(id: string, text = "hello"): Row {
 		config: {
 			type: "Text",
 			source: "",
+			visible: "true",
 			actions: [],
 			view: {
 				content: { title: "T", text },
@@ -49,6 +51,7 @@ function containerRow(id: string, child: Row, children: Row[] = []): Row {
 		config: {
 			type: "ListContainer",
 			source: "",
+			visible: "true",
 			actions: [],
 			view: {
 				content: {
@@ -67,7 +70,9 @@ function calendarRow(id: string): Row {
 		row: null,
 		config: {
 			type: "Calendar",
-			source: "",
+			source: "{delivery_selection}",
+			destination: "{pickup_selection}",
+			visible: "true",
 			actions: [],
 			view: {
 				content: {
@@ -76,10 +81,8 @@ function calendarRow(id: string): Row {
 					end_time: "19:00",
 					timeslot_interval_minutes: 30,
 					label_interval_minutes: 60,
-					header_format: '{formatDatetime($datum, "EEE d")}',
-					timeslot_format: '{formatDatetime($datum, "HH:mm")}',
-					primary: "{pickup_selection}",
-					secondary: "{delivery_selection}",
+					header_format: "EEE d",
+					timeslot_format: "HH:mm",
 				},
 			},
 		} as Row["config"],
@@ -93,6 +96,7 @@ function selectSegmentRow(id: string): Row {
 		config: {
 			type: "SelectSegmentContainer",
 			source: "",
+			visible: "true",
 			actions: [],
 			view: {
 				content: {
@@ -218,11 +222,22 @@ describe("pageReducer", () => {
 			type: "UPDATE_ROW",
 			rowId: "row-1",
 			configId: "header_format",
-			configValue: '{formatDatetime($datum, "EEE dd")}',
+			configValue: "EEE d, HH:mm",
 		});
 		const row = next.flows[0].pages[0].rows.find((r) => r.id === "row-1");
-		expect(row?.config.view.content.header_format).toBe(
-			'{formatDatetime($datum, "EEE dd")}',
+		expect(row?.config.view.content.header_format).toBe("EEE d, HH:mm");
+	});
+
+	it("Calendar fixture uses row-level selection bindings", () => {
+		const row = calendarRow("row-1");
+		expect(row.config.source).toBe("{delivery_selection}");
+		expect(row.config.destination).toBe("{pickup_selection}");
+		expect(row.config.view.content.header_format).toBe("EEE d");
+		expect(row.config.view.content.timeslot_format).toBe("HH:mm");
+		expect(row.config.view.content).not.toHaveProperty("primary");
+		expect(row.config.view.content).not.toHaveProperty("secondary");
+		expect(row.config.view.content).not.toHaveProperty(
+			"secondary_timeslots",
 		);
 	});
 
@@ -324,6 +339,7 @@ describe("pageReducer", () => {
 			config: {
 				type: "ListContainer",
 				source: "",
+				visible: "true",
 				actions: [],
 				view: {
 					content: {
@@ -365,6 +381,7 @@ describe("pageReducer", () => {
 			config: {
 				type: "ListContainer",
 				source: "",
+				visible: "true",
 				actions: [],
 				view: {
 					content: {

--- a/web/app/state/reducers/pageReducer.ts
+++ b/web/app/state/reducers/pageReducer.ts
@@ -18,6 +18,8 @@ import {
 	updateRowInTree,
 } from "../../utils/rowTree";
 
+const SEARCH_ROW_TYPE = "Search";
+
 const CLEARED_SELECTION: Partial<AppState> = {
 	activePageId: undefined,
 	activeRowId: undefined,
@@ -72,7 +74,7 @@ function ensureShowActionOnParent(
 ): UI_Page[] {
 	if (!destinationContainer) return pages;
 	const parentRow = findRowInPages(destinationContainer.rowId, pages);
-	if (!parentRow || parentRow.config.type === "Search") return pages;
+	if (!parentRow || parentRow.config.type === SEARCH_ROW_TYPE) return pages;
 	if (parentRow.config.actions.some((a) => a.true === "{show()}"))
 		return pages;
 
@@ -355,21 +357,13 @@ export const pageReducer = (state: AppState, action: RowAction): AppState => {
 				const value = configContentValue(
 					action.configId,
 					action.configValue,
-					row.config.view.content[
-						action.configId as keyof typeof row.config.view.content
-					],
+					row.config[action.configId as keyof typeof row.config],
 				);
 				return {
 					...row,
 					config: {
 						...row.config,
-						view: {
-							...row.config.view,
-							content: {
-								...row.config.view.content,
-								[action.configId]: value,
-							},
-						},
+						[action.configId]: value,
 					},
 				};
 			};

--- a/web/app/types/row.ts
+++ b/web/app/types/row.ts
@@ -1,13 +1,10 @@
 /**
- * Row types. All serial shapes come from evy-types (schema-generated).
- * RowContent/RowView/RowConfig are derived with UI Row in place of serial Row.
+ * Row types. Serial row shapes come from evy-types (schema-generated).
+ * RowConfig is the serial row shape without id, with recursive child rows using the UI Row type.
  * Row is the UI type (id + ReactNode + config).
  */
 
-import type {
-	UI_Row as SerialRow,
-	UI_RowContent as SerialRowContent,
-} from "evy-types";
+import type { UI_Row as SerialRow } from "evy-types";
 import type React from "react";
 
 export type Row = {
@@ -16,18 +13,11 @@ export type Row = {
 	config: RowConfig;
 };
 
-/** Same shape as evy-types RowContent but children/child use UI Row */
-type RowContent = Omit<SerialRowContent, "children" | "child"> & {
+type RowAttributes = Omit<SerialRow, "id" | "child" | "children"> & {
 	children?: Row[];
 	child?: Row;
 };
 
-/** Same shape as serial Row.view but content uses UI RowContent */
-type RowView = Omit<SerialRow["view"], "content"> & {
-	content: RowContent;
-};
-
-/** Same shape as evy-types Row minus id; view uses RowView (UI content) */
-export type RowConfig = Omit<SerialRow, "id" | "view"> & { view: RowView };
+export type RowConfig = RowAttributes;
 
 export type ContainerType = "child" | "children";

--- a/web/app/utils/childPageHelpers.ts
+++ b/web/app/utils/childPageHelpers.ts
@@ -24,7 +24,7 @@ export function buildActiveChildPages({
 	let currentParentRow = activeRootRow;
 
 	for (const selectedDescendantRowId of configStack) {
-		const singularChild = currentParentRow.config.view.content.child;
+		const singularChild = currentParentRow.config.child;
 		if (singularChild?.id === selectedDescendantRowId) {
 			childPages.push({
 				childRow: singularChild,
@@ -34,7 +34,7 @@ export function buildActiveChildPages({
 			continue;
 		}
 
-		const nestedChild = currentParentRow.config.view.content.children?.find(
+		const nestedChild = currentParentRow.config.children?.find(
 			(child) => child.id === selectedDescendantRowId,
 		);
 		if (nestedChild) {
@@ -47,7 +47,7 @@ export function buildActiveChildPages({
 		currentParentRow = fallbackRow;
 	}
 
-	const nextChildRow = currentParentRow.config.view.content.child;
+	const nextChildRow = currentParentRow.config.child;
 	if (nextChildRow) {
 		childPages.push({
 			childRow: nextChildRow,

--- a/web/app/utils/decodeFlow.test.ts
+++ b/web/app/utils/decodeFlow.test.ts
@@ -20,10 +20,11 @@ const ROW_B = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
 function makeServerRow(overrides: Record<string, unknown> = {}): ServerRow {
 	return {
 		id: ROW_A,
+		type: "Text",
 		source: "",
 		visible: "",
 		actions: [],
-		view: { content: {} },
+		title: "",
 		...overrides,
 	} as unknown as ServerRow;
 }
@@ -32,58 +33,46 @@ describe("normalizeServerRow", () => {
 	it("fills root string defaults and empty destination when omitted", () => {
 		const partial = makeServerRow({
 			type: "Button",
-			view: {
-				content: {
-					label: "OK",
-				},
-			},
+			label: "OK",
 			actions: [{ condition: "", false: "", true: "{close()}" }],
 		});
 
 		const n = normalizeServerRow(partial);
 		expect(n.source).toBe("");
 		expect(n.destination).toBe("");
-		expect(n.view.content).toMatchObject({
+		expect(n).toMatchObject({
 			title: "",
 			label: "OK",
 		});
 	});
 
-	it("does not merge Text content string fields from defaults when missing", () => {
+	it("does not merge Text string fields from defaults when missing", () => {
 		const n = normalizeServerRow(
 			makeServerRow({
 				type: "Text",
-				view: {
-					content: {
-						title: "T",
-						subtitle: "Sub",
-					},
-				},
+				title: "T",
+				subtitle: "Sub",
 			}),
 		);
 
-		expect(n.view.content).toEqual({
+		expect(rowAttributes(n)).toEqual({
 			title: "T",
 			subtitle: "Sub",
 		});
 	});
 
-	it("preserves Text content keys as sent by the server", () => {
+	it("preserves Text keys as sent by the server", () => {
 		const n = normalizeServerRow(
 			makeServerRow({
 				type: "Text",
-				view: {
-					content: {
-						title: "T",
-						text: "extra",
-						subtitle: "",
-						icon: "",
-					},
-				},
+				title: "T",
+				text: "extra",
+				subtitle: "",
+				icon: "",
 			}),
 		);
 
-		expect((n.view.content as { text?: string }).text).toBe("extra");
+		expect(n.text).toBe("extra");
 	});
 
 	it("normalizes Map row without replacing live non-string location", () => {
@@ -91,16 +80,12 @@ describe("normalizeServerRow", () => {
 		const n = normalizeServerRow(
 			makeServerRow({
 				type: "Map",
-				view: {
-					content: {
-						title: "Pickup location",
-						location,
-					},
-				},
+				title: "Pickup location",
+				location,
 			}),
 		);
 
-		expect(n.view.content as unknown).toEqual({
+		expect(rowAttributes(n)).toEqual({
 			title: "Pickup location",
 			location,
 		});
@@ -110,29 +95,21 @@ describe("normalizeServerRow", () => {
 		const n = normalizeServerRow(
 			makeServerRow({
 				type: "ListContainer",
-				view: {
-					content: {
-						title: "List",
-						children: [
-							makeServerRow({
-								id: ROW_B,
-								type: "Button",
-								view: {
-									content: {
-										label: "Go",
-									},
-								},
-							}),
-						],
-					},
-				},
+				title: "List",
+				children: [
+					makeServerRow({
+						id: ROW_B,
+						type: "Button",
+						label: "Go",
+					}),
+				],
 			}),
 		);
 
-		const first = n.view.content.children?.[0];
+		const first = n.children?.[0];
 		expect(first?.type).toBe("Button");
 		expect(first?.destination).toBe("");
-		expect(first?.view.content).toMatchObject({
+		expect(first).toMatchObject({
 			title: "",
 			label: "Go",
 		});
@@ -143,27 +120,19 @@ describe("normalizeServerRow", () => {
 			makeServerRow({
 				type: "ListContainer",
 				source: "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd}",
-				view: {
-					content: {
-						title: "List",
-						child: makeServerRow({
-							id: ROW_B,
-							type: "Text",
-							view: {
-								content: {
-									title: "{$datum.title}",
-								},
-							},
-						}),
-						children: [],
-					},
-				},
+				title: "List",
+				child: makeServerRow({
+					id: ROW_B,
+					type: "Text",
+					title: "{$datum.title}",
+				}),
+				children: [],
 			}),
 		);
 
-		expect(n.view.content.child?.type).toBe("Text");
-		expect(n.view.content.child?.destination).toBe("");
-		expect(n.view.content.child?.view.content).toEqual({
+		expect(n.child?.type).toBe("Text");
+		expect(n.child?.destination).toBe("");
+		expect(rowAttributes(n.child)).toEqual({
 			title: "{$datum.title}",
 		});
 	});
@@ -172,16 +141,12 @@ describe("normalizeServerRow", () => {
 		const n = normalizeServerRow(
 			makeServerRow({
 				type: "SelectSegmentContainer",
-				view: {
-					content: {
-						title: "Tabs",
-						children: [],
-					},
-				},
+				title: "Tabs",
+				children: [],
 			}),
 		);
 
-		expect(n.view.content).toEqual({
+		expect(rowAttributes(n)).toEqual({
 			title: "Tabs",
 			children: [],
 		});
@@ -193,16 +158,12 @@ describe("normalizeServerRow", () => {
 				type: "Search",
 				source: "{tags}",
 				destination: "",
-				view: {
-					content: {
-						title: "Find",
-						placeholder: "Search",
-					},
-				},
+				title: "Find",
+				placeholder: "Search",
 			}),
 		);
 
-		expect(n.view.content).toEqual({
+		expect(rowAttributes(n)).toEqual({
 			title: "Find",
 			placeholder: "Search",
 		});
@@ -226,13 +187,8 @@ describe("decodeFlows / encodeFlow", () => {
 							actions: [],
 							visible:
 								"{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_methods.cash == true}",
-							view: {
-								content: {
-									title: "Hello",
-									text: "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}",
-								},
-								max_lines: "",
-							},
+							title: "Hello",
+							text: "{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.title}",
 						},
 					],
 				},
@@ -254,9 +210,7 @@ describe("decodeRow unknown types", () => {
 			type: "FutureRow",
 			visible:
 				"{dc28ed59-298e-493c-8ff3-3e60f2ebccbd.payment_methods.cash == true}",
-			view: {
-				content: { title: "Future" },
-			},
+			title: "Future",
 		});
 		const flow = {
 			id: FLOW_ID,
@@ -281,17 +235,31 @@ describe("buildRowForNewPageFromBase", () => {
 		const row = buildRowForNewPageFromBase(SearchRow, newId);
 		expect(row.id).toBe(newId);
 		expect(row.config.type).toBe("Search");
-		expect(row.config.view.content.title).toBe("Search row title");
-		expect(row.config.view.content.placeholder).toBe("");
-		const child = row.config.view.content.child;
+		expect(row.config.title).toBe("Search row title");
+		expect(row.config.placeholder).toBe("");
+		const child = row.config.child;
 		invariant(child, "search row template child");
 		const childId = child.id;
 		expect(childId).toBeDefined();
 		expect(childId).not.toBe("09f07052-c27c-4116-a508-a2bcb074c827");
-		expect(child.config.view.content).toMatchObject({
+		expect(child.config).toMatchObject({
 			title: "{$datum.value}",
 			subtitle: "",
 			label: "",
 		});
 	});
 });
+
+function rowAttributes(row: ServerRow | undefined): Record<string, unknown> {
+	if (!row) return {};
+	const {
+		id: _id,
+		type: _type,
+		source: _source,
+		destination: _destination,
+		actions: _actions,
+		visible: _visible,
+		...attributes
+	} = row as ServerRow & Record<string, unknown>;
+	return attributes;
+}

--- a/web/app/utils/decodeFlow.ts
+++ b/web/app/utils/decodeFlow.ts
@@ -2,13 +2,13 @@ import type {
 	UI_Flow as ServerFlow,
 	UI_Page as ServerPage,
 	UI_Row as ServerRow,
-	UI_RowContent as ServerRowContent,
 } from "evy-types";
 import { createElement } from "react";
 import { baseRows } from "../rows/baseRows";
 import { UnknownRow } from "../rows/EVYRow";
 import type { UI_Flow, UI_Page } from "../types/flow";
-import type { Row } from "../types/row";
+import type { Row, RowConfig } from "../types/row";
+import { ROW_METADATA_KEYS } from "./rowConstants";
 
 type RowComponent = (typeof baseRows)[number];
 
@@ -20,19 +20,27 @@ function getBaseRowForType(type: string): RowComponent | undefined {
 	return BASE_ROW_BY_TYPE.get(type);
 }
 
+function rowConfigAttributes(config: RowConfig): Record<string, unknown> {
+	const attributes: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(config)) {
+		if (!ROW_METADATA_KEYS.has(key) && value !== undefined) {
+			attributes[key] = value;
+		}
+	}
+	return attributes;
+}
+
 export function mergeRowContentWithPaletteDefaults(
 	row: Row,
 ): Record<string, unknown> {
 	const baseRow = getBaseRowForType(row.config.type);
-	const content = {
-		...(row.config.view.content as Record<string, unknown>),
-	};
+	const attributes = rowConfigAttributes(row.config);
 	if (!baseRow) {
-		return content;
+		return attributes;
 	}
 	return {
-		...(baseRow.config.view.content as Record<string, unknown>),
-		...content,
+		...rowConfigAttributes(baseRow.config),
+		...attributes,
 	};
 }
 
@@ -41,21 +49,7 @@ export function normalizeServerRow(row: ServerRow): ServerRow {
 	if (!baseRow) {
 		return normalizeUnknownServerRow(row);
 	}
-	const view: ServerRow["view"] = {
-		content: normalizeServerRowContent(row.view.content),
-	};
-	if (row.view.max_lines !== undefined) {
-		view.max_lines = row.view.max_lines;
-	}
-	return {
-		id: row.id,
-		type: row.type,
-		source: row.source ?? "",
-		destination: row.destination ?? "",
-		actions: row.actions ?? [],
-		visible: row.visible ?? "true",
-		view,
-	};
+	return normalizeKnownServerRow(row);
 }
 
 export function normalizeServerFlow(flow: ServerFlow): ServerFlow {
@@ -69,80 +63,41 @@ export function normalizeServerFlow(flow: ServerFlow): ServerFlow {
 	};
 }
 
-function normalizeUnknownServerRow(row: ServerRow): ServerRow {
-	const title =
-		typeof row.view.content.title === "string"
-			? row.view.content.title
-			: "Unknown row";
+function normalizeKnownServerRow(row: ServerRow): ServerRow {
 	return {
+		...normalizeRowAttributes(row, normalizeServerRow),
 		id: row.id,
 		type: row.type,
 		source: row.source ?? "",
 		destination: row.destination ?? "",
 		actions: row.actions ?? [],
 		visible: row.visible ?? "true",
-		view: {
-			...(row.view.max_lines !== undefined
-				? { max_lines: row.view.max_lines }
-				: {}),
-			content: {
-				...row.view.content,
-				title,
-			} as ServerRowContent,
-		},
-	};
-}
-
-function normalizeServerRowContent(
-	incoming: ServerRowContent,
-): ServerRowContent {
-	return transformRowContent(
-		incoming as unknown as Record<string, unknown>,
-		normalizeServerRow,
-	);
-}
-
-/** Map builder Row → wire ServerRow shape (recursive child/children); does not run `normalizeServerRow`. */
-function rowToServerRow(row: Row): ServerRow {
-	const { view, ...rowRoot } = row.config;
-	const content = view.content as unknown as Record<string, unknown>;
-	const serverContent: Record<string, unknown> = {};
-	for (const key of Object.keys(content)) {
-		if (key === "children") {
-			const ch = content.children;
-			serverContent.children = Array.isArray(ch)
-				? (ch as Row[]).map(rowToServerRow)
-				: [];
-		} else if (key === "child") {
-			if (content.child) {
-				serverContent.child = rowToServerRow(content.child as Row);
-			}
-		} else {
-			serverContent[key] = content[key];
-		}
-	}
-	return {
-		id: row.id,
-		...rowRoot,
-		view: {
-			...view,
-			content: serverContent as unknown as ServerRowContent,
-		},
+		title: typeof row.title === "string" ? row.title : "",
 	} as ServerRow;
 }
 
-function encodeRowContent(incoming: Record<string, unknown>): ServerRowContent {
-	return transformRowContent(incoming, (row) =>
-		encodeRowToServerRow(row as unknown as Row),
-	);
+function normalizeUnknownServerRow(row: ServerRow): ServerRow {
+	return {
+		...normalizeRowAttributes(row, normalizeServerRow),
+		id: row.id,
+		type: row.type,
+		source: row.source ?? "",
+		destination: row.destination ?? "",
+		actions: row.actions ?? [],
+		visible: row.visible ?? "true",
+		title: typeof row.title === "string" ? row.title : "Unknown row",
+	} as ServerRow;
 }
 
-function transformRowContent(
-	incoming: Record<string, unknown>,
+function normalizeRowAttributes(
+	incoming: ServerRow,
 	transformRow: (row: ServerRow) => ServerRow,
-): ServerRowContent {
+): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(incoming)) {
+		if (ROW_METADATA_KEYS.has(key)) {
+			continue;
+		}
 		if (key === "children") {
 			out.children = Array.isArray(value)
 				? value.map((child) => transformRow(child as ServerRow))
@@ -164,36 +119,54 @@ function transformRowContent(
 				: [];
 			continue;
 		}
-		out[key] = value;
+		if (value !== undefined) {
+			out[key] = value;
+		}
 	}
 	if (typeof out.title !== "string") {
 		out.title = "";
 	}
-	return out as unknown as ServerRowContent;
+	return out;
 }
 
-function encodeRowToServerRow(row: Row): ServerRow {
-	const baseRow = getBaseRowForType(row.config.type);
-	if (!baseRow) {
-		return normalizeUnknownServerRow(rowToServerRow(row));
-	}
-	const view: ServerRow["view"] = {
-		content: encodeRowContent(
-			row.config.view.content as unknown as Record<string, unknown>,
-		),
-	};
-	if (row.config.view.max_lines !== undefined) {
-		view.max_lines = row.config.view.max_lines;
-	}
-	return {
+function rowToServerRow(row: Row): ServerRow {
+	const serverRow: Record<string, unknown> = {
 		id: row.id,
 		type: row.config.type,
 		source: row.config.source ?? "",
 		destination: row.config.destination ?? "",
 		actions: row.config.actions ?? [],
 		visible: row.config.visible ?? "true",
-		view,
 	};
+
+	for (const [key, value] of Object.entries(row.config)) {
+		if (ROW_METADATA_KEYS.has(key) || value === undefined) {
+			continue;
+		}
+		if (key === "children") {
+			serverRow.children = Array.isArray(value)
+				? (value as Row[]).map(rowToServerRow)
+				: [];
+			continue;
+		}
+		if (key === "child") {
+			if (value) {
+				serverRow.child = rowToServerRow(value as Row);
+			}
+			continue;
+		}
+		serverRow[key] = value;
+	}
+
+	if (typeof serverRow.title !== "string") {
+		serverRow.title = "";
+	}
+
+	return serverRow as ServerRow;
+}
+
+function encodeRowToServerRow(row: Row): ServerRow {
+	return normalizeServerRow(rowToServerRow(row));
 }
 
 export function encodeFlow(flow: UI_Flow): ServerFlow {
@@ -210,6 +183,7 @@ export function encodeFlow(flow: UI_Flow): ServerFlow {
 function decodeRow(row: ServerRow): Row {
 	const normalized = normalizeServerRow(row);
 	const baseRow = getBaseRowForType(normalized.type);
+	const config = decodeRowConfig(normalized);
 	if (!baseRow) {
 		return {
 			id: normalized.id,
@@ -217,28 +191,9 @@ function decodeRow(row: ServerRow): Row {
 				key: normalized.id,
 				rowId: normalized.id,
 			}),
-			config: {
-				type: normalized.type,
-				source: normalized.source,
-				destination: normalized.destination,
-				actions: normalized.actions,
-				visible: normalized.visible,
-				view: normalized.view as Row["config"]["view"],
-			},
+			config,
 		};
 	}
-	const vc = normalized.view.content;
-	const decodedContent = {
-		...vc,
-		...(Array.isArray(vc.children)
-			? {
-					children: vc.children.map((child: ServerRow) =>
-						decodeRow(child),
-					),
-				}
-			: {}),
-		...(vc.child ? { child: decodeRow(vc.child) } : {}),
-	} as unknown as Row["config"]["view"]["content"];
 
 	return {
 		id: normalized.id,
@@ -246,18 +201,43 @@ function decodeRow(row: ServerRow): Row {
 			key: normalized.id,
 			rowId: normalized.id,
 		}),
-		config: {
-			type: normalized.type,
-			source: normalized.source,
-			destination: normalized.destination,
-			actions: normalized.actions,
-			visible: normalized.visible,
-			view: {
-				max_lines: normalized.view.max_lines,
-				content: decodedContent,
-			},
-		},
+		config,
 	};
+}
+
+function decodeRowConfig(row: ServerRow): RowConfig {
+	const config: Record<string, unknown> = {
+		type: row.type,
+		source: row.source,
+		destination: row.destination ?? "",
+		actions: row.actions,
+		visible: row.visible,
+	};
+
+	for (const [key, value] of Object.entries(row)) {
+		if (ROW_METADATA_KEYS.has(key) || key === "id" || value === undefined) {
+			continue;
+		}
+		if (key === "children") {
+			config.children = Array.isArray(value)
+				? value.map((child) => decodeRow(child as ServerRow))
+				: [];
+			continue;
+		}
+		if (key === "child") {
+			if (value) {
+				config.child = decodeRow(value as ServerRow);
+			}
+			continue;
+		}
+		config[key] = value;
+	}
+
+	if (typeof config.title !== "string") {
+		config.title = "";
+	}
+
+	return config as RowConfig;
 }
 
 export const decodeFlows = (flows: ServerFlow[]): UI_Flow[] => {
@@ -273,44 +253,50 @@ export const decodeFlows = (flows: ServerFlow[]): UI_Flow[] => {
 
 function assignFreshIdsInPlace(row: ServerRow, rootId: string): void {
 	row.id = rootId;
-	const { child, children } = row.view.content;
-	if (child) {
-		assignFreshIdsInPlace(child, crypto.randomUUID());
+	if (row.child) {
+		assignFreshIdsInPlace(row.child, crypto.randomUUID());
 	}
-	if (children) {
-		for (const c of children) {
-			assignFreshIdsInPlace(c, crypto.randomUUID());
+	if (row.children) {
+		for (const childRow of row.children) {
+			assignFreshIdsInPlace(childRow, crypto.randomUUID());
 		}
 	}
 }
 
-function resetContentToTestTitleOnly(
-	content: ServerRowContent,
-): ServerRowContent {
-	const resetContent: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(
-		content as unknown as Record<string, unknown>,
-	)) {
+function resetRowAttributesForNewPage(row: ServerRow): ServerRow {
+	const resetRow: Record<string, unknown> = {
+		id: row.id,
+		type: row.type,
+		source: row.source ?? "",
+		destination: row.destination ?? "",
+		actions: row.actions ?? [],
+		visible: row.visible ?? "true",
+	};
+
+	for (const [key, value] of Object.entries(row)) {
+		if (ROW_METADATA_KEYS.has(key) || key === "id") {
+			continue;
+		}
 		if (key === "title") {
-			resetContent.title = typeof value === "string" ? value : "";
+			resetRow.title = typeof value === "string" ? value : "";
 			continue;
 		}
 		if (key === "children" || key === "segments") {
-			resetContent[key] = [];
+			resetRow[key] = [];
 			continue;
 		}
 		if (key === "child") {
 			if (value !== undefined && value !== null) {
-				resetContent.child = value;
+				resetRow.child = value;
 			}
 			continue;
 		}
-		resetContent[key] = typeof value === "string" ? "" : value;
+		resetRow[key] = typeof value === "string" ? "" : value;
 	}
-	if (typeof resetContent.title !== "string") {
-		resetContent.title = "";
+	if (typeof resetRow.title !== "string") {
+		resetRow.title = "";
 	}
-	return resetContent as unknown as ServerRowContent;
+	return resetRow as ServerRow;
 }
 
 export function buildRowForNewPageFromBase(
@@ -323,8 +309,9 @@ export function buildRowForNewPageFromBase(
 		row: createElement(baseRow, { key: tempId, rowId: tempId }),
 		config: baseRow.config,
 	};
-	const cloned = structuredClone(rowToServerRow(seed));
-	cloned.view.content = resetContentToTestTitleOnly(cloned.view.content);
+	const cloned = resetRowAttributesForNewPage(
+		structuredClone(rowToServerRow(seed)),
+	);
 	assignFreshIdsInPlace(cloned, newRowId);
 	return decodeRow(cloned);
 }

--- a/web/app/utils/dropHandler.ts
+++ b/web/app/utils/dropHandler.ts
@@ -303,16 +303,15 @@ export function handleDrop(
 
 			if (
 				destinationContainer?.type === "children" &&
-				destinationContainer.container.config.view.content.children
-					?.length
+				destinationContainer.container.config.children?.length
 			) {
 				dispatchOptions.destinationIndex =
-					destinationContainer.container.config.view.content.children.findIndex(
+					destinationContainer.container.config.children.findIndex(
 						(r) => r.id === destinationRow.data.rowId,
 					);
 			} else if (
 				destinationContainer?.type === "child" &&
-				destinationContainer.container.config.view.content.child?.id
+				destinationContainer.container.config.child?.id
 			) {
 				dispatchOptions.destinationIndex = 0;
 			} else if (closestEdgeOfTarget && !destinationContainer) {

--- a/web/app/utils/idCandidates.test.ts
+++ b/web/app/utils/idCandidates.test.ts
@@ -15,7 +15,7 @@ import {
 	type IdCandidate,
 } from "./idCandidates";
 
-function makeRow(id: string, content: Row["config"]["view"]["content"]): Row {
+function makeRow(id: string, content: Partial<Row["config"]>): Row {
 	return {
 		id,
 		row: null,
@@ -24,9 +24,8 @@ function makeRow(id: string, content: Row["config"]["view"]["content"]): Row {
 			actions: [],
 			source: "",
 			visible: "true",
-			view: {
-				content,
-			},
+			title: "",
+			...content,
 		},
 	};
 }

--- a/web/app/utils/idCandidates.ts
+++ b/web/app/utils/idCandidates.ts
@@ -4,6 +4,7 @@ import type { ResourceAttributeMetadata, ServiceResource } from "../api/sync";
 import type { UI_Flow } from "../types/flow";
 import type { Row } from "../types/row";
 import { ACTION_FUNCTIONS } from "./actionBranch";
+import { ROW_METADATA_KEYS } from "./rowConstants";
 
 export type IdCandidateCategory =
 	| "Flow"
@@ -49,7 +50,6 @@ type SuggestionFilterContext =
 
 const DATUM_CANDIDATE_ID = "$datum";
 const MAX_FILTERED_CANDIDATES = 20;
-const rowRootAttributeNames = ["source", "destination", "visible"];
 const functionCandidateNames = [
 	...ACTION_FUNCTIONS,
 	"count",
@@ -89,11 +89,18 @@ function isDisplayCandidate(candidate: IdCandidate): boolean {
 }
 
 function addRowAttributeNames(row: Row, attributeNames: Set<string>) {
-	for (const attributeName of rowRootAttributeNames) {
+	const ROOT_ATTRIBUTE_NAMES = [...ROW_METADATA_KEYS].filter(
+		(k) => k !== "id" && k !== "type" && k !== "actions",
+	);
+	for (const attributeName of ROOT_ATTRIBUTE_NAMES) {
 		attributeNames.add(attributeName);
 	}
 
-	for (const [key, value] of Object.entries(row.config.view.content)) {
+	for (const [key, value] of Object.entries(row.config)) {
+		if (ROW_METADATA_KEYS.has(key)) {
+			continue;
+		}
+
 		if (key === "child") {
 			if (isRow(value)) addRowAttributeNames(value, attributeNames);
 			continue;

--- a/web/app/utils/navLabels.ts
+++ b/web/app/utils/navLabels.ts
@@ -3,7 +3,7 @@ import type { Row } from "../types/row";
 import { splitCamelCaseToWords } from "./labelFormatting";
 
 export function breadcrumbLabelForRow(row: Row): string {
-	const title = row.config.view.content.title;
+	const title = row.config.title;
 	if (typeof title === "string" && title.trim() !== "") {
 		return title;
 	}

--- a/web/app/utils/rowConstants.ts
+++ b/web/app/utils/rowConstants.ts
@@ -1,0 +1,10 @@
+// Single source of truth for UI_Row structural metadata field names.
+// These are the fixed fields on every row that are not row-type content.
+export const ROW_METADATA_KEYS = new Set([
+	"id",
+	"type",
+	"source",
+	"destination",
+	"actions",
+	"visible",
+]);

--- a/web/app/utils/rowTree.test.ts
+++ b/web/app/utils/rowTree.test.ts
@@ -18,7 +18,7 @@ import {
 
 function makeRow(
 	id: string,
-	contentOverrides: Partial<Row["config"]["view"]["content"]> = {},
+	contentOverrides: Partial<Row["config"]> = {},
 ): Row {
 	return {
 		id,
@@ -26,14 +26,11 @@ function makeRow(
 		config: {
 			type: "Text",
 			source: "",
+			visible: "true",
 			actions: [],
-			view: {
-				content: {
-					title: "",
-					text: "",
-					...contentOverrides,
-				} as Row["config"]["view"]["content"],
-			},
+			title: "",
+			text: "",
+			...contentOverrides,
 		} as Row["config"],
 	};
 }
@@ -83,13 +80,11 @@ describe("row tree traversal", () => {
 		const inner = makeRow("inner", { text: "old" });
 		const outer = makeRow("outer", { child: inner });
 		const out = updateRowInTree([outer], "inner", (row) =>
-			makeRow(row.id, { ...row.config.view.content, text: "new" }),
+			makeRow(row.id, { ...row.config, text: "new" }),
 		);
 
 		expect(out[0]).not.toBe(outer);
-		expect(out[0].config.view.content.child?.config.view.content.text).toBe(
-			"new",
-		);
+		expect(out[0].config.child?.config.text).toBe("new");
 	});
 });
 
@@ -134,9 +129,7 @@ describe("page-level row tree helpers", () => {
 		);
 
 		expect(withoutBody.rows).toEqual([]);
-		expect(
-			withoutFooterChild.footer?.config.view.content.child,
-		).toBeUndefined();
+		expect(withoutFooterChild.footer?.config.child).toBeUndefined();
 		expect(withoutFooter.footer).toBeUndefined();
 	});
 
@@ -154,9 +147,7 @@ describe("page-level row tree helpers", () => {
 		);
 
 		expect(pageInsert.rows.map((row) => row.id)).toEqual(["b", "a"]);
-		expect(footerInsert.footer?.config.view.content.children?.[0].id).toBe(
-			"new",
-		);
+		expect(footerInsert.footer?.config.children?.[0].id).toBe("new");
 	});
 });
 

--- a/web/app/utils/rowTree.ts
+++ b/web/app/utils/rowTree.ts
@@ -70,13 +70,13 @@ function findRowIdPathFromAncestorRow(
 ): string[] | null {
 	if (root.id === leafRowId) return [root.id];
 
-	const child = root.config.view.content.child;
+	const child = root.config.child;
 	if (child) {
 		const sub = findRowIdPathFromAncestorRow(child, leafRowId);
 		if (sub) return [root.id, ...sub];
 	}
 
-	for (const nested of root.config.view.content.children ?? []) {
+	for (const nested of root.config.children ?? []) {
 		const sub = findRowIdPathFromAncestorRow(nested, leafRowId);
 		if (sub) return [root.id, ...sub];
 	}
@@ -87,13 +87,13 @@ function findRowIdPathFromAncestorRow(
 function findRowInSubtree(row: Row, rowId: string): Row | undefined {
 	if (row.id === rowId) return row;
 
-	const child = row.config.view.content.child;
+	const child = row.config.child;
 	if (child) {
 		const foundChild = findRowInSubtree(child, rowId);
 		if (foundChild) return foundChild;
 	}
 
-	for (const childRow of row.config.view.content.children ?? []) {
+	for (const childRow of row.config.children ?? []) {
 		const foundChild = findRowInSubtree(childRow, rowId);
 		if (foundChild) return foundChild;
 	}
@@ -104,11 +104,9 @@ function findRowInSubtree(row: Row, rowId: string): Row | undefined {
 export function getRowsRecursive(row: Row): Row[] {
 	return [
 		row,
-		...(row.config.view.content.child
-			? getRowsRecursive(row.config.view.content.child)
-			: []),
-		...(row.config.view.content.children
-			? row.config.view.content.children.flatMap(getRowsRecursive)
+		...(row.config.child ? getRowsRecursive(row.config.child) : []),
+		...(row.config.children
+			? row.config.children.flatMap(getRowsRecursive)
 			: []),
 	];
 }
@@ -153,12 +151,10 @@ function findContainerOfRow(
 	rows: Row[],
 ): { container: Row; type: ContainerType } | null {
 	return findContainerByPredicate(rows, (container) => {
-		if (container.config.view.content.child?.id === rowId) {
+		if (container.config.child?.id === rowId) {
 			return { rowId: container.id, type: "child" };
 		}
-		if (
-			container.config.view.content.children?.some((r) => r.id === rowId)
-		) {
+		if (container.config.children?.some((r) => r.id === rowId)) {
 			return { rowId: container.id, type: "children" };
 		}
 		return null;
@@ -174,16 +170,10 @@ function findContainerById(
 	rows: Row[],
 ): { container: Row; type: ContainerType } | null {
 	return findContainerByPredicate(rows, (container) => {
-		if (
-			"child" in container.config.view.content &&
-			container.id === rowId
-		) {
+		if ("child" in container.config && container.id === rowId) {
 			return { rowId: container.id, type: "child" };
 		}
-		if (
-			"children" in container.config.view.content &&
-			container.id === rowId
-		) {
+		if ("children" in container.config && container.id === rowId) {
 			return { rowId: container.id, type: "children" };
 		}
 		return null;
@@ -202,17 +192,17 @@ function findContainerByPredicate(
 		const match = predicate(row);
 		if (match) return { container: row, type: match.type };
 
-		if (row.config.view.content.child) {
+		if (row.config.child) {
 			const childResult = findContainerByPredicate(
-				[row.config.view.content.child],
+				[row.config.child],
 				predicate,
 			);
 			if (childResult) return childResult;
 		}
 
-		if (row.config.view.content.children) {
+		if (row.config.children) {
 			const nestedResult = findContainerByPredicate(
-				row.config.view.content.children,
+				row.config.children,
 				predicate,
 			);
 			if (nestedResult) return nestedResult;
@@ -223,16 +213,13 @@ function findContainerByPredicate(
 
 function withContentUpdate(
 	row: Row,
-	contentPatch: Partial<Row["config"]["view"]["content"]>,
+	contentPatch: Partial<Row["config"]>,
 ): Row {
 	return {
 		...row,
 		config: {
 			...row.config,
-			view: {
-				...row.config.view,
-				content: { ...row.config.view.content, ...contentPatch },
-			},
+			...contentPatch,
 		},
 	};
 }
@@ -240,16 +227,15 @@ function withContentUpdate(
 function removeRowInSubtree(row: Row, targetRowId: string): Row {
 	let nextRow = row;
 
-	if (row.config.view.content.children) {
-		const filteredChildren = row.config.view.content.children.filter(
+	if (row.config.children) {
+		const filteredChildren = row.config.children.filter(
 			(child) => child.id !== targetRowId,
 		);
 		const updatedChildren = filteredChildren.map((child) =>
 			removeRowInSubtree(child, targetRowId),
 		);
 		const childUpdated =
-			filteredChildren.length !==
-				row.config.view.content.children.length ||
+			filteredChildren.length !== row.config.children.length ||
 			updatedChildren.some(
 				(child, index) => child !== filteredChildren[index],
 			);
@@ -258,16 +244,16 @@ function removeRowInSubtree(row: Row, targetRowId: string): Row {
 		}
 	}
 
-	if (nextRow.config.view.content.child?.id === targetRowId) {
+	if (nextRow.config.child?.id === targetRowId) {
 		return withContentUpdate(nextRow, { child: undefined });
 	}
 
-	if (nextRow.config.view.content.child) {
+	if (nextRow.config.child) {
 		const updatedChild = removeRowInSubtree(
-			nextRow.config.view.content.child,
+			nextRow.config.child,
 			targetRowId,
 		);
-		if (updatedChild !== nextRow.config.view.content.child) {
+		if (updatedChild !== nextRow.config.child) {
 			return withContentUpdate(nextRow, { child: updatedChild });
 		}
 	}
@@ -323,7 +309,7 @@ function insertRowIntoSubtree(
 		return {
 			row: withContentUpdate(row, {
 				children: insertRowAtIndex(
-					row.config.view.content.children ?? [],
+					row.config.children ?? [],
 					rowToInsert,
 					destinationIndex,
 				),
@@ -332,7 +318,7 @@ function insertRowIntoSubtree(
 		};
 	}
 
-	const child = row.config.view.content.child;
+	const child = row.config.child;
 	if (child) {
 		const childResult = insertRowIntoSubtree(
 			child,
@@ -349,7 +335,7 @@ function insertRowIntoSubtree(
 		}
 	}
 
-	const children = row.config.view.content.children;
+	const children = row.config.children;
 	if (children) {
 		for (const [index, childRow] of children.entries()) {
 			const childResult = insertRowIntoSubtree(
@@ -412,21 +398,20 @@ function updateRowInSubtree(
 	if (row.id === targetRowId) {
 		return updater(row);
 	}
-	if (row.config.view.content.children) {
-		const updatedChildren = row.config.view.content.children.map(
+	if (row.config.children) {
+		const updatedChildren = row.config.children.map(
 			(child) => updateRowInSubtree(child, targetRowId, updater) ?? child,
 		);
 		const childUpdated = updatedChildren.some(
-			(child, index) =>
-				child !== row.config.view.content.children?.[index],
+			(child, index) => child !== row.config.children?.[index],
 		);
 		if (childUpdated) {
 			return withContentUpdate(row, { children: updatedChildren });
 		}
 	}
-	if (row.config.view.content.child) {
+	if (row.config.child) {
 		const updatedChild = updateRowInSubtree(
-			row.config.view.content.child,
+			row.config.child,
 			targetRowId,
 			updater,
 		);

--- a/web/app/utils/urlUtils.test.ts
+++ b/web/app/utils/urlUtils.test.ts
@@ -15,11 +15,10 @@ function textRow(id: string): Row {
 		config: {
 			type: "Text",
 			source: "",
+			visible: "true",
 			actions: [],
-			view: {
-				content: { title: "", text: "" },
-				max_lines: "",
-			},
+			title: "",
+			text: "",
 		} as Row["config"],
 	};
 }
@@ -43,13 +42,10 @@ describe("validateRowPathSegmentsForPage", () => {
 			config: {
 				type: "ListContainer",
 				source: "",
+				visible: "true",
 				actions: [],
-				view: {
-					content: {
-						title: "",
-						children: [child],
-					},
-				},
+				title: "",
+				children: [child],
 			} as Row["config"],
 		};
 		const page: UI_Page = {
@@ -107,13 +103,10 @@ describe("validateRowPathSegmentsForPage", () => {
 			config: {
 				type: "ListContainer",
 				source: "",
+				visible: "true",
 				actions: [],
-				view: {
-					content: {
-						title: "",
-						child: leaf,
-					},
-				},
+				title: "",
+				child: leaf,
 			} as Row["config"],
 		};
 		const root: Row = {
@@ -122,13 +115,10 @@ describe("validateRowPathSegmentsForPage", () => {
 			config: {
 				type: "ListContainer",
 				source: "",
+				visible: "true",
 				actions: [],
-				view: {
-					content: {
-						title: "",
-						child: middle,
-					},
-				},
+				title: "",
+				child: middle,
 			} as Row["config"],
 		};
 		const page: UI_Page = {

--- a/web/app/utils/urlUtils.ts
+++ b/web/app/utils/urlUtils.ts
@@ -31,12 +31,9 @@ export function isNonRoutablePreviewRowId(rowId: string): boolean {
 }
 
 function isDirectChildRow(parent: Row, childId: string): boolean {
-	const child = parent.config.view.content.child;
+	const child = parent.config.child;
 	if (child?.id === childId) return true;
-	return (
-		parent.config.view.content.children?.some((c) => c.id === childId) ??
-		false
-	);
+	return parent.config.children?.some((c) => c.id === childId) ?? false;
 }
 
 /**

--- a/web/e2e/e2e.pw.ts
+++ b/web/e2e/e2e.pw.ts
@@ -75,20 +75,15 @@ async function createFlowInApi(flow: UI_Flow): Promise<void> {
 }
 
 function rowContainsTitle(row: UI_Row, title: string): boolean {
-	if (row.view.content.title === title) {
+	if (row.title === title) {
 		return true;
 	}
 
-	if (
-		row.view.content.child &&
-		rowContainsTitle(row.view.content.child, title)
-	) {
+	if (row.child && rowContainsTitle(row.child, title)) {
 		return true;
 	}
 
-	return (row.view.content.children ?? []).some((child) =>
-		rowContainsTitle(child, title),
-	);
+	return (row.children ?? []).some((child) => rowContainsTitle(child, title));
 }
 
 function flowContainsRowTitle(
@@ -222,11 +217,7 @@ test.describe("Web E2E Integration Tests", () => {
 							source: "",
 							visible: "true",
 							actions: [],
-							view: {
-								content: {
-									title: initialRowTitle,
-								},
-							},
+							title: initialRowTitle,
 						},
 					],
 				},
@@ -276,36 +267,24 @@ test.describe("Web E2E Integration Tests", () => {
 			source: "",
 			visible: "true",
 			actions: [],
-			view: {
-				content: {
-					title: "E2E First Child Row",
-					text: "First child text",
-					child: {
-						id: crypto.randomUUID(),
-						type: "Text",
-						source: "",
-						visible: "true",
-						actions: [],
-						view: {
-							content: {
-								title: "E2E Second Child Row",
-								text: "Second child text",
-								child: {
-									id: crypto.randomUUID(),
-									type: "Text",
-									source: "",
-									visible: "true",
-									actions: [],
-									view: {
-										content: {
-											title: "E2E Third Child Row",
-											text: "Third child text",
-										},
-									},
-								},
-							},
-						},
-					},
+			title: "E2E First Child Row",
+			text: "First child text",
+			child: {
+				id: crypto.randomUUID(),
+				type: "Text",
+				source: "",
+				visible: "true",
+				actions: [],
+				title: "E2E Second Child Row",
+				text: "Second child text",
+				child: {
+					id: crypto.randomUUID(),
+					type: "Text",
+					source: "",
+					visible: "true",
+					actions: [],
+					title: "E2E Third Child Row",
+					text: "Third child text",
 				},
 			},
 		};
@@ -315,14 +294,10 @@ test.describe("Web E2E Integration Tests", () => {
 			source: "",
 			visible: "true",
 			actions: [],
-			view: {
-				content: {
-					title: "E2E Parent Row",
-					subtitle: "Parent subtitle",
-					icon: "",
-					child: firstChild,
-				},
-			},
+			title: "E2E Parent Row",
+			subtitle: "Parent subtitle",
+			icon: "",
+			child: firstChild,
 		};
 		await createFlowInApi({
 			id: crypto.randomUUID(),
@@ -425,12 +400,8 @@ test.describe("Web E2E Integration Tests", () => {
 						visible: "true",
 						destination: "",
 						actions: [],
-						view: {
-							content: {
-								title: "",
-								label: footerLabel,
-							},
-						},
+						title: "",
+						label: footerLabel,
 					},
 				},
 			],

--- a/web/integration/builderAssistFlow.pw.ts
+++ b/web/integration/builderAssistFlow.pw.ts
@@ -81,12 +81,8 @@ function buildBuilderAssistFlow(): ServerFlow[] {
 							id: "row-title",
 							type: "Text",
 							source: `{${ITEM_RESOURCE_ID}}`,
-							view: {
-								content: {
-									title: "Editable title",
-									subtitle: "Editable subtitle",
-								},
-							},
+							title: "Editable title",
+							subtitle: "Editable subtitle",
 							destination: "",
 							actions: [],
 						},
@@ -94,12 +90,8 @@ function buildBuilderAssistFlow(): ServerFlow[] {
 							id: "row-button",
 							type: "Button",
 							source: "",
-							view: {
-								content: {
-									title: "",
-									label: "Open checkout",
-								},
-							},
+							title: "",
+							label: "Open checkout",
 							actions: [{ condition: "", false: "", true: "" }],
 						},
 					],

--- a/web/integration/childPage.pw.ts
+++ b/web/integration/childPage.pw.ts
@@ -16,34 +16,22 @@ async function openTwoSegmentTabContainer(page: Page) {
 			rows: [
 				{
 					type: "SelectSegmentContainer" as const,
-					view: {
-						content: {
-							title: "Tab Container",
-							segments: ["Segment A", "Segment B"],
-							children: [
-								{
-									type: "Text" as const,
-									view: {
-										content: {
-											title: "First Segment Child",
-											subtitle: "First content",
-										},
-									},
-									actions: [],
-								},
-								{
-									type: "Text" as const,
-									view: {
-										content: {
-											title: "Second Segment Child",
-											text: "Second content",
-										},
-									},
-									actions: [],
-								},
-							],
+					title: "Tab Container",
+					segments: ["Segment A", "Segment B"],
+					children: [
+						{
+							type: "Text" as const,
+							title: "First Segment Child",
+							subtitle: "First content",
+							actions: [],
 						},
-					},
+						{
+							type: "Text" as const,
+							title: "Second Segment Child",
+							text: "Second content",
+							actions: [],
+						},
+					],
 					actions: [],
 				},
 			],
@@ -62,12 +50,8 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "Root Text Row",
-								subtitle: "Root subtitle",
-							},
-						},
+						title: "Root Text Row",
+						subtitle: "Root subtitle",
 						actions: [],
 					},
 				],
@@ -105,21 +89,13 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Text" as const,
-						view: {
-							content: {
-								title: "Parent Row",
-								subtitle: "Parent subtitle",
-								child: {
-									type: "Text" as const,
-									view: {
-										content: {
-											title: "Child Row Title",
-											text: "Child text content",
-										},
-									},
-									actions: [],
-								},
-							},
+						title: "Parent Row",
+						subtitle: "Parent subtitle",
+						child: {
+							type: "Text" as const,
+							title: "Child Row Title",
+							text: "Child text content",
+							actions: [],
 						},
 						actions: [],
 					},
@@ -163,41 +139,25 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Text" as const,
-						view: {
-							content: {
-								title: "Parent Row",
-								subtitle: "Parent subtitle",
+						title: "Parent Row",
+						subtitle: "Parent subtitle",
+						child: {
+							type: "Text" as const,
+							title: "First Child Row",
+							text: "First child text",
+							child: {
+								type: "Text" as const,
+								title: "Second Child Row",
+								text: "Second child text",
 								child: {
 									type: "Text" as const,
-									view: {
-										content: {
-											title: "First Child Row",
-											text: "First child text",
-											child: {
-												type: "Text" as const,
-												view: {
-													content: {
-														title: "Second Child Row",
-														text: "Second child text",
-														child: {
-															type: "Text" as const,
-															view: {
-																content: {
-																	title: "Third Child Row",
-																	text: "Third child text",
-																},
-															},
-															actions: [],
-														},
-													},
-												},
-												actions: [],
-											},
-										},
-									},
+									title: "Third Child Row",
+									text: "Third child text",
 									actions: [],
 								},
+								actions: [],
 							},
+							actions: [],
 						},
 						actions: [],
 					},
@@ -269,78 +229,49 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "SelectSegmentContainer" as const,
-						view: {
-							content: {
-								title: "Root Select Segment",
-								segments: ["Children 0"],
+						title: "Root Select Segment",
+						segments: ["Children 0"],
+						children: [
+							{
+								type: "ListContainer" as const,
+								title: "Children 0 List Container",
 								children: [
 									{
-										type: "ListContainer" as const,
-										view: {
-											content: {
-												title: "Children 0 List Container",
-												children: [
-													{
-														type: "Text" as const,
-														view: {
-															content: {
-																title: "Children 0 Text Row",
-																text: "Text row",
-															},
-														},
-														actions: [],
-													},
-													{
-														type: "Text" as const,
-														view: {
-															content: {
-																title: "Children 1 Text Action",
-																text: "Action text",
-																action: "Change",
-																child: {
-																	type: "Search" as const,
-																	view: {
-																		content:
-																			{
-																				title: "Search Child Row",
-																				placeholder:
-																					"Search...",
-																				value: "",
-																				child: {
-																					type: "Text" as const,
-																					view: {
-																						content:
-																							{
-																								title: "Search Text Child",
-																								subtitle:
-																									"Text child",
-																							},
-																					},
-																					actions:
-																						[],
-																				},
-																			},
-																	},
-																	actions: [],
-																},
-															},
-														},
-														actions: [
-															{
-																condition: "",
-																true: "{show()}",
-																false: "",
-															},
-														],
-													},
-												],
-											},
-										},
+										type: "Text" as const,
+										title: "Children 0 Text Row",
+										text: "Text row",
 										actions: [],
 									},
+									{
+										type: "Text" as const,
+										title: "Children 1 Text Action",
+										text: "Action text",
+										action: "Change",
+										child: {
+											type: "Search" as const,
+											title: "Search Child Row",
+											placeholder: "Search...",
+											value: "",
+											child: {
+												type: "Text" as const,
+												title: "Search Text Child",
+												subtitle: "Text child",
+												actions: [],
+											},
+											actions: [],
+										},
+										actions: [
+											{
+												condition: "",
+												true: "{show()}",
+												false: "",
+											},
+										],
+									},
 								],
+								actions: [],
 							},
-						},
+						],
 						actions: [],
 					},
 				],
@@ -386,21 +317,13 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Text" as const,
-						view: {
-							content: {
-								title: "Parent Row",
-								subtitle: "Parent subtitle",
-								child: {
-									type: "Text" as const,
-									view: {
-										content: {
-											title: "Child Text Row",
-											text: "Child text",
-										},
-									},
-									actions: [],
-								},
-							},
+						title: "Parent Row",
+						subtitle: "Parent subtitle",
+						child: {
+							type: "Text" as const,
+							title: "Child Text Row",
+							text: "Child text",
+							actions: [],
 						},
 						actions: [],
 					},
@@ -434,7 +357,7 @@ test.describe("Child Page Rendering", () => {
 		).toHaveText("Child Text Row");
 	});
 
-	test("dropping a row into an existing child page replaces view.content.child", async ({
+	test("dropping a row into an existing child page replaces child", async ({
 		page,
 	}) => {
 		await openAppWithTestFlows(page, [
@@ -444,21 +367,13 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Text" as const,
-						view: {
-							content: {
-								title: "Parent Row",
-								subtitle: "Parent subtitle",
-								child: {
-									type: "Text" as const,
-									view: {
-										content: {
-											title: "Existing Child Row",
-											text: "Existing child text",
-										},
-									},
-									actions: [],
-								},
-							},
+						title: "Parent Row",
+						subtitle: "Parent subtitle",
+						child: {
+							type: "Text" as const,
+							title: "Existing Child Row",
+							text: "Existing child text",
+							actions: [],
 						},
 						actions: [],
 					},
@@ -491,7 +406,7 @@ test.describe("Child Page Rendering", () => {
 		await expect(page.getByTestId("blank-child-page")).toBeVisible();
 	});
 
-	test("dropping a row into the blank child page creates view.content.child", async ({
+	test("dropping a row into the blank child page creates child", async ({
 		page,
 	}) => {
 		await openAppWithTestFlows(page, [
@@ -501,12 +416,8 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "Root Row",
-								subtitle: "Subtitle",
-							},
-						},
+						title: "Root Row",
+						subtitle: "Subtitle",
 						actions: [],
 					},
 				],
@@ -556,13 +467,9 @@ test.describe("Child Page Rendering", () => {
 				rows: [
 					{
 						type: "Search" as const,
-						view: {
-							content: {
-								title: "Search Row Title",
-								placeholder: "Search...",
-								value: "",
-							},
-						},
+						title: "Search Row Title",
+						placeholder: "Search...",
+						value: "",
 						actions: [],
 					},
 				],

--- a/web/integration/configuration.pw.ts
+++ b/web/integration/configuration.pw.ts
@@ -23,24 +23,15 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "ColumnContainer",
-						view: {
-							content: {
-								title: "Container Row",
-								children: [
-									{
-										type: "Input",
-										view: {
-											content: {
-												title: "Input Row",
-												placeholder:
-													"First placeholder",
-											},
-										},
-										actions: [],
-									},
-								],
+						title: "Container Row",
+						children: [
+							{
+								type: "Input",
+								title: "Input Row",
+								placeholder: "First placeholder",
+								actions: [],
 							},
-						},
+						],
 						actions: [],
 					},
 				],
@@ -85,12 +76,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "Test Text Row",
-								subtitle: "Initial subtitle content",
-							},
-						},
+						title: "Test Text Row",
+						subtitle: "Initial subtitle content",
 						actions: [],
 					},
 				],
@@ -127,12 +114,8 @@ test.describe("Row configuration", () => {
 					{
 						type: "Text",
 						source: "{initial}",
-						view: {
-							content: {
-								title: "Binding row",
-								subtitle: "Body",
-							},
-						},
+						title: "Binding row",
+						subtitle: "Body",
 						actions: [],
 					},
 				],
@@ -161,13 +144,9 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "InputList",
-						view: {
-							content: {
-								title: "Tags",
-								placeholder: "Search for tags",
-								format: "{$datum.value}",
-							},
-						},
+						title: "Tags",
+						placeholder: "Search for tags",
+						format: "{$datum.value}",
 						actions: [],
 					},
 				],
@@ -194,12 +173,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Button",
-						view: {
-							content: {
-								title: "",
-								label: "Test Button",
-							},
-						},
+						title: "",
+						label: "Test Button",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -250,12 +225,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Button",
-						view: {
-							content: {
-								title: "",
-								label: "Nav Button",
-							},
-						},
+						title: "",
+						label: "Nav Button",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -307,13 +278,9 @@ test.describe("Row configuration", () => {
 									id: "name_input",
 									type: "Input",
 									source: "",
-									view: {
-										content: {
-											title: "Name",
-											value: `{${MARKETPLACE_ITEMS_RESOURCE_ID}.name}`,
-											placeholder: "Enter name",
-										},
-									},
+									title: "Name",
+									value: `{${MARKETPLACE_ITEMS_RESOURCE_ID}.name}`,
+									placeholder: "Enter name",
 									destination: `{${MARKETPLACE_ITEMS_RESOURCE_ID}.name}`,
 									actions: [],
 								},
@@ -321,12 +288,8 @@ test.describe("Row configuration", () => {
 									id: "submit_button",
 									type: "Button",
 									source: "",
-									view: {
-										content: {
-											title: "",
-											label: "Submit",
-										},
-									},
+									title: "",
+									label: "Submit",
 									actions: [
 										{
 											condition: "",
@@ -407,12 +370,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "No Action Row",
-								subtitle: "Some subtitle",
-							},
-						},
+						title: "No Action Row",
+						subtitle: "Some subtitle",
 						actions: [],
 					},
 				],
@@ -440,19 +399,16 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Price",
-								value: "{price}",
-								placeholder: "",
-							},
-						},
+						title: "Price",
+						value: "{price}",
+						placeholder: "",
 						destination: "{price}",
 						actions: [],
 					},
 					{
 						type: "Button",
-						view: { content: { title: "", label: "Check" } },
+						title: "",
+						label: "Check",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -497,19 +453,16 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Items",
-								value: "{items}",
-								placeholder: "",
-							},
-						},
+						title: "Items",
+						value: "{items}",
+						placeholder: "",
 						destination: "{items}",
 						actions: [],
 					},
 					{
 						type: "Button",
-						view: { content: { title: "", label: "Validate" } },
+						title: "",
+						label: "Validate",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -556,31 +509,24 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Name",
-								value: "{name}",
-								placeholder: "",
-							},
-						},
+						title: "Name",
+						value: "{name}",
+						placeholder: "",
 						destination: "{name}",
 						actions: [],
 					},
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Email",
-								value: "{email}",
-								placeholder: "",
-							},
-						},
+						title: "Email",
+						value: "{email}",
+						placeholder: "",
 						destination: "{email}",
 						actions: [],
 					},
 					{
 						type: "Button",
-						view: { content: { title: "", label: "Send" } },
+						title: "",
+						label: "Send",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -632,7 +578,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Button",
-						view: { content: { title: "", label: "Cancel Test" } },
+						title: "",
+						label: "Cancel Test",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -675,9 +622,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Button",
-						view: {
-							content: { title: "", label: "Multi Action" },
-						},
+						title: "",
+						label: "Multi Action",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 							{
@@ -723,13 +669,9 @@ test.describe("Row configuration", () => {
 								id: "row_input",
 								type: "Input",
 								source: "",
-								view: {
-									content: {
-										title: "Name",
-										value: "{name}",
-										placeholder: "",
-									},
-								},
+								title: "Name",
+								value: "{name}",
+								placeholder: "",
 								destination: "{name}",
 								actions: [],
 							},
@@ -737,9 +679,8 @@ test.describe("Row configuration", () => {
 								id: "row_btn",
 								type: "Button",
 								source: "",
-								view: {
-									content: { title: "", label: "Prefilled" },
-								},
+								title: "",
+								label: "Prefilled",
 								actions: [
 									{
 										condition: "{name == true}",
@@ -815,12 +756,8 @@ test.describe("Row configuration", () => {
 									id: "or_test_button",
 									type: "Button",
 									source: "",
-									view: {
-										content: {
-											title: "",
-											label: "OR Test",
-										},
-									},
+									title: "",
+									label: "OR Test",
 									actions: [
 										{
 											condition: `{count(${MARKETPLACE_ITEMS_RESOURCE_ID}.pickup_timeslots) > 0 || count(${MARKETPLACE_ITEMS_RESOURCE_ID}.delivery_timeslots) > 0}`,
@@ -869,12 +806,8 @@ test.describe("Row configuration", () => {
 									id: "nested_test_button",
 									type: "Button",
 									source: "",
-									view: {
-										content: {
-											title: "",
-											label: "Nested Test",
-										},
-									},
+									title: "",
+									label: "Nested Test",
 									actions: [
 										{
 											condition: `{count(${MARKETPLACE_ITEMS_RESOURCE_ID}.pickup_timeslots) > 0 && (count(${MARKETPLACE_ITEMS_RESOURCE_ID}.delivery_timeslots) > 0 || count(${MARKETPLACE_ITEMS_RESOURCE_ID}.shipping_destination_areas) > 0)}`,
@@ -917,31 +850,24 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Name",
-								value: "{name}",
-								placeholder: "",
-							},
-						},
+						title: "Name",
+						value: "{name}",
+						placeholder: "",
 						destination: "{name}",
 						actions: [],
 					},
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Email",
-								value: "{email}",
-								placeholder: "",
-							},
-						},
+						title: "Email",
+						value: "{email}",
+						placeholder: "",
 						destination: "{email}",
 						actions: [],
 					},
 					{
 						type: "Button",
-						view: { content: { title: "", label: "Toggle Test" } },
+						title: "",
+						label: "Toggle Test",
 						actions: [
 							{
 								condition: "{name == true || email == true}",
@@ -996,31 +922,24 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Name",
-								value: "{name}",
-								placeholder: "",
-							},
-						},
+						title: "Name",
+						value: "{name}",
+						placeholder: "",
 						destination: "{name}",
 						actions: [],
 					},
 					{
 						type: "Input",
-						view: {
-							content: {
-								title: "Email",
-								value: "{email}",
-								placeholder: "",
-							},
-						},
+						title: "Email",
+						value: "{email}",
+						placeholder: "",
 						destination: "{email}",
 						actions: [],
 					},
 					{
 						type: "Button",
-						view: { content: { title: "", label: "Nest Test" } },
+						title: "",
+						label: "Nest Test",
 						actions: [
 							{
 								condition: "{name == true || email == true}",
@@ -1074,39 +993,27 @@ test.describe("Row configuration", () => {
 	}) => {
 		type DeepNestRow = {
 			type: "Input" | "ColumnContainer";
-			view: {
-				content: {
-					title: string;
-					placeholder?: string;
-					value?: string;
-					children?: DeepNestRow[];
-				};
-			};
+			title: string;
+			placeholder?: string;
+			value?: string;
+			children?: DeepNestRow[];
 			actions: [];
 		};
 
 		function deepNest(level: number): DeepNestRow {
 			if (level === 0) {
 				return {
-					type: "Input" as const,
-					view: {
-						content: {
-							title: "Deep leaf",
-							placeholder: "",
-							value: "",
-						},
-					},
+					type: "Input",
+					title: "Deep leaf",
+					placeholder: "",
+					value: "",
 					actions: [],
 				};
 			}
 			return {
-				type: "ColumnContainer" as const,
-				view: {
-					content: {
-						title: `Nest level ${level}`,
-						children: [deepNest(level - 1)],
-					},
-				},
+				type: "ColumnContainer",
+				title: `Nest level ${level}`,
+				children: [deepNest(level - 1)],
 				actions: [],
 			};
 		}
@@ -1166,9 +1073,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Button",
-						view: {
-							content: { title: "", label: "Clear Branch" },
-						},
+						title: "",
+						label: "Clear Branch",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],
@@ -1232,9 +1138,8 @@ test.describe("Row configuration", () => {
 				rows: [
 					{
 						type: "Button",
-						view: {
-							content: { title: "", label: "Cancel Clear" },
-						},
+						title: "",
+						label: "Cancel Clear",
 						actions: [
 							{ condition: "", false: "", true: "{close()}" },
 						],

--- a/web/integration/dragAndDrop.pw.ts
+++ b/web/integration/dragAndDrop.pw.ts
@@ -121,24 +121,16 @@ test.describe("Drag & Drop UX", () => {
 					{
 						id: "column-1",
 						type: "ColumnContainer" as const,
-						view: {
-							content: {
-								title: "Column container row title",
-								children: [
-									{
-										id: "column-child-1",
-										type: "Text" as const,
-										view: {
-											content: {
-												title: "Child Text",
-												subtitle: "Child subtitle",
-											},
-										},
-										actions: [],
-									},
-								],
+						title: "Column container row title",
+						children: [
+							{
+								id: "column-child-1",
+								type: "Text" as const,
+								title: "Child Text",
+								subtitle: "Child subtitle",
+								actions: [],
 							},
-						},
+						],
 						actions: [],
 					},
 				],
@@ -171,24 +163,16 @@ test.describe("Drag & Drop UX", () => {
 					{
 						id: "list-1",
 						type: "ListContainer" as const,
-						view: {
-							content: {
-								title: "List container row title",
-								children: [
-									{
-										id: "list-child-1",
-										type: "Text" as const,
-										view: {
-											content: {
-												title: "Nested Text",
-												subtitle: "Nested subtitle",
-											},
-										},
-										actions: [],
-									},
-								],
+						title: "List container row title",
+						children: [
+							{
+								id: "list-child-1",
+								type: "Text" as const,
+								title: "Nested Text",
+								subtitle: "Nested subtitle",
+								actions: [],
 							},
-						},
+						],
 						actions: [],
 					},
 				],

--- a/web/integration/flowFixtures.ts
+++ b/web/integration/flowFixtures.ts
@@ -3,16 +3,19 @@ import type {
 	UI_RowAction as RowAction,
 	UI_Flow as ServerFlow,
 	UI_Row as ServerRow,
-	UI_RowContent as ServerRowContent,
 } from "evy-types";
 import type {
 	ResourceAttributeMetadata,
 	ServiceResource,
 } from "../app/api/sync";
 
-// Input types where id is optional
-// Using explicit interface to avoid index signature conflicts with ServerRowContent
-interface ServerRowInputContent {
+interface ServerRowInput {
+	id?: string;
+	type: ServerRow["type"];
+	source?: string;
+	destination?: string;
+	actions: RowAction[];
+	visible?: string;
 	title: string;
 	children?: ServerRowInput[];
 	child?: ServerRowInput;
@@ -26,18 +29,6 @@ interface ServerRowInputContent {
 	segments?: string[];
 }
 
-interface ServerRowInput {
-	id?: string;
-	type: ServerRow["type"];
-	source?: string;
-	view: {
-		content: ServerRowInputContent;
-		max_lines?: string;
-	};
-	destination?: string;
-	actions: RowAction[];
-}
-
 interface ServerPageInput {
 	id?: string;
 	title: string;
@@ -46,26 +37,15 @@ interface ServerPageInput {
 }
 
 function ensureRowId(row: ServerRowInput): ServerRow {
-	const inputContent = row.view.content;
-	const { children, child, ...contentRest } = inputContent;
-
-	const content: ServerRowContent = {
-		...contentRest,
+	const { children, child, ...rowRest } = row;
+	return {
+		...rowRest,
+		id: row.id ?? crypto.randomUUID(),
+		source: row.source ?? "",
+		visible: row.visible ?? "true",
 		...(children !== undefined ? { children: ensureRowIds(children) } : {}),
 		...(child !== undefined ? { child: ensureRowId(child) } : {}),
-	};
-
-	return {
-		id: row.id ?? crypto.randomUUID(),
-		type: row.type,
-		view: {
-			content,
-			max_lines: row.view.max_lines,
-		},
-		source: row.source ?? "",
-		destination: row.destination,
-		actions: row.actions,
-	};
+	} as ServerRow;
 }
 
 function ensureRowIds(rows: ServerRowInput[]): ServerRow[] {
@@ -90,53 +70,63 @@ export function createTestFlows(pages: ServerPageInput[]): ServerFlow[] {
 export async function initTestFlows(
 	page: Page,
 	pages: ServerPageInput[],
+	resources: ServiceResource[] = [],
+	metadata: ResourceAttributeMetadata[] = [],
 ): Promise<void> {
 	await page.addInitScript((flows: ServerFlow[]) => {
 		window.__TEST_FLOWS__ = flows;
 	}, createTestFlows(pages));
+	await initServiceResources(page, resources);
+	await initResourceAttributeMetadata(page, metadata);
 }
 
 export async function initFullFlows(
 	page: Page,
 	flows: ServerFlow[],
-	serviceResources: ServiceResource[] = [],
-	resourceAttributeMetadata: ResourceAttributeMetadata[] = [],
+	resources: ServiceResource[] = [],
+	metadata: ResourceAttributeMetadata[] = [],
 ): Promise<void> {
-	await page.addInitScript(
-		({ flowData, resources, attributes }) => {
-			window.__TEST_FLOWS__ = flowData;
-			window.__TEST_SERVICE_RESOURCES__ = resources;
-			window.__TEST_RESOURCE_ATTRIBUTE_METADATA__ = attributes;
-		},
-		{
-			flowData: flows,
-			resources: serviceResources,
-			attributes: resourceAttributeMetadata,
-		},
-	);
+	await page.addInitScript((flows: ServerFlow[]) => {
+		window.__TEST_FLOWS__ = flows;
+	}, flows);
+	await initServiceResources(page, resources);
+	await initResourceAttributeMetadata(page, metadata);
 }
 
-/** Loads injected full flow JSON and opens the app (same pattern as component tests that use `initFullFlows`). */
-export async function openAppWithFullFlows(
+export async function initServiceResources(
 	page: Page,
-	flows: ServerFlow[],
-	serviceResources: ServiceResource[] = [],
-	resourceAttributeMetadata: ResourceAttributeMetadata[] = [],
+	resources: ServiceResource[],
 ): Promise<void> {
-	await initFullFlows(
-		page,
-		flows,
-		serviceResources,
-		resourceAttributeMetadata,
-	);
+	await page.addInitScript((resources: ServiceResource[]) => {
+		window.__TEST_SERVICE_RESOURCES__ = resources;
+	}, resources);
+}
+
+export async function initResourceAttributeMetadata(
+	page: Page,
+	metadata: ResourceAttributeMetadata[],
+): Promise<void> {
+	await page.addInitScript((metadata: ResourceAttributeMetadata[]) => {
+		window.__TEST_RESOURCE_ATTRIBUTE_METADATA__ = metadata;
+	}, metadata);
+}
+
+export async function openAppWithTestFlows(
+	page: Page,
+	pages: ServerPageInput[],
+	resources: ServiceResource[] = [],
+	metadata: ResourceAttributeMetadata[] = [],
+): Promise<void> {
+	await initTestFlows(page, pages, resources, metadata);
 	await page.goto("/");
 }
 
-/** Injects simplified page fixtures via `initTestFlows` and opens the app. */
-export async function openAppWithTestFlows(
+export async function openAppWithFullFlows(
 	page: Page,
-	pages: Parameters<typeof initTestFlows>[1],
+	flows: ServerFlow[],
+	resources: ServiceResource[] = [],
+	metadata: ResourceAttributeMetadata[] = [],
 ): Promise<void> {
-	await initTestFlows(page, pages);
+	await initFullFlows(page, flows, resources, metadata);
 	await page.goto("/");
 }

--- a/web/integration/flowSelector.pw.ts
+++ b/web/integration/flowSelector.pw.ts
@@ -22,12 +22,8 @@ test.describe("Flow Selector", () => {
 						{
 							id: "row-1-1-1",
 							type: "Text",
-							view: {
-								content: {
-									title: "Flow 1 Text",
-									subtitle: "This is from Flow 1",
-								},
-							},
+							title: "Flow 1 Text",
+							subtitle: "This is from Flow 1",
 							actions: [],
 						},
 					],
@@ -45,12 +41,8 @@ test.describe("Flow Selector", () => {
 						{
 							id: "row-2-1-1",
 							type: "Text",
-							view: {
-								content: {
-									title: "Flow 2 Text",
-									subtitle: "This is from Flow 2",
-								},
-							},
+							title: "Flow 2 Text",
+							subtitle: "This is from Flow 2",
 							actions: [],
 						},
 					],

--- a/web/integration/rowSelection.pw.ts
+++ b/web/integration/rowSelection.pw.ts
@@ -16,12 +16,8 @@ test.describe("Row Selection", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "First Text Row",
-								subtitle: "First row subtitle content",
-							},
-						},
+						title: "First Text Row",
+						subtitle: "First row subtitle content",
 						actions: [],
 					},
 				],
@@ -55,22 +51,14 @@ test.describe("Row Selection", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "First Text Row",
-								subtitle: "First row subtitle content",
-							},
-						},
+						title: "First Text Row",
+						subtitle: "First row subtitle content",
 						actions: [],
 					},
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "Second Text Row",
-								subtitle: "Second row subtitle content",
-							},
-						},
+						title: "Second Text Row",
+						subtitle: "Second row subtitle content",
 						actions: [],
 					},
 				],
@@ -109,22 +97,14 @@ test.describe("Row Selection", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "First Text Row",
-								subtitle: "First row subtitle content",
-							},
-						},
+						title: "First Text Row",
+						subtitle: "First row subtitle content",
 						actions: [],
 					},
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "Text Row",
-								text: "Text row content",
-							},
-						},
+						title: "Text Row",
+						text: "Text row content",
 						actions: [],
 					},
 				],
@@ -182,12 +162,8 @@ test.describe("Row Selection", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "First Text Row",
-								subtitle: "First row subtitle content",
-							},
-						},
+						title: "First Text Row",
+						subtitle: "First row subtitle content",
 						actions: [],
 					},
 				],
@@ -225,12 +201,8 @@ test.describe("Row Selection", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "First Text Row",
-								subtitle: "First row subtitle content",
-							},
-						},
+						title: "First Text Row",
+						subtitle: "First row subtitle content",
 						actions: [],
 					},
 				],
@@ -269,23 +241,15 @@ test.describe("Row Selection with Containers", () => {
 					{
 						type: "ListContainer",
 						actions: [],
-						view: {
-							content: {
-								title: "Container Row",
-								children: [
-									{
-										type: "Text",
-										view: {
-											content: {
-												title: "Child Text Row",
-												text: "Child row text",
-											},
-										},
-										actions: [],
-									},
-								],
+						title: "Container Row",
+						children: [
+							{
+								type: "Text",
+								title: "Child Text Row",
+								text: "Child row text",
+								actions: [],
 							},
-						},
+						],
 					},
 				],
 			},
@@ -312,23 +276,15 @@ test.describe("Row Selection with Containers", () => {
 					{
 						type: "ListContainer",
 						actions: [],
-						view: {
-							content: {
-								title: "Container Row",
-								children: [
-									{
-										type: "Text",
-										view: {
-											content: {
-												title: "Child Text Row",
-												text: "Child row text",
-											},
-										},
-										actions: [],
-									},
-								],
+						title: "Container Row",
+						children: [
+							{
+								type: "Text",
+								title: "Child Text Row",
+								text: "Child row text",
+								actions: [],
 							},
-						},
+						],
 					},
 				],
 			},
@@ -356,23 +312,15 @@ test.describe("Row Selection with Containers", () => {
 					{
 						type: "ListContainer",
 						actions: [],
-						view: {
-							content: {
-								title: "Container Row",
-								children: [
-									{
-										type: "Text",
-										view: {
-											content: {
-												title: "Child Text Row",
-												text: "Child row text",
-											},
-										},
-										actions: [],
-									},
-								],
+						title: "Container Row",
+						children: [
+							{
+								type: "Text",
+								title: "Child Text Row",
+								text: "Child row text",
+								actions: [],
 							},
-						},
+						],
 					},
 				],
 			},

--- a/web/integration/rows.pw.ts
+++ b/web/integration/rows.pw.ts
@@ -35,12 +35,8 @@ test.describe("EVY Rows", () => {
 				rows: [
 					{
 						type: "Text",
-						view: {
-							content: {
-								title: "Test Text",
-								subtitle: "Test subtitle",
-							},
-						},
+						title: "Test Text",
+						subtitle: "Test subtitle",
 						actions: [],
 					},
 				],


### PR DESCRIPTION
## Summary

Removes hardcoded field-name guards across iOS and web codebases, and flattens the `view.content` nesting layer from all `UI_Row` definitions.

## Major changes

### iOS (Swift)

- **EVYDatumRowFormatter**: Removed `searchableAttributes(from:)` exclusion list and `path.contains("actions")` guard. All row attributes (including nested child content) are now uniformly searchable and datum references are resolved everywhere.
- **ContentView.swift**: Extracted `"sdui"` resource filter string to `sduiResourceKey` constant.
- **EVYDraft.swift**: Extracted `"browse"` scope key to `Scope.browseKey` constant.
- **EVY+QueryParams.swift**: Extracted `"id"` query key to `entityIdQueryKey` constant.
- **Row flattening**: Removed the `view.content` intermediate nesting from all `UI_Row` JSON in tests and previews — row attributes sit directly on the row object.

### TypeScript (Web)

- **rowConstants.ts** (new): Single source of truth for `ROW_METADATA_KEYS`.
- **decodeFlow.ts / idCandidates.ts**: Consolidated three overlapping metadata-key sets into the shared `ROW_METADATA_KEYS` constant.
- **sync.ts**: Replaced raw strings `"sdui"` and `"serviceResources"` with `EVY_CORE_RESOURCE.SDUI` and `EVY_CORE_RESOURCE.SERVICE_RESOURCES`.
- **pageReducer.ts**: Replaced inline `"Search"` string with `SEARCH_ROW_TYPE` constant.

### Schema / generation

- **evy.schema.json**: Row attributes (`title`, `subtitle`, `label`, etc.) moved from nested `view.content` to top-level row properties.
- **generate-swift-sdui.ts**: Updated code generation to emit flat row properties instead of nested `view.content` wrappers.
- All row types across iOS, web, and test fixtures updated to the flat format.

## Tests ran

- iOS: 142/142 tests passed
- Web unit: 123/123 tests passed
- Web lint: 174 files checked, no issues

## Notes

- The `actions` guard removal means datum references inside action strings (e.g. `{$datum.id}` inside navigate expressions) are now resolved at template-format time. This is a behaviour change — actions are bound to the specific datum at render, not lazily evaluated at action-run time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785118403&installation_id=127792561&pr_number=223&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F223&signature=6f2fa5c41e6e4bb645560ed1bf1c1ac74016088b25d1b3ae28885371ae3593a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->