### PR TITLE
[BUG] Simplify E2E CI by removing local service mode

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -63,6 +63,20 @@ jobs:
                   'true'
               run: bun run --cwd web test:setup
 
+            - name: Setup Docker
+              if:
+                  github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
+                  'true'
+              run: |
+                  set -euo pipefail
+                  brew install docker docker-compose colima
+                  mkdir -p ~/.docker/cli-plugins
+                  ln -sfn "$(brew --prefix docker-compose)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
+                  colima start --cpu 4 --memory 8 --disk 20
+                  docker context use colima
+                  docker info
+                  docker compose version
+
             - name: Verify Xcode and iOS simulators
               if:
                   github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -16,7 +16,7 @@ jobs:
         permissions:
             contents: read
             packages: read
-        timeout-minutes: 25
+        timeout-minutes: 10
         runs-on: blacksmith-6vcpu-macos-26
 
         steps:
@@ -77,23 +77,11 @@ jobs:
                   xcodebuild -showsdks
                   xcodebuild -showdestinations -project ios/evy.xcodeproj -scheme evy | sed -n '1,80p'
 
-            - name: Install PostgreSQL
-              if:
-                  github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
-                  'true'
-              run: |
-                  set -euo pipefail
-                  if ! command -v postgres >/dev/null 2>&1; then
-                    brew install postgresql@16
-                    echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
-                  fi
-
             - name: Run E2E tests
               if:
                   github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
                   'true'
               env:
-                  E2E_SERVICE_MODE: local
                   IOS_SIMULATOR_DEVICE_NAME: iPhone 17
                   IOS_SIMULATOR_OS_VERSION: 26.5
               run: bash run-e2e.sh

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -63,17 +63,34 @@ jobs:
                   'true'
               run: bun run --cwd web test:setup
 
-            - name: Setup Docker
+            - name: Start Docker daemon
               if:
                   github.event_name == 'workflow_dispatch' || steps.paths.outputs.e2e ==
                   'true'
+              shell: bash
               run: |
                   set -euo pipefail
-                  brew install docker docker-compose colima
-                  mkdir -p ~/.docker/cli-plugins
-                  ln -sfn "$(brew --prefix docker-compose)/bin/docker-compose" ~/.docker/cli-plugins/docker-compose
-                  colima start --cpu 4 --memory 8 --disk 20
-                  docker context use colima
+
+                  if ! command -v docker >/dev/null 2>&1; then
+                      echo "Docker CLI is not installed on this runner."
+                      exit 1
+                  fi
+
+                  if ! docker info >/dev/null 2>&1; then
+                      if [ ! -d /Applications/Docker.app ]; then
+                          echo "Docker daemon is not running and /Applications/Docker.app is unavailable."
+                          exit 1
+                      fi
+
+                      open -a Docker
+                      for _ in {1..60}; do
+                          if docker info >/dev/null 2>&1; then
+                              break
+                          fi
+                          sleep 2
+                      done
+                  fi
+
                   docker info
                   docker compose version
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker compose -f docker-compose.prod.yml up
 
 ## End to end testing
 
-`./run-e2e.sh` runs API, web, and iOS end-to-end tests. It uses Docker Compose when Docker is available, or `E2E_SERVICE_MODE=local` to run PostgreSQL and the services directly with Bun.
+`./run-e2e.sh` runs API, web, and iOS end-to-end tests with docker.
 
 You can optionally skip the iOS tests (which are heavy and slow) by running `./run-e2e.sh --skip-ios`
 
@@ -85,4 +85,4 @@ You can optionally skip the iOS tests (which are heavy and slow) by running `./r
 
 - API lint, build, and tests, and web lint run on Linux.
 - Web tests run on Linux and install Playwright before running.
-- E2E tests run on macOS with `./run-e2e.sh`, which starts API, marketplace, web, and PostgreSQL before running iOS Simulator tests. CI uses local PostgreSQL/Bun services because the Apple Silicon macOS runner does not provide Docker. iOS tests target iPhone 17 / iOS 26.5.
+- E2E tests run on macOS with `./run-e2e.sh`, which starts API, marketplace, web, and PostgreSQL with Docker Compose before running iOS Simulator tests. iOS tests target iPhone 17 / iOS 26.5.

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -29,22 +29,6 @@ IOS_RESULT=0
 IOS_SKIPPED=false
 MAX_RETRIES=30
 RETRY_DELAY_SECONDS=2
-REQUESTED_SERVICE_MODE="${E2E_SERVICE_MODE:-auto}"
-SERVICE_MODE=""
-LOCAL_SERVICE_PIDS=""
-POSTGRES_STARTED_BY_E2E=false
-E2E_RUNTIME_DIR="$REPO_ROOT/.e2e"
-E2E_LOG_DIR="$E2E_RUNTIME_DIR/logs"
-POSTGRES_DATA_DIR="$E2E_RUNTIME_DIR/postgres"
-POSTGRES_PASSWORD_FILE="$E2E_RUNTIME_DIR/postgres-password"
-POSTGRES_LOG_FILE="$E2E_LOG_DIR/postgres.log"
-API_LOG_FILE="$E2E_LOG_DIR/api.log"
-MARKETPLACE_LOG_FILE="$E2E_LOG_DIR/marketplace.log"
-WEB_LOG_FILE="$E2E_LOG_DIR/web.log"
-PG_CTL=""
-INITDB=""
-PG_ISREADY=""
-CREATEDB=""
 
 # Preserve env overrides when sourcing `.env` (e.g. WEB_PORT=3001 ./run-e2e.sh).
 _PRESET_WEB_PORT="${WEB_PORT-}"
@@ -71,172 +55,6 @@ echo -e "${YELLOW}========================================${NC}"
 echo -e "${YELLOW}EVY End-to-End Test Runner${NC}"
 echo -e "${YELLOW}========================================${NC}"
 
-command_exists() {
-    command -v "$1" > /dev/null 2>&1
-}
-
-find_postgres_bin_dir() {
-    local candidate_dir
-    for candidate_dir in \
-        /opt/homebrew/opt/postgresql@18/bin \
-        /usr/local/opt/postgresql@18/bin \
-        /opt/homebrew/opt/postgresql@17/bin \
-        /usr/local/opt/postgresql@17/bin \
-        /opt/homebrew/opt/postgresql@16/bin \
-        /usr/local/opt/postgresql@16/bin \
-        /opt/homebrew/opt/postgresql/bin \
-        /usr/local/opt/postgresql/bin; do
-        if [ -x "$candidate_dir/postgres" ] && [ -x "$candidate_dir/pg_ctl" ] && [ -x "$candidate_dir/initdb" ] && [ -x "$candidate_dir/pg_isready" ] && [ -x "$candidate_dir/createdb" ]; then
-            printf '%s' "$candidate_dir"
-            return 0
-        fi
-    done
-
-    if command_exists postgres; then
-        local postgres_path
-        local postgres_bin_dir
-        postgres_path="$(command -v postgres)"
-        postgres_bin_dir="${postgres_path%/*}"
-        if [ -x "$postgres_bin_dir/pg_ctl" ] && [ -x "$postgres_bin_dir/initdb" ] && [ -x "$postgres_bin_dir/pg_isready" ] && [ -x "$postgres_bin_dir/createdb" ]; then
-            printf '%s' "$postgres_bin_dir"
-            return 0
-        fi
-    fi
-
-    return 1
-}
-
-resolve_service_mode() {
-    case "$REQUESTED_SERVICE_MODE" in
-        docker)
-            SERVICE_MODE="docker"
-            ;;
-        local)
-            SERVICE_MODE="local"
-            ;;
-        auto)
-            if command_exists docker && docker compose version > /dev/null 2>&1; then
-                SERVICE_MODE="docker"
-            else
-                SERVICE_MODE="local"
-            fi
-            ;;
-        *)
-            echo -e "${RED}Unknown E2E_SERVICE_MODE: $REQUESTED_SERVICE_MODE${NC}"
-            echo "Use E2E_SERVICE_MODE=auto, docker, or local."
-            exit 1
-            ;;
-    esac
-
-    echo "Using $SERVICE_MODE service mode"
-}
-
-require_e2e_env() {
-    local env_name="$1"
-    if [ -z "${!env_name:-}" ]; then
-        echo -e "${RED}$env_name environment variable is not set${NC}"
-        exit 1
-    fi
-}
-
-require_postgres_commands() {
-    local postgres_bin_dir
-    postgres_bin_dir="$(find_postgres_bin_dir || true)"
-
-    if [ -z "$postgres_bin_dir" ]; then
-        echo -e "${RED}PostgreSQL server tools are required for E2E_SERVICE_MODE=local${NC}"
-        echo "Install PostgreSQL 16 or run with Docker available."
-        exit 1
-    fi
-
-    PATH="$postgres_bin_dir:$PATH"
-    export PATH
-    PG_CTL="$postgres_bin_dir/pg_ctl"
-    INITDB="$postgres_bin_dir/initdb"
-    PG_ISREADY="$postgres_bin_dir/pg_isready"
-    CREATEDB="$postgres_bin_dir/createdb"
-}
-
-configure_local_service_env() {
-    export DB_DOMAIN=127.0.0.1
-    export MARKETPLACE_GRPC_HOST=127.0.0.1
-}
-
-ensure_local_database() {
-    local database_name="$1"
-    PGPASSWORD="$DB_PASS" "$CREATEDB" -h 127.0.0.1 -p "$DB_PORT" -U "$DB_USER" "$database_name"
-}
-
-start_local_postgres() {
-    require_e2e_env DB_USER
-    require_e2e_env DB_PASS
-    require_e2e_env DB_PORT
-    require_e2e_env DB_EVY_DATABASE
-    require_e2e_env DB_MARKETPLACE_DATABASE
-    require_postgres_commands
-
-    mkdir -p "$E2E_LOG_DIR"
-    rm -rf "$POSTGRES_DATA_DIR"
-    printf '%s\n' "$DB_PASS" > "$POSTGRES_PASSWORD_FILE"
-
-    "$INITDB" \
-        -D "$POSTGRES_DATA_DIR" \
-        -U "$DB_USER" \
-        --pwfile="$POSTGRES_PASSWORD_FILE" \
-        --auth-local=trust \
-        --auth-host=scram-sha-256 \
-        --encoding=UTF8 \
-        > "$POSTGRES_LOG_FILE" \
-        2>&1
-    rm -f "$POSTGRES_PASSWORD_FILE"
-
-    {
-        echo "port = $DB_PORT"
-        echo "listen_addresses = '127.0.0.1'"
-    } >> "$POSTGRES_DATA_DIR/postgresql.conf"
-
-    "$PG_CTL" -D "$POSTGRES_DATA_DIR" -l "$POSTGRES_LOG_FILE" start
-    POSTGRES_STARTED_BY_E2E=true
-    retry_until_cmd "local PostgreSQL" "$PG_ISREADY" -h 127.0.0.1 -p "$DB_PORT" -U "$DB_USER"
-
-    ensure_local_database "$DB_EVY_DATABASE"
-    ensure_local_database "$DB_MARKETPLACE_DATABASE"
-}
-
-start_local_service() {
-    local service_name="$1"
-    local log_file="$2"
-    shift 2
-
-    echo "Starting $service_name (logs: $log_file)..."
-    "$@" > "$log_file" 2>&1 &
-    local pid=$!
-    LOCAL_SERVICE_PIDS="$LOCAL_SERVICE_PIDS $pid"
-
-    sleep 1
-    if ! kill -0 "$pid" 2>/dev/null; then
-        echo -e "${RED}$service_name failed to start${NC}"
-        cat "$log_file" || true
-        exit 1
-    fi
-}
-
-start_docker_services() {
-    export DOCKER_BUILDKIT=1
-    export COMPOSE_DOCKER_CLI_BUILD=1
-    export COMPOSE_PARALLEL_LIMIT="${COMPOSE_PARALLEL_LIMIT:-1}"
-
-    docker compose up --build -d
-}
-
-start_local_services() {
-    configure_local_service_env
-    start_local_postgres
-    start_local_service "Marketplace" "$MARKETPLACE_LOG_FILE" bun run --cwd services/marketplace start
-    start_local_service "API" "$API_LOG_FILE" bun run --cwd api start
-    start_local_service "Web" "$WEB_LOG_FILE" bun run --cwd web start
-}
-
 # Run a command (stdout/stderr discarded) until it succeeds or max retries.
 retry_until_cmd() {
     local description="$1"
@@ -256,26 +74,7 @@ retry_until_cmd() {
 
 cleanup() {
     echo -e "\n${YELLOW}Cleaning up...${NC}"
-    rm -f "$POSTGRES_PASSWORD_FILE"
-
-    if [ "$SERVICE_MODE" = "docker" ]; then
-        docker compose down -v --remove-orphans 2>/dev/null || true
-        return
-    fi
-
-    if [ "$SERVICE_MODE" = "local" ]; then
-        local pid
-        for pid in $LOCAL_SERVICE_PIDS; do
-            kill "$pid" 2>/dev/null || true
-        done
-        for pid in $LOCAL_SERVICE_PIDS; do
-            wait "$pid" 2>/dev/null || true
-        done
-
-        if [ "$POSTGRES_STARTED_BY_E2E" = true ] && [ -x "${PG_CTL:-}" ] && [ -d "$POSTGRES_DATA_DIR" ]; then
-            "$PG_CTL" -D "$POSTGRES_DATA_DIR" -m fast stop > /dev/null 2>&1 || true
-        fi
-    fi
+    docker compose down -v --remove-orphans 2>/dev/null || true
 }
 
 wait_for_http_service() {
@@ -287,21 +86,13 @@ wait_for_http_service() {
 wait_for_api_readiness() {
     local script_name="$1"
     local display_name="$2"
-    if [ "$SERVICE_MODE" = "docker" ]; then
-        retry_until_cmd "$display_name" bash -c "cd \"$REPO_ROOT\" && docker compose exec -T api bun run \"$script_name\""
-    else
-        retry_until_cmd "$display_name" bun run --cwd api "$script_name"
-    fi
+    retry_until_cmd "$display_name" bash -c "cd \"$REPO_ROOT\" && docker compose exec -T api bun run \"$script_name\""
 }
 
 wait_for_marketplace_readiness() {
     local script_name="$1"
     local display_name="$2"
-    if [ "$SERVICE_MODE" = "docker" ]; then
-        retry_until_cmd "$display_name" bash -c "cd \"$REPO_ROOT\" && docker compose exec -T marketplace bun run \"$script_name\""
-    else
-        retry_until_cmd "$display_name" bun run --cwd services/marketplace "$script_name"
-    fi
+    retry_until_cmd "$display_name" bash -c "cd \"$REPO_ROOT\" && docker compose exec -T marketplace bun run \"$script_name\""
 }
 
 extract_ios_simulator_destination() {
@@ -410,33 +201,27 @@ trap cleanup EXIT
 echo -e "\n${YELLOW}Installing dependencies...${NC}"
 bun run install:all
 
-resolve_service_mode
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+export COMPOSE_PARALLEL_LIMIT="${COMPOSE_PARALLEL_LIMIT:-1}"
 
-echo -e "\n${YELLOW}Step 1: Generating types...${NC}"
-if ! bun types:generate; then
-    echo -e "${RED}Type generation failed${NC}"
-    exit 1
-fi
+echo -e "\n${YELLOW}Step 1: Starting services with docker compose...${NC}"
+docker compose up --build -d
 
-echo -e "\n${YELLOW}Step 2: Starting services in $SERVICE_MODE mode...${NC}"
-if [ "$SERVICE_MODE" = "docker" ]; then
-    start_docker_services
-else
-    start_local_services
-fi
+echo -e "\n${YELLOW}Step 2: Waiting for services to be healthy...${NC}"
 
-echo -e "\n${YELLOW}Step 3: Waiting for services to be healthy...${NC}"
-
-if [ "$SERVICE_MODE" = "docker" ]; then
-    retry_until_cmd "PostgreSQL" bash -c "cd \"$REPO_ROOT\" && docker compose exec -T postgres pg_isready -U \"$DB_USER\""
-fi
+retry_until_cmd "PostgreSQL" bash -c "cd \"$REPO_ROOT\" && docker compose exec -T postgres pg_isready -U \"$DB_USER\""
 
 wait_for_marketplace_readiness "health" "Marketplace"
 
 wait_for_api_readiness "health" "API"
 wait_for_http_service "Web" "http://localhost:$WEB_PORT"
 
-
+echo -e "\n${YELLOW}Step 3: Generating types...${NC}"
+if ! bun types:generate; then
+    echo -e "${RED}Type generation failed${NC}"
+    exit 1
+fi
 
 echo -e "\n${YELLOW}Step 4: Running API e2e tests...${NC}"
 seed_database


### PR DESCRIPTION
## Summary

Removes the dual-mode (local/Docker) service infrastructure from the E2E test runner and CI workflow, making Docker Compose the single, mandatory service runtime. This simplifies both the CI pipeline and the `run-e2e.sh` script significantly.

## Major changes

- **`run-e2e.sh`**: Removed ~175 lines of local-mode code including PostgreSQL management via `pg_ctl`/`initdb`, local service startup, the `resolve_service_mode` logic, and all associated variables and helper functions. The script now always uses `docker compose up --build -d` and `docker compose exec` for health checks.
- **`.github/workflows/e2e_tests.yml`**: Added a `Start Docker daemon` step that waits for Docker to be available on the Blacksmith macOS runner. Removed the `Install PostgreSQL` step and the `E2E_SERVICE_MODE: local` env var. Reduced the job timeout from 25 to 10 minutes.
- **`README.md`**: Updated documentation to reflect Docker-only E2E testing.

## Tests ran

CI will validate via the existing e2e workflow.

## Risks

The macOS CI runner must have Docker available. The new `Start Docker daemon` step attempts to start it and fails with a clear error if not found, so failures are explicit.