### PR TITLE
[FEAT] Speed up iOS e2e with parallel simulators and background build

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -36,6 +36,7 @@ jobs:
                         - 'types/**'
                         - 'services/**'
                         - 'run-e2e.sh'
+                        - 'scripts/run-ios-e2e.sh'
                         - '.github/workflows/e2e_tests.yml'
                         - '.github/actions/**'
                         - '!**/*.md'
@@ -110,4 +111,15 @@ jobs:
               with:
                   name: e2e-tests-playwright-report
                   path: web/playwright-report/
+                  retention-days: 1
+
+            - name: Upload iOS e2e results
+              uses: actions/upload-artifact@v7
+              if: always() && (github.event_name == 'workflow_dispatch' ||
+                  steps.paths.outputs.e2e == 'true')
+              with:
+                  name: ios-e2e-results
+                  path: |
+                      ios/TestResults-*.xcresult
+                      ios-e2e-*.log
                   retention-days: 1

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,5 +1,7 @@
 build/
+DerivedData-e2e/
 TestDiagnostics/
+TestResults-*.xcresult
 xcuserdata/
 
 # sourcekit-lsp BSP manifest (regenerated per machine, see README)

--- a/ios/e2e/e2e.swift
+++ b/ios/e2e/e2e.swift
@@ -5,8 +5,8 @@
 
 import XCTest
 
-private let MARKETPLACE_ITEMS_RESOURCE_ID = MarketplaceE2EFixture.itemsRef
-private let MARKETPLACE_SERVICE = MarketplaceE2EFixture.service
+let MARKETPLACE_ITEMS_RESOURCE_ID = MarketplaceE2EFixture.itemsRef
+let MARKETPLACE_SERVICE = MarketplaceE2EFixture.service
 
 // MARK: - Minimal WebSocket Emitter for E2E Tests
 
@@ -360,7 +360,7 @@ actor WSEmitter {
   }
 }
 
-private enum E2EFlowIds {
+enum E2EFlowIds {
   /// The seeded production home flow the app boots into when no HOME_FLOW_ID override is set.
   static let defaultHomeFlow = "f267c629-2594-4770-8cec-d5324ebb4058"
   static let navigationHomeFlow = "10000000-0000-4000-8000-000000000001"
@@ -834,6 +834,189 @@ class E2ETestBase: XCTestCase {
       }
       await emitter.disconnect()
     }
+  }
+
+  func seedIsolatedFlows() throws {
+    try seedFlows(
+      [
+        (
+          flowId: E2EFlowIds.webSocketHomeFlow,
+          flowData: createHomeFlowData(buttonLabel: "View")
+        ),
+        (
+          flowId: E2EFlowIds.webSocketViewFlow,
+          flowData: Self.viewItemFlowData(
+            flowId: E2EFlowIds.webSocketViewFlow,
+            pageId: E2EFlowIds.webSocketViewPage
+          )
+        ),
+        (
+          flowId: E2EFlowIds.webSocketCreateFlow,
+          flowData: Self.minimalCreateItemFlowData()
+        ),
+      ]
+    )
+  }
+
+  static func viewItemNavigateAction(viewItemId: String?) -> String {
+    guard let viewItemId else {
+      return "{navigate(\(E2EFlowIds.webSocketViewFlow),\(E2EFlowIds.webSocketViewPage))}"
+    }
+    return
+      "{navigate(\(E2EFlowIds.webSocketViewFlow),\(E2EFlowIds.webSocketViewPage),{\(MARKETPLACE_ITEMS_RESOURCE_ID): [\(viewItemId)]})}"
+  }
+
+  @MainActor
+  func openViewItemPage(
+    emitter: WSEmitter,
+    labelPrefix: String,
+    itemId: String,
+    viewFlowDataBuilder: (String, String) -> [String: Any] = E2ETestBase.viewItemRequestFlowData,
+    viewFlowId: String = E2EFlowIds.webSocketViewFlow,
+    viewPageId: String = E2EFlowIds.webSocketViewPage,
+    buttonExistenceMessage: String = "View button should load after relaunch"
+  ) async throws -> String {
+    let viewLabel = "\(labelPrefix) \(Int(Date().timeIntervalSince1970))"
+    try await emitter.updateSDUI(
+      flowData: createHomeFlowData(buttonLabel: viewLabel, viewItemId: itemId),
+      flowId: E2EFlowIds.webSocketHomeFlow
+    )
+    try await emitter.updateSDUI(
+      flowData: viewFlowDataBuilder(viewFlowId, viewPageId),
+      flowId: viewFlowId
+    )
+    app.terminate()
+    try launchApp()
+    let viewButton = app.buttons[viewLabel]
+    XCTAssertTrue(
+      viewButton.waitForExistence(timeout: 20),
+      buttonExistenceMessage)
+    viewButton.tap()
+    return viewLabel
+  }
+
+  func createHomeFlowData(
+    buttonLabel: String,
+    viewItemId: String? = nil,
+    includeAddedSharedRow: Bool = false,
+    includeHeadingRow: Bool = false,
+    includeHomeInbox: Bool = false
+  ) -> [String: Any] {
+    let viewAction = Self.viewItemNavigateAction(viewItemId: viewItemId)
+
+    var children: [[String: Any]] = []
+    if includeHeadingRow {
+      children.append(
+        Self.headingRow(
+          id: "b1c2d3e4-f5a6-4789-8012-3456789abcde",
+          title: "Heading: {e2e.unrelated_input}"
+        )
+      )
+    }
+    children.append(contentsOf: [
+      Self.inputRow(
+        id: "c72107b6-a50f-4bdb-98d8-4f803e2e8e1b",
+        title: "Notes",
+        source: nil,
+        placeholder: "Type here",
+        destination: "e2e.unrelated_input"
+      ),
+      Self.textRow(
+        id: "5af45c82-6b8a-4f33-9864-1c5f9eb47ed1",
+        title: "Live: {e2e.unrelated_input}"
+      ),
+    ])
+    if includeAddedSharedRow {
+      children.append(
+        Self.textRow(
+          id: "9c1e7f4a-3b2d-4e6a-8f1c-2d3e4f5a6b7c",
+          title: "Added: {e2e.unrelated_input}"
+        )
+      )
+    }
+    children.append(contentsOf: [
+      Self.buttonRow(
+        id: "53d04050-29f3-48ec-b55b-1a6a30fc2111",
+        label: "Details",
+        action:
+          "{navigate(\(E2EFlowIds.webSocketHomeFlow),\(E2EFlowIds.webSocketHomeDetailsPage))}"
+      ),
+      Self.buttonRow(
+        id: "441c1433-446b-4682-854d-5d795ef52709",
+        label: buttonLabel,
+        action: viewAction
+      ),
+      Self.buttonRow(
+        id: "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
+        label: "Create",
+        action:
+          "{navigate(\(E2EFlowIds.webSocketCreateFlow),\(E2EFlowIds.webSocketCreatePage))}"
+      ),
+    ])
+
+    var homeRows: [[String: Any]] = [
+      [
+        "id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
+        "type": "vertical_container",
+        "actions": [:],
+        "visible": "true",
+        "title": "",
+        "children": children,
+      ]
+    ]
+    if includeHomeInbox {
+      homeRows.insert(Self.homeInboxTabRow(), at: 0)
+    }
+
+    return [
+      "id": E2EFlowIds.webSocketHomeFlow,
+      "name": "Home",
+      "pages": [
+        [
+          "id": E2EFlowIds.webSocketHomePage,
+          "title": "Home",
+          "rows": homeRows,
+        ],
+        [
+          "id": E2EFlowIds.webSocketHomeDetailsPage,
+          "title": "Details",
+          "rows": [
+            Self.textRow(
+              id: "36dc56d0-706b-4d5a-bc2a-6dc6956c9277",
+              title: "Details page"
+            )
+          ],
+        ],
+      ],
+    ]
+  }
+
+  func createConditionalFlowData(buttonLabel: String) -> [String: Any] {
+    var flowData = createHomeFlowData(buttonLabel: buttonLabel)
+    guard var pages = flowData["pages"] as? [[String: Any]],
+      var homePage = pages.first,
+      var rows = homePage["rows"] as? [[String: Any]],
+      var firstRow = rows.first,
+      var children = firstRow["children"] as? [[String: Any]],
+      let buttonIndex = children.firstIndex(where: { ($0["label"] as? String) == buttonLabel }),
+      let actionsObject = children[buttonIndex]["actions"] as? [String: Any],
+      var actions = actionsObject["tap"] as? [[String: Any]],
+      var firstAction = actions.first
+    else {
+      return flowData
+    }
+
+    var button = children[buttonIndex]
+    firstAction["condition"] = "{1 > 0 || (0 > 1 && 2 > 3)}"
+    actions[0] = firstAction
+    button["actions"] = ["tap": actions]
+    children[buttonIndex] = button
+    firstRow["children"] = children
+    rows[0] = firstRow
+    homePage["rows"] = rows
+    pages[0] = homePage
+    flowData["pages"] = pages
+    return flowData
   }
 
   static func homeFlowData(
@@ -2242,28 +2425,6 @@ final class WebSocketE2ETests: E2ETestBase {
     try super.tearDownWithError()
   }
 
-  private func seedIsolatedFlows() throws {
-    try seedFlows(
-      [
-        (
-          flowId: E2EFlowIds.webSocketHomeFlow,
-          flowData: createHomeFlowData(buttonLabel: "View")
-        ),
-        (
-          flowId: E2EFlowIds.webSocketViewFlow,
-          flowData: Self.viewItemFlowData(
-            flowId: E2EFlowIds.webSocketViewFlow,
-            pageId: E2EFlowIds.webSocketViewPage
-          )
-        ),
-        (
-          flowId: E2EFlowIds.webSocketCreateFlow,
-          flowData: Self.minimalCreateItemFlowData()
-        ),
-      ]
-    )
-  }
-
   @MainActor
   func testWebSocketNotificationUpdatesUI() async throws {
     let viewItemButton = app.buttons["View"]
@@ -2603,855 +2764,6 @@ final class WebSocketE2ETests: E2ETestBase {
       "Nested TimeslotPicker slot should be hittable inside segment nesting")
   }
 
-  @MainActor
-  func testTimeslotPickerCreatesPickupRequest() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let selectedTimeslot = "2026-06-03T09:00:00"
-    let (selectedItemId, selectedItemTitle) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Pickup request item",
-      pickupSelection: [selectedTimeslot]
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Request pickup",
-      itemId: selectedItemId,
-      buttonExistenceMessage: "Request view button should load"
-    )
-    try await emitter.subscribe(event: "data_changed")
-
-    let timeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
-    timeslot.tap()
-
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should appear after selecting a timeslot")
-    XCTAssertTrue(
-      app.staticTexts.containing(
-        NSPredicate(format: "label CONTAINS %@", selectedItemTitle)
-      ).firstMatch.waitForExistence(timeout: 5),
-      "Confirmation sheet should mention the item title")
-
-    tapConfirmationSheetRequestButton()
-    XCTAssertFalse(
-      app.alerts.firstMatch.waitForExistence(timeout: 2),
-      "Pickup request should not show a native confirmation alert")
-
-    let pickupRequestCreated = try await waitForMessage(
-      emitter: emitter,
-      type: "pickup",
-      itemId: selectedItemId,
-      valueKey: "time",
-      value: selectedTimeslot
-    )
-    XCTAssertTrue(
-      pickupRequestCreated,
-      "Tapping a pickup timeslot should create a matching marketplace message"
-    )
-    await emitter.disconnect()
-  }
-
-  @MainActor
-  func testTimeslotConfirmationCancelDoesNotCreateRequest() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let selectedTimeslot = "2026-06-03T09:00:00"
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Cancel pickup item",
-      pickupSelection: [selectedTimeslot]
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Cancel pickup",
-      itemId: selectedItemId,
-      buttonExistenceMessage: "Request view button should load"
-    )
-
-    let timeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
-    timeslot.tap()
-
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should appear after selecting a timeslot")
-    dismissConfirmationSheet()
-
-    let messagesAfterCancel = try await emitter.getResource(
-      resource: EVYCoreResource.messages.ref
-    )
-    XCTAssertFalse(
-      Self.messagesContain(
-        messagesAfterCancel,
-        type: "pickup",
-        itemId: selectedItemId
-      ),
-      "Cancelling confirmation should not create a pickup request"
-    )
-    XCTAssertTrue(timeslot.exists, "Pickup timeslot should remain visible after cancel")
-    XCTAssertFalse(
-      app.buttons["Cancel pickup request"].exists,
-      "Cancel pickup request should not appear when no request was created"
-    )
-    await emitter.disconnect()
-  }
-
-  @MainActor
-  func testPickupConfirmationSheetShowsEarlierTimeslotWarning() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Later pickup item",
-      pickupSelection: ["2026-06-03T09:00:00", "2026-06-03T10:00:00"]
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Later pickup",
-      itemId: selectedItemId,
-      buttonExistenceMessage: "Request view button should load"
-    )
-
-    let laterTimeslot = app.staticTexts["10:00"].firstMatch
-    XCTAssertTrue(
-      laterTimeslot.waitForExistence(timeout: 10), "Later pickup timeslot should be visible")
-    laterTimeslot.tap()
-
-    let earlierTimeslotWarning = app.staticTexts.containing(
-      NSPredicate(format: "label CONTAINS %@", "earlier than your selected timeslot")
-    ).firstMatch
-    XCTAssertTrue(
-      earlierTimeslotWarning.waitForExistence(timeout: 5),
-      "Later timeslot confirmation should show the earlier-timeslot warning")
-
-    dismissConfirmationSheet()
-    XCTAssertTrue(
-      waitForConfirmationSheetDismissed(timeout: 5),
-      "Confirmation sheet should dismiss")
-
-    let earlierTimeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(
-      earlierTimeslot.waitForExistence(timeout: 10), "Earlier pickup timeslot should be visible")
-    earlierTimeslot.tap()
-
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Confirmation sheet should reopen for the earlier timeslot")
-    XCTAssertFalse(
-      earlierTimeslotWarning.waitForExistence(timeout: 2),
-      "Earliest timeslot confirmation should not show the earlier-timeslot warning")
-    await emitter.disconnect()
-  }
-
-  @MainActor
-  func testCancelRequestTogglesPickerAndShippingButton() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let selectedTimeslot = "2026-06-03T09:00:00"
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Cancel request item",
-      pickupSelection: [selectedTimeslot]
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Cancel request",
-      itemId: selectedItemId,
-      viewFlowDataBuilder: Self.viewItemCancelRequestFlowData,
-      buttonExistenceMessage: "Request view button should load"
-    )
-    try await emitter.subscribe(event: "data_changed")
-
-    let timeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
-    XCTAssertFalse(
-      app.buttons["Cancel pickup request"].exists,
-      "Cancel pickup request should be hidden before a request exists")
-
-    timeslot.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should appear after selecting a timeslot")
-    tapConfirmationSheetRequestButton()
-
-    let pickupRequestCreated = try await waitForMessage(
-      emitter: emitter,
-      type: "pickup",
-      itemId: selectedItemId,
-      valueKey: "time",
-      value: selectedTimeslot
-    )
-    XCTAssertTrue(pickupRequestCreated, "Tapping a pickup timeslot should create a message")
-
-    let cancelButton = app.buttons["Cancel pickup request"].firstMatch
-    XCTAssertTrue(
-      cancelButton.waitForExistence(timeout: 10),
-      "Cancel pickup request should replace the transfer tabs and pickup timeslot")
-    XCTAssertFalse(timeslot.exists, "Pickup timeslot should be hidden after creating a request")
-    XCTAssertFalse(
-      app.segmentedControls.buttons["Shipping"].waitForExistence(timeout: 2),
-      "Transfer tabs collapse while an arrangement is in flight, leaving just that request")
-
-    cancelButton.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Cancel pickup confirmation sheet should appear")
-    // The row button and the sheet's confirm button share the "Cancel request" label; tap the
-    // hittable one (the confirm button on top of the sheet) so the write actually fires.
-    let confirmCancelButton = try XCTUnwrap(
-      waitForHittableButton(labeled: "Cancel request"),
-      "Confirm cancel button should be tappable in the sheet")
-    confirmCancelButton.tap()
-
-    let requestWithdrawn = try await waitForMessage(
-      emitter: emitter,
-      itemId: selectedItemId,
-      valueKey: "value",
-      value: "cancel"
-    )
-    XCTAssertTrue(
-      requestWithdrawn, "Cancel request should append a cancel message, not rewrite the request")
-    XCTAssertTrue(
-      timeslot.waitForExistence(timeout: 10),
-      "Pickup timeslot should return after cancelling the request")
-
-    timeslot.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should reopen after cancelling the request")
-    tapConfirmationSheetRequestButton()
-    XCTAssertTrue(
-      app.buttons["Cancel pickup request"].firstMatch.waitForExistence(timeout: 10),
-      "Cancel pickup request should reappear after creating another request")
-    await emitter.disconnect()
-  }
-
-  /// The case the latest-message model exists for: a rejection is terminal but leaves nothing
-  /// in flight, so the buyer is back to picking a timeslot and can ask again. The old
-  /// predicates could not express this - the request was still there, unanswered as far as any
-  /// flat lookup could tell.
-  @MainActor
-  func testRejectedRequestReturnsTheTimeslots() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let selectedTimeslot = "2026-06-03T09:00:00"
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Rejected request item",
-      pickupSelection: [selectedTimeslot]
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Rejected request",
-      itemId: selectedItemId,
-      viewFlowDataBuilder: Self.viewItemCancelRequestFlowData,
-      buttonExistenceMessage: "Request view button should load"
-    )
-    try await emitter.subscribe(event: "data_changed")
-
-    let timeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
-    timeslot.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should appear after selecting a timeslot")
-    tapConfirmationSheetRequestButton()
-
-    XCTAssertTrue(
-      waitForCancelRequestVisible(timeout: 10),
-      "Cancel pickup request should be visible while the request is open")
-
-    let requestId = try await waitForMessageId(
-      emitter: emitter,
-      itemId: selectedItemId,
-      type: "pickup",
-      value: "pending",
-      failureMessage: "An open pickup request should exist for the item"
-    )
-
-    // The owner rejects. Like every other settling message it names the request and carries
-    // its payload forward.
-    _ = try await emitter.createResource(
-      resource: EVYCoreResource.messages.ref,
-      data: [
-        "fk": selectedItemId,
-        "resource": MARKETPLACE_ITEMS_RESOURCE_ID,
-        "visibility": "private",
-        "parent_message_id": requestId,
-        "data": Self.settlingMessageData(
-          value: "reject",
-          type: "pickup",
-          time: selectedTimeslot
-        ),
-      ]
-    )
-    let rejectedOnServer = try await waitForMessageResponse(
-      emitter: emitter,
-      messageId: requestId,
-      value: "reject"
-    )
-    XCTAssertTrue(rejectedOnServer, "The API should hold the message rejecting the request")
-
-    XCTAssertTrue(
-      waitForCancelRequestHidden(timeout: 10),
-      "Cancel pickup request should go once the request has been answered")
-    XCTAssertTrue(
-      timeslot.waitForExistence(timeout: 10),
-      "Pickup timeslots should return after a rejection")
-    XCTAssertFalse(
-      app.staticTexts.matching(
-        NSPredicate(format: "label BEGINSWITH %@", "Pickup confirmed for")
-      ).firstMatch.exists,
-      "A rejection is not a confirmation")
-
-    // And the buyer can ask again, which is the whole point.
-    timeslot.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should reopen after a rejection")
-    tapConfirmationSheetRequestButton()
-    XCTAssertTrue(
-      waitForCancelRequestVisible(timeout: 10),
-      "A fresh request after a rejection is open again")
-
-    await emitter.disconnect()
-  }
-
-  /// The id of a message for an item, as the server holds it.
-  @MainActor
-  private func waitForMessageId(
-    emitter: WSEmitter,
-    itemId: String,
-    type: String = "pickup",
-    value: String? = "pending",
-    failureMessage: String,
-    timeout: TimeInterval = 10
-  ) async throws -> String {
-    let deadline = Date().addingTimeInterval(timeout)
-    repeat {
-      let payload = try await emitter.getResource(
-        resource: EVYCoreResource.messages.ref
-      )
-      if let rows = Self.responseDataArray(from: payload),
-        let match = rows.compactMap({ $0 as? [String: Any] }).first(where: { row in
-          let data = row["data"] as? [String: Any]
-          guard row["fk"] as? String == itemId,
-            data?["type"] as? String == type
-          else { return false }
-          if let value {
-            return data?["value"] as? String == value
-          }
-          return true
-        }),
-        let id = match["id"] as? String
-      {
-        return id
-      }
-    } while try await emitter.nextDataChanged(
-      resource: EVYCoreResource.messages.ref, deadline: deadline)
-    XCTFail(failureMessage)
-    return ""
-  }
-
-  @MainActor
-  func testAcceptedRequestHidesCancelAndShowsConfirmation() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let selectedTimeslot = "2026-06-03T09:00:00"
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Accepted request item",
-      pickupSelection: [selectedTimeslot]
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Accepted request",
-      itemId: selectedItemId,
-      viewFlowDataBuilder: Self.viewItemCancelRequestFlowData,
-      buttonExistenceMessage: "Request view button should load"
-    )
-    try await emitter.subscribe(event: "data_changed")
-
-    let timeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
-    timeslot.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should appear after selecting a timeslot")
-    tapConfirmationSheetRequestButton()
-
-    let pickupRequestCreated = try await waitForMessage(
-      emitter: emitter,
-      type: "pickup",
-      itemId: selectedItemId,
-      valueKey: "time",
-      value: selectedTimeslot
-    )
-    XCTAssertTrue(pickupRequestCreated, "Tapping a pickup timeslot should create a message")
-    XCTAssertTrue(
-      waitForCancelRequestVisible(timeout: 10),
-      "Cancel pickup request should be visible for a pending request")
-
-    let messagesPayload = try await emitter.getResource(
-      resource: EVYCoreResource.messages.ref
-    )
-    let messageRows = try XCTUnwrap(
-      Self.responseDataArray(from: messagesPayload),
-      "Messages payload should be an array"
-    )
-    let request = try XCTUnwrap(
-      messageRows.compactMap { $0 as? [String: Any] }.first {
-        $0["id"] as? String != nil
-          && ($0["data"] as? [String: Any])?["type"] as? String == "pickup"
-          && $0["fk"] as? String == selectedItemId
-      },
-      "Created pickup message should be readable from the API"
-    )
-    let messageId = try XCTUnwrap(
-      request["id"] as? String,
-      "Created pickup message should include an id"
-    )
-
-    // Accepting is a new message naming the request, not an edit to it - and it carries
-    // the request's payload forward. `findFirst` predicates cannot nest, so the row that
-    // says "Pickup confirmed for …" reads the time off the message that says "accepted".
-    _ = try await emitter.createResource(
-      resource: EVYCoreResource.messages.ref,
-      data: [
-        "fk": selectedItemId,
-        "resource": MARKETPLACE_ITEMS_RESOURCE_ID,
-        "visibility": "private",
-        "parent_message_id": messageId,
-        "data": Self.settlingMessageData(
-          value: "accept",
-          type: "pickup",
-          time: selectedTimeslot,
-          pickupAddress: Self.amazingFridgePickupAddressRow
-        ),
-      ]
-    )
-    let acceptedOnServer = try await waitForMessageResponse(
-      emitter: emitter,
-      messageId: messageId,
-      value: "accept"
-    )
-    XCTAssertTrue(
-      acceptedOnServer,
-      "The API should persist the message that accepts the pickup request")
-
-    XCTAssertTrue(
-      waitForCancelRequestHidden(timeout: 10),
-      "Cancel pickup request should hide once the request is answered")
-    XCTAssertTrue(
-      app.staticTexts.matching(
-        NSPredicate(format: "label BEGINSWITH %@", "Pickup confirmed for")
-      ).firstMatch.waitForExistence(timeout: 10),
-      "Pickup segment should show the accepted confirmation row")
-    // The postcode map gives way to the seller's full address, which only exists on the accept.
-    XCTAssertTrue(
-      app.staticTexts["C509 28 Rothschild Avenue, 2018 Rosebery NSW"].waitForExistence(
-        timeout: 10),
-      "Accepted pickup should show the full address carried by the accept message")
-    XCTAssertFalse(
-      app.segmentedControls.buttons["Shipping"].waitForExistence(timeout: 2),
-      "Transfer tabs stay collapsed once an arrangement is agreed")
-    let shippingConfirmation = app.staticTexts.matching(
-      NSPredicate(format: "label BEGINSWITH %@", "Shipping confirmed")
-    ).firstMatch
-    XCTAssertFalse(
-      shippingConfirmation.waitForExistence(timeout: 2),
-      "Shipping confirmation should stay hidden for an accepted pickup request")
-
-    await emitter.disconnect()
-  }
-
-  @MainActor
-  func testSenderIsOfferedCancelAndCannotAnswerItsOwnRequest() throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    let host = apiHost
-    let selectedTimeslot = "2026-06-03T09:00:00"
-    let (itemId, _) = try awaitResult("create sender cancel item") {
-      try await emitter.connect(host: host)
-      try await emitter.login(token: "e2e-test", os: "ios")
-      return try await self.createMarketplaceItem(
-        emitter: emitter,
-        titlePrefix: "Sender cancel item",
-        pickupSelection: [selectedTimeslot]
-      )
-    }
-
-    let viewLabel = "Sender cancel \(Int(Date().timeIntervalSince1970))"
-    let homeFlowData = createHomeFlowData(
-      buttonLabel: viewLabel,
-      viewItemId: itemId,
-      includeHomeInbox: true
-    )
-    let senderFlowData = E2ETestBase.senderViewFlowData(
-      flowId: E2EFlowIds.webSocketViewFlow,
-      pageId: E2EFlowIds.webSocketViewPage
-    )
-    try awaitResult("seed sender inbox flow") {
-      try await emitter.updateSDUI(
-        flowData: homeFlowData,
-        flowId: E2EFlowIds.webSocketHomeFlow
-      )
-      try await emitter.updateSDUI(
-        flowData: senderFlowData,
-        flowId: E2EFlowIds.webSocketViewFlow
-      )
-      try await emitter.subscribe(event: "data_changed")
-    }
-
-    app.terminate()
-    try launchApp()
-    let viewButton = app.buttons[viewLabel]
-    XCTAssertTrue(
-      viewButton.waitForExistence(timeout: 20),
-      "Sender request view button should load")
-    XCTAssertTrue(
-      scrollUntilHittable(viewButton),
-      "Sender request view button should be reachable")
-    viewButton.tap()
-
-    let timeslot = app.staticTexts["09:00"].firstMatch
-    XCTAssertTrue(timeslot.waitForExistence(timeout: 15), "Pickup timeslot should be visible")
-    timeslot.tap()
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Pickup confirmation sheet should appear after selecting a timeslot")
-    tapConfirmationSheetRequestButton()
-
-    let requestId = try awaitResult("wait for sender request") {
-      try await self.waitForMessageId(
-        emitter: emitter,
-        itemId: itemId,
-        type: "pickup",
-        value: nil,
-        failureMessage: "Tapping a pickup timeslot should have created a request"
-      )
-    }
-    let backButton = app.navigationBars.buttons.firstMatch
-    XCTAssertTrue(
-      backButton.waitForExistence(timeout: 5), "The request page should have a back button")
-    backButton.tap()
-
-    let fromYouTab = app.segmentedControls.buttons["From you"]
-    XCTAssertTrue(
-      fromYouTab.waitForExistence(timeout: 10),
-      "The inbox should include a From you tab")
-    XCTAssertTrue(
-      scrollUntilHittable(fromYouTab),
-      "The From you tab should be reachable below the request picker")
-    fromYouTab.tap()
-
-    let childRowId = E2ETestBase.homeInboxFromYouChildRowId
-    let row = app.otherElements["swipeRow_\(childRowId)_\(requestId)"]
-    XCTAssertTrue(
-      row.waitForExistence(timeout: 10),
-      "The request created by this device should appear under From you")
-    XCTAssertTrue(
-      scrollUntilHittable(row),
-      "The request row should be reachable after scrolling")
-    row.swipeLeft(velocity: .slow)
-
-    let swipeButtonId = "swipeLeft_\(childRowId)_\(requestId)"
-    let swipeButton = app.buttons[swipeButtonId]
-    XCTAssertTrue(
-      swipeButton.waitForExistence(timeout: 3),
-      "The sender should be offered cancel")
-    XCTAssertEqual(swipeButton.label, "Cancel")
-    XCTAssertEqual(
-      app.buttons.matching(identifier: swipeButtonId).count,
-      1,
-      "The From you row should reveal exactly one declarative action")
-
-    XCTAssertTrue(
-      swipeButton.isHittable,
-      "The revealed Cancel action should accept taps"
-    )
-    swipeButton.tap()
-    XCTAssertTrue(
-      row.waitForNonExistence(timeout: 5),
-      "Cancel should optimistically remove the request from From you"
-    )
-
-    let cancelled = try awaitResult("wait for cancel response") {
-      try await self.waitForMessageResponse(
-        emitter: emitter,
-        messageId: requestId,
-        value: "cancel"
-      )
-    }
-    XCTAssertTrue(cancelled, "Cancel should persist a response naming the request")
-    try awaitResult("disconnect sender emitter") { await emitter.disconnect() }
-  }
-
-  @MainActor
-  func testAskToBuyCreatesShippingRequestAndValidatesEmptyPostcode() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Shipping request item",
-      pickupSelection: ["2026-06-03T09:00:00"],
-      shippingFee: "0"
-    )
-
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: "Request shipping",
-      itemId: selectedItemId,
-      buttonExistenceMessage: "Request view button should load"
-    )
-    try await emitter.subscribe(event: "data_changed")
-
-    let askToBuyButton = app.buttons["Ask to buy"]
-    XCTAssertTrue(
-      askToBuyButton.waitForExistence(timeout: 10), "Ask to buy button should be visible")
-    askToBuyButton.tap()
-
-    let missingInformationAlert = app.alerts["Missing information"]
-    XCTAssertTrue(
-      missingInformationAlert.waitForExistence(timeout: 5),
-      "An empty shipping postcode should show the missing-information alert"
-    )
-    let messagesAfterEmptyPostcode = try await emitter.getResource(
-      resource: EVYCoreResource.messages.ref
-    )
-    XCTAssertFalse(
-      Self.messagesContain(
-        messagesAfterEmptyPostcode,
-        type: "shipping",
-        itemId: selectedItemId
-      ),
-      "An empty postcode must not create a shipping request"
-    )
-    let dismissAlertButton = missingInformationAlert.buttons.firstMatch
-    XCTAssertTrue(dismissAlertButton.exists, "Missing-information alert should be dismissible")
-    dismissAlertButton.tap()
-
-    try fillShippingPostcodeAndAskToBuy()
-
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Shipping confirmation sheet should appear after Ask to buy with a postcode")
-    tapConfirmationSheetRequestButton()
-
-    let shippingRequestCreated = try await waitForMessage(
-      emitter: emitter,
-      type: "shipping",
-      itemId: selectedItemId,
-      valueKey: "postalcode",
-      value: "2018"
-    )
-    XCTAssertTrue(
-      shippingRequestCreated,
-      "Ask to buy should create a shipping request with the entered postcode"
-    )
-    await emitter.disconnect()
-  }
-
-  /// Requests shipping for a freshly created item and asserts which surcharge-aware copy
-  /// appears in the confirmation sheet.
-  @MainActor
-  private func assertShippingConfirmationCopy(
-    emitter: WSEmitter,
-    titlePrefix: String,
-    shippingFee: String,
-    viewLabelPrefix: String,
-    expectedCopy: String,
-    expectedMessage: String,
-    absentCopy: String,
-    absentMessage: String,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) async throws {
-    let (itemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: titlePrefix,
-      pickupSelection: ["2026-06-03T09:00:00"],
-      shippingFee: shippingFee
-    )
-    _ = try await openViewItemPage(
-      emitter: emitter,
-      labelPrefix: viewLabelPrefix,
-      itemId: itemId
-    )
-
-    try fillShippingPostcodeAndAskToBuy()
-
-    XCTAssertTrue(
-      waitForConfirmationSheet(timeout: 5),
-      "Shipping confirmation sheet should open", file: file, line: line)
-    XCTAssertTrue(
-      app.staticTexts.containing(
-        NSPredicate(format: "label CONTAINS %@", expectedCopy)
-      ).firstMatch.waitForExistence(timeout: 5),
-      expectedMessage, file: file, line: line)
-    XCTAssertFalse(
-      app.staticTexts.containing(
-        NSPredicate(format: "label CONTAINS %@", absentCopy)
-      ).firstMatch.waitForExistence(timeout: 2),
-      absentMessage, file: file, line: line)
-  }
-
-  @MainActor
-  func testShippingConfirmationSheetShowsSurchargeAwareCopy() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-
-    let heldPaymentCopy =
-      "Your payment will be held on EVY until shipping has been confirmed (within 48 hours)."
-    let noSurchargeCopy =
-      "Shipping should be confirmed within 48 hours by the seller."
-
-    try await assertShippingConfirmationCopy(
-      emitter: emitter,
-      titlePrefix: "Surcharge shipping item",
-      shippingFee: "5",
-      viewLabelPrefix: "Surcharge shipping",
-      expectedCopy: heldPaymentCopy,
-      expectedMessage: "Surcharge item confirmation should show the held-payment notice",
-      absentCopy: noSurchargeCopy,
-      absentMessage: "Surcharge item confirmation should not show the no-surcharge notice"
-    )
-
-    dismissConfirmationSheet()
-    XCTAssertTrue(
-      waitForConfirmationSheetDismissed(timeout: 5),
-      "Shipping confirmation sheet should dismiss")
-
-    try await assertShippingConfirmationCopy(
-      emitter: emitter,
-      titlePrefix: "Free shipping item",
-      shippingFee: "0",
-      viewLabelPrefix: "Free shipping",
-      expectedCopy: noSurchargeCopy,
-      expectedMessage: "No-surcharge item confirmation should show the 48-hour notice",
-      absentCopy: heldPaymentCopy,
-      absentMessage: "No-surcharge item confirmation should not show the held-payment notice"
-    )
-    await emitter.disconnect()
-  }
-
-  @MainActor
-  func testViewItemPaymentRowsRespectVisiblePredicate() async throws {
-    let viewItemButton = app.buttons["View"]
-    XCTAssertTrue(
-      viewItemButton.waitForExistence(timeout: 20),
-      "Home screen not loaded - verify API is running and database is seeded")
-
-    let emitter = WSEmitter()
-    try await emitter.connect(host: apiHost)
-    try await emitter.login(token: "e2e-test", os: "ios")
-
-    let (selectedItemId, _) = try await createMarketplaceItem(
-      emitter: emitter,
-      titlePrefix: "Payment Item",
-      paymentMethods: ["cash": true, "app": false]
-    )
-
-    let viewButtonLabel = "View payment \(Int(Date().timeIntervalSince1970))"
-    try await emitter.updateSDUI(
-      flowData: createHomeFlowData(
-        buttonLabel: viewButtonLabel,
-        viewItemId: selectedItemId
-      ),
-      flowId: E2EFlowIds.webSocketHomeFlow
-    )
-    try await emitter.updateSDUI(
-      flowData: Self.viewItemFlowData(
-        flowId: E2EFlowIds.webSocketViewFlow,
-        pageId: E2EFlowIds.webSocketViewPage
-      ),
-      flowId: E2EFlowIds.webSocketViewFlow
-    )
-    await emitter.disconnect()
-
-    app.terminate()
-    try launchApp()
-
-    let queryButton = app.buttons[viewButtonLabel]
-    XCTAssertTrue(
-      queryButton.waitForExistence(timeout: 20),
-      "Home view button should load with query-aware label after relaunch")
-
-    queryButton.tap()
-
-    let scrollView = app.scrollViews.firstMatch
-    XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "View item page should appear")
-
-    XCTAssertTrue(
-      app.staticTexts["Cash accepted"].waitForExistence(timeout: 10),
-      "Cash payment row should be visible when \(MARKETPLACE_ITEMS_RESOURCE_ID).payment_methods.cash is true"
-    )
-    XCTAssertFalse(
-      app.staticTexts["App payments accepted"].waitForExistence(timeout: 2),
-      "App payment row should be hidden when \(MARKETPLACE_ITEMS_RESOURCE_ID).payment_methods.app is false"
-    )
-  }
-
   // Synchronous on purpose (async bridged via `awaitResult`): heavy async UI tests hit an
   // Xcode 26 Swift-concurrency runtime crash ("freed pointer was not the last allocation",
   // swiftlang/swift#84793) that aborts the runner mid-test.
@@ -3707,83 +3019,6 @@ final class WebSocketE2ETests: E2ETestBase {
     try awaitResult("emitter disconnect") { await emitter.disconnect() }
   }
 
-  private static func viewItemNavigateAction(viewItemId: String?) -> String {
-    guard let viewItemId else {
-      return "{navigate(\(E2EFlowIds.webSocketViewFlow),\(E2EFlowIds.webSocketViewPage))}"
-    }
-    return
-      "{navigate(\(E2EFlowIds.webSocketViewFlow),\(E2EFlowIds.webSocketViewPage),{\(MARKETPLACE_ITEMS_RESOURCE_ID): [\(viewItemId)]})}"
-  }
-
-  @MainActor
-  private func waitForCancelRequestVisible(timeout: TimeInterval) -> Bool {
-    let labels = ["pickup", "delivery", "shipping"].map { Self.cancelRequestButtonLabel(type: $0) }
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-      if labels.contains(where: { app.buttons[$0].exists }) {
-        return true
-      }
-      RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-    }
-    return labels.contains { app.buttons[$0].exists }
-  }
-
-  @MainActor
-  private func waitForCancelRequestHidden(timeout: TimeInterval) -> Bool {
-    let labels = ["pickup", "delivery", "shipping"].map { Self.cancelRequestButtonLabel(type: $0) }
-    let deadline = Date().addingTimeInterval(timeout)
-    while Date() < deadline {
-      if labels.allSatisfy({ !app.buttons[$0].exists }) {
-        return true
-      }
-      RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-    }
-    return labels.allSatisfy { !app.buttons[$0].exists }
-  }
-
-  private func waitForMessage(
-    emitter: WSEmitter,
-    type: String? = nil,
-    itemId: String,
-    valueKey: String? = nil,
-    value: String? = nil
-  ) async throws -> Bool {
-    try await waitForResourceUpdate(
-      emitter: emitter, resource: EVYCoreResource.messages.ref
-    ) {
-      Self.messagesContain(
-        $0,
-        type: type,
-        itemId: itemId,
-        valueKey: valueKey,
-        value: value
-      )
-    }
-  }
-
-  private static func messagesContain(
-    _ messages: Any,
-    type: String? = nil,
-    itemId: String,
-    valueKey: String? = nil,
-    value: String? = nil
-  ) -> Bool {
-    guard let messageRows = responseDataArray(from: messages) else { return false }
-    return messageRows.contains { message in
-      guard let messageData = message as? [String: Any],
-        messageData["fk"] as? String == itemId,
-        let messageDetails = messageData["data"] as? [String: Any]
-      else {
-        return false
-      }
-      if let type, messageDetails["type"] as? String != type {
-        return false
-      }
-      guard let valueKey, let value else { return true }
-      return messageDetails[valueKey] as? String == value
-    }
-  }
-
   private static func marketplaceItemsContainListing(
     title: String,
     priceValue: Double,
@@ -3895,210 +3130,6 @@ final class WebSocketE2ETests: E2ETestBase {
     return false
   }
 
-  @MainActor
-  private func publishHomeFlow(_ flowData: [String: Any]) async {
-    let emitter = WSEmitter()
-    do {
-      try await emitter.connect(host: apiHost)
-      try await emitter.login(token: "e2e-test", os: "ios")
-      try await emitter.updateSDUI(
-        flowData: flowData, flowId: E2EFlowIds.webSocketHomeFlow)
-    } catch {
-      XCTFail("Failed to publish home flow: \(error.localizedDescription)")
-    }
-    await emitter.disconnect()
-  }
-
-  @MainActor
-  private func typeIntoHomeEphemeralField(_ text: String) async throws {
-    guard let inputContainer = findElement(identifier: "textField_e2e.unrelated_input") else {
-      XCTFail("Home input row should be visible")
-      return
-    }
-    guard let inputField = tapAndGetEditableField(container: inputContainer) else {
-      XCTFail("Failed to get editable home input field")
-      return
-    }
-    clearAndType(field: inputField, text: text, placeholder: "Type here")
-  }
-
-  private func sharedHomeText(_ text: String) -> XCUIElement {
-    app.staticTexts["Live: \(text)"]
-  }
-
-  private func headingHomeText(_ text: String) -> XCUIElement {
-    app.staticTexts["Heading: \(text)"]
-  }
-
-  private func addedHomeText(_ text: String) -> XCUIElement {
-    app.staticTexts["Added: \(text)"]
-  }
-
-  @MainActor
-  func openViewItemPage(
-    emitter: WSEmitter,
-    labelPrefix: String,
-    itemId: String,
-    viewFlowDataBuilder: (String, String) -> [String: Any] = E2ETestBase.viewItemRequestFlowData,
-    viewFlowId: String = E2EFlowIds.webSocketViewFlow,
-    viewPageId: String = E2EFlowIds.webSocketViewPage,
-    buttonExistenceMessage: String = "View button should load after relaunch"
-  ) async throws -> String {
-    let viewLabel = "\(labelPrefix) \(Int(Date().timeIntervalSince1970))"
-    try await emitter.updateSDUI(
-      flowData: createHomeFlowData(buttonLabel: viewLabel, viewItemId: itemId),
-      flowId: E2EFlowIds.webSocketHomeFlow
-    )
-    try await emitter.updateSDUI(
-      flowData: viewFlowDataBuilder(viewFlowId, viewPageId),
-      flowId: viewFlowId
-    )
-    app.terminate()
-    try launchApp()
-    let viewButton = app.buttons[viewLabel]
-    XCTAssertTrue(
-      viewButton.waitForExistence(timeout: 20),
-      buttonExistenceMessage)
-    viewButton.tap()
-    return viewLabel
-  }
-
-  @MainActor
-  func fillShippingPostcodeAndAskToBuy(postcode: String = "2018") throws {
-    let postcodeContainer = try XCTUnwrap(
-      findElement(identifier: "textField_{shipping_address.postcode}"),
-      "Shipping postcode input should be visible"
-    )
-    let editablePostcodeField = tapAndGetEditableField(container: postcodeContainer)
-    let postcodeField = try XCTUnwrap(editablePostcodeField)
-    clearAndType(field: postcodeField, text: postcode, placeholder: "Postcode")
-    dismissKeyboard()
-    app.buttons["Ask to buy"].tap()
-  }
-
-  private func createHomeFlowData(
-    buttonLabel: String,
-    viewItemId: String? = nil,
-    includeAddedSharedRow: Bool = false,
-    includeHeadingRow: Bool = false,
-    includeHomeInbox: Bool = false
-  ) -> [String: Any] {
-    let viewAction = Self.viewItemNavigateAction(viewItemId: viewItemId)
-
-    var children: [[String: Any]] = []
-    if includeHeadingRow {
-      children.append(
-        Self.headingRow(
-          id: "b1c2d3e4-f5a6-4789-8012-3456789abcde",
-          title: "Heading: {e2e.unrelated_input}"
-        )
-      )
-    }
-    children.append(contentsOf: [
-      Self.inputRow(
-        id: "c72107b6-a50f-4bdb-98d8-4f803e2e8e1b",
-        title: "Notes",
-        source: nil,
-        placeholder: "Type here",
-        destination: "e2e.unrelated_input"
-      ),
-      Self.textRow(
-        id: "5af45c82-6b8a-4f33-9864-1c5f9eb47ed1",
-        title: "Live: {e2e.unrelated_input}"
-      ),
-    ])
-    if includeAddedSharedRow {
-      children.append(
-        Self.textRow(
-          id: "9c1e7f4a-3b2d-4e6a-8f1c-2d3e4f5a6b7c",
-          title: "Added: {e2e.unrelated_input}"
-        )
-      )
-    }
-    children.append(contentsOf: [
-      Self.buttonRow(
-        id: "53d04050-29f3-48ec-b55b-1a6a30fc2111",
-        label: "Details",
-        action:
-          "{navigate(\(E2EFlowIds.webSocketHomeFlow),\(E2EFlowIds.webSocketHomeDetailsPage))}"
-      ),
-      Self.buttonRow(
-        id: "441c1433-446b-4682-854d-5d795ef52709",
-        label: buttonLabel,
-        action: viewAction
-      ),
-      Self.buttonRow(
-        id: "c1ad8812-a824-4ca2-bb27-5bc840ae7e08",
-        label: "Create",
-        action:
-          "{navigate(\(E2EFlowIds.webSocketCreateFlow),\(E2EFlowIds.webSocketCreatePage))}"
-      ),
-    ])
-
-    var homeRows: [[String: Any]] = [
-      [
-        "id": "a74bc80e-ffda-4e19-b8f3-cd882405958b",
-        "type": "vertical_container",
-        "actions": [:],
-        "visible": "true",
-        "title": "",
-        "children": children,
-      ]
-    ]
-    if includeHomeInbox {
-      homeRows.insert(Self.homeInboxTabRow(), at: 0)
-    }
-
-    return [
-      "id": E2EFlowIds.webSocketHomeFlow,
-      "name": "Home",
-      "pages": [
-        [
-          "id": E2EFlowIds.webSocketHomePage,
-          "title": "Home",
-          "rows": homeRows,
-        ],
-        [
-          "id": E2EFlowIds.webSocketHomeDetailsPage,
-          "title": "Details",
-          "rows": [
-            Self.textRow(
-              id: "36dc56d0-706b-4d5a-bc2a-6dc6956c9277",
-              title: "Details page"
-            )
-          ],
-        ],
-      ],
-    ]
-  }
-
-  private func createConditionalFlowData(buttonLabel: String) -> [String: Any] {
-    var flowData = createHomeFlowData(buttonLabel: buttonLabel)
-    guard var pages = flowData["pages"] as? [[String: Any]],
-      var homePage = pages.first,
-      var rows = homePage["rows"] as? [[String: Any]],
-      var firstRow = rows.first,
-      var children = firstRow["children"] as? [[String: Any]],
-      let buttonIndex = children.firstIndex(where: { ($0["label"] as? String) == buttonLabel }),
-      let actionsObject = children[buttonIndex]["actions"] as? [String: Any],
-      var actions = actionsObject["tap"] as? [[String: Any]],
-      var firstAction = actions.first
-    else {
-      return flowData
-    }
-
-    var button = children[buttonIndex]
-    firstAction["condition"] = "{1 > 0 || (0 > 1 && 2 > 3)}"
-    actions[0] = firstAction
-    button["actions"] = ["tap": actions]
-    children[buttonIndex] = button
-    firstRow["children"] = children
-    rows[0] = firstRow
-    homePage["rows"] = rows
-    pages[0] = homePage
-    flowData["pages"] = pages
-    return flowData
-  }
 }
 
 // MARK: - Swipe-left trigger

--- a/ios/e2e/e2eRequests.swift
+++ b/ios/e2e/e2eRequests.swift
@@ -1,0 +1,954 @@
+//
+//  e2eRequests.swift
+//  evyUITests
+//
+
+import XCTest
+
+// MARK: - Marketplace request flows (WebSocket)
+
+final class WebSocketRequestE2ETests: E2ETestBase {
+  override var homeFlowId: String? { E2EFlowIds.webSocketHomeFlow }
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    try seedIsolatedFlows()
+    try launchApp()
+  }
+
+  override func tearDownWithError() throws {
+    try? seedIsolatedFlows()
+    try super.tearDownWithError()
+  }
+
+  @MainActor
+  func testTimeslotPickerCreatesPickupRequest() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let selectedTimeslot = "2026-06-03T09:00:00"
+    let (selectedItemId, selectedItemTitle) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Pickup request item",
+      pickupSelection: [selectedTimeslot]
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Request pickup",
+      itemId: selectedItemId,
+      buttonExistenceMessage: "Request view button should load"
+    )
+    try await emitter.subscribe(event: "data_changed")
+
+    let timeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
+    timeslot.tap()
+
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should appear after selecting a timeslot")
+    XCTAssertTrue(
+      app.staticTexts.containing(
+        NSPredicate(format: "label CONTAINS %@", selectedItemTitle)
+      ).firstMatch.waitForExistence(timeout: 5),
+      "Confirmation sheet should mention the item title")
+
+    tapConfirmationSheetRequestButton()
+    XCTAssertFalse(
+      app.alerts.firstMatch.waitForExistence(timeout: 2),
+      "Pickup request should not show a native confirmation alert")
+
+    let pickupRequestCreated = try await waitForMessage(
+      emitter: emitter,
+      type: "pickup",
+      itemId: selectedItemId,
+      valueKey: "time",
+      value: selectedTimeslot
+    )
+    XCTAssertTrue(
+      pickupRequestCreated,
+      "Tapping a pickup timeslot should create a matching marketplace message"
+    )
+    await emitter.disconnect()
+  }
+
+  @MainActor
+  func testTimeslotConfirmationCancelDoesNotCreateRequest() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let selectedTimeslot = "2026-06-03T09:00:00"
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Cancel pickup item",
+      pickupSelection: [selectedTimeslot]
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Cancel pickup",
+      itemId: selectedItemId,
+      buttonExistenceMessage: "Request view button should load"
+    )
+
+    let timeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
+    timeslot.tap()
+
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should appear after selecting a timeslot")
+    dismissConfirmationSheet()
+
+    let messagesAfterCancel = try await emitter.getResource(
+      resource: EVYCoreResource.messages.ref
+    )
+    XCTAssertFalse(
+      Self.messagesContain(
+        messagesAfterCancel,
+        type: "pickup",
+        itemId: selectedItemId
+      ),
+      "Cancelling confirmation should not create a pickup request"
+    )
+    XCTAssertTrue(timeslot.exists, "Pickup timeslot should remain visible after cancel")
+    XCTAssertFalse(
+      app.buttons["Cancel pickup request"].exists,
+      "Cancel pickup request should not appear when no request was created"
+    )
+    await emitter.disconnect()
+  }
+
+  @MainActor
+  func testPickupConfirmationSheetShowsEarlierTimeslotWarning() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Later pickup item",
+      pickupSelection: ["2026-06-03T09:00:00", "2026-06-03T10:00:00"]
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Later pickup",
+      itemId: selectedItemId,
+      buttonExistenceMessage: "Request view button should load"
+    )
+
+    let laterTimeslot = app.staticTexts["10:00"].firstMatch
+    XCTAssertTrue(
+      laterTimeslot.waitForExistence(timeout: 10), "Later pickup timeslot should be visible")
+    laterTimeslot.tap()
+
+    let earlierTimeslotWarning = app.staticTexts.containing(
+      NSPredicate(format: "label CONTAINS %@", "earlier than your selected timeslot")
+    ).firstMatch
+    XCTAssertTrue(
+      earlierTimeslotWarning.waitForExistence(timeout: 5),
+      "Later timeslot confirmation should show the earlier-timeslot warning")
+
+    dismissConfirmationSheet()
+    XCTAssertTrue(
+      waitForConfirmationSheetDismissed(timeout: 5),
+      "Confirmation sheet should dismiss")
+
+    let earlierTimeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(
+      earlierTimeslot.waitForExistence(timeout: 10), "Earlier pickup timeslot should be visible")
+    earlierTimeslot.tap()
+
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Confirmation sheet should reopen for the earlier timeslot")
+    XCTAssertFalse(
+      earlierTimeslotWarning.waitForExistence(timeout: 2),
+      "Earliest timeslot confirmation should not show the earlier-timeslot warning")
+    await emitter.disconnect()
+  }
+
+  @MainActor
+  func testCancelRequestTogglesPickerAndShippingButton() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let selectedTimeslot = "2026-06-03T09:00:00"
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Cancel request item",
+      pickupSelection: [selectedTimeslot]
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Cancel request",
+      itemId: selectedItemId,
+      viewFlowDataBuilder: Self.viewItemCancelRequestFlowData,
+      buttonExistenceMessage: "Request view button should load"
+    )
+    try await emitter.subscribe(event: "data_changed")
+
+    let timeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
+    XCTAssertFalse(
+      app.buttons["Cancel pickup request"].exists,
+      "Cancel pickup request should be hidden before a request exists")
+
+    timeslot.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should appear after selecting a timeslot")
+    tapConfirmationSheetRequestButton()
+
+    let pickupRequestCreated = try await waitForMessage(
+      emitter: emitter,
+      type: "pickup",
+      itemId: selectedItemId,
+      valueKey: "time",
+      value: selectedTimeslot
+    )
+    XCTAssertTrue(pickupRequestCreated, "Tapping a pickup timeslot should create a message")
+
+    let cancelButton = app.buttons["Cancel pickup request"].firstMatch
+    XCTAssertTrue(
+      cancelButton.waitForExistence(timeout: 10),
+      "Cancel pickup request should replace the transfer tabs and pickup timeslot")
+    XCTAssertFalse(timeslot.exists, "Pickup timeslot should be hidden after creating a request")
+    XCTAssertFalse(
+      app.segmentedControls.buttons["Shipping"].waitForExistence(timeout: 2),
+      "Transfer tabs collapse while an arrangement is in flight, leaving just that request")
+
+    cancelButton.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Cancel pickup confirmation sheet should appear")
+    // The row button and the sheet's confirm button share the "Cancel request" label; tap the
+    // hittable one (the confirm button on top of the sheet) so the write actually fires.
+    let confirmCancelButton = try XCTUnwrap(
+      waitForHittableButton(labeled: "Cancel request"),
+      "Confirm cancel button should be tappable in the sheet")
+    confirmCancelButton.tap()
+
+    let requestWithdrawn = try await waitForMessage(
+      emitter: emitter,
+      itemId: selectedItemId,
+      valueKey: "value",
+      value: "cancel"
+    )
+    XCTAssertTrue(
+      requestWithdrawn, "Cancel request should append a cancel message, not rewrite the request")
+    XCTAssertTrue(
+      timeslot.waitForExistence(timeout: 10),
+      "Pickup timeslot should return after cancelling the request")
+
+    timeslot.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should reopen after cancelling the request")
+    tapConfirmationSheetRequestButton()
+    XCTAssertTrue(
+      app.buttons["Cancel pickup request"].firstMatch.waitForExistence(timeout: 10),
+      "Cancel pickup request should reappear after creating another request")
+    await emitter.disconnect()
+  }
+
+  /// The case the latest-message model exists for: a rejection is terminal but leaves nothing
+  /// in flight, so the buyer is back to picking a timeslot and can ask again. The old
+  /// predicates could not express this - the request was still there, unanswered as far as any
+  /// flat lookup could tell.
+  @MainActor
+  func testRejectedRequestReturnsTheTimeslots() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let selectedTimeslot = "2026-06-03T09:00:00"
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Rejected request item",
+      pickupSelection: [selectedTimeslot]
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Rejected request",
+      itemId: selectedItemId,
+      viewFlowDataBuilder: Self.viewItemCancelRequestFlowData,
+      buttonExistenceMessage: "Request view button should load"
+    )
+    try await emitter.subscribe(event: "data_changed")
+
+    let timeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
+    timeslot.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should appear after selecting a timeslot")
+    tapConfirmationSheetRequestButton()
+
+    XCTAssertTrue(
+      waitForCancelRequestVisible(timeout: 10),
+      "Cancel pickup request should be visible while the request is open")
+
+    let requestId = try await waitForMessageId(
+      emitter: emitter,
+      itemId: selectedItemId,
+      type: "pickup",
+      value: "pending",
+      failureMessage: "An open pickup request should exist for the item"
+    )
+
+    // The owner rejects. Like every other settling message it names the request and carries
+    // its payload forward.
+    _ = try await emitter.createResource(
+      resource: EVYCoreResource.messages.ref,
+      data: [
+        "fk": selectedItemId,
+        "resource": MARKETPLACE_ITEMS_RESOURCE_ID,
+        "visibility": "private",
+        "parent_message_id": requestId,
+        "data": Self.settlingMessageData(
+          value: "reject",
+          type: "pickup",
+          time: selectedTimeslot
+        ),
+      ]
+    )
+    let rejectedOnServer = try await waitForMessageResponse(
+      emitter: emitter,
+      messageId: requestId,
+      value: "reject"
+    )
+    XCTAssertTrue(rejectedOnServer, "The API should hold the message rejecting the request")
+
+    XCTAssertTrue(
+      waitForCancelRequestHidden(timeout: 10),
+      "Cancel pickup request should go once the request has been answered")
+    XCTAssertTrue(
+      timeslot.waitForExistence(timeout: 10),
+      "Pickup timeslots should return after a rejection")
+    XCTAssertFalse(
+      app.staticTexts.matching(
+        NSPredicate(format: "label BEGINSWITH %@", "Pickup confirmed for")
+      ).firstMatch.exists,
+      "A rejection is not a confirmation")
+
+    // And the buyer can ask again, which is the whole point.
+    timeslot.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should reopen after a rejection")
+    tapConfirmationSheetRequestButton()
+    XCTAssertTrue(
+      waitForCancelRequestVisible(timeout: 10),
+      "A fresh request after a rejection is open again")
+
+    await emitter.disconnect()
+  }
+
+  /// The id of a message for an item, as the server holds it.
+  @MainActor
+  private func waitForMessageId(
+    emitter: WSEmitter,
+    itemId: String,
+    type: String = "pickup",
+    value: String? = "pending",
+    failureMessage: String,
+    timeout: TimeInterval = 10
+  ) async throws -> String {
+    let deadline = Date().addingTimeInterval(timeout)
+    repeat {
+      let payload = try await emitter.getResource(
+        resource: EVYCoreResource.messages.ref
+      )
+      if let rows = Self.responseDataArray(from: payload),
+        let match = rows.compactMap({ $0 as? [String: Any] }).first(where: { row in
+          let data = row["data"] as? [String: Any]
+          guard row["fk"] as? String == itemId,
+            data?["type"] as? String == type
+          else { return false }
+          if let value {
+            return data?["value"] as? String == value
+          }
+          return true
+        }),
+        let id = match["id"] as? String
+      {
+        return id
+      }
+    } while try await emitter.nextDataChanged(
+      resource: EVYCoreResource.messages.ref, deadline: deadline)
+    XCTFail(failureMessage)
+    return ""
+  }
+
+  @MainActor
+  func testAcceptedRequestHidesCancelAndShowsConfirmation() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let selectedTimeslot = "2026-06-03T09:00:00"
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Accepted request item",
+      pickupSelection: [selectedTimeslot]
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Accepted request",
+      itemId: selectedItemId,
+      viewFlowDataBuilder: Self.viewItemCancelRequestFlowData,
+      buttonExistenceMessage: "Request view button should load"
+    )
+    try await emitter.subscribe(event: "data_changed")
+
+    let timeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(timeslot.waitForExistence(timeout: 10), "Pickup timeslot should be visible")
+    timeslot.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should appear after selecting a timeslot")
+    tapConfirmationSheetRequestButton()
+
+    let pickupRequestCreated = try await waitForMessage(
+      emitter: emitter,
+      type: "pickup",
+      itemId: selectedItemId,
+      valueKey: "time",
+      value: selectedTimeslot
+    )
+    XCTAssertTrue(pickupRequestCreated, "Tapping a pickup timeslot should create a message")
+    XCTAssertTrue(
+      waitForCancelRequestVisible(timeout: 10),
+      "Cancel pickup request should be visible for a pending request")
+
+    let messagesPayload = try await emitter.getResource(
+      resource: EVYCoreResource.messages.ref
+    )
+    let messageRows = try XCTUnwrap(
+      Self.responseDataArray(from: messagesPayload),
+      "Messages payload should be an array"
+    )
+    let request = try XCTUnwrap(
+      messageRows.compactMap { $0 as? [String: Any] }.first {
+        $0["id"] as? String != nil
+          && ($0["data"] as? [String: Any])?["type"] as? String == "pickup"
+          && $0["fk"] as? String == selectedItemId
+      },
+      "Created pickup message should be readable from the API"
+    )
+    let messageId = try XCTUnwrap(
+      request["id"] as? String,
+      "Created pickup message should include an id"
+    )
+
+    // Accepting is a new message naming the request, not an edit to it - and it carries
+    // the request's payload forward. `findFirst` predicates cannot nest, so the row that
+    // says "Pickup confirmed for …" reads the time off the message that says "accepted".
+    _ = try await emitter.createResource(
+      resource: EVYCoreResource.messages.ref,
+      data: [
+        "fk": selectedItemId,
+        "resource": MARKETPLACE_ITEMS_RESOURCE_ID,
+        "visibility": "private",
+        "parent_message_id": messageId,
+        "data": Self.settlingMessageData(
+          value: "accept",
+          type: "pickup",
+          time: selectedTimeslot,
+          pickupAddress: Self.amazingFridgePickupAddressRow
+        ),
+      ]
+    )
+    let acceptedOnServer = try await waitForMessageResponse(
+      emitter: emitter,
+      messageId: messageId,
+      value: "accept"
+    )
+    XCTAssertTrue(
+      acceptedOnServer,
+      "The API should persist the message that accepts the pickup request")
+
+    XCTAssertTrue(
+      waitForCancelRequestHidden(timeout: 10),
+      "Cancel pickup request should hide once the request is answered")
+    XCTAssertTrue(
+      app.staticTexts.matching(
+        NSPredicate(format: "label BEGINSWITH %@", "Pickup confirmed for")
+      ).firstMatch.waitForExistence(timeout: 10),
+      "Pickup segment should show the accepted confirmation row")
+    // The postcode map gives way to the seller's full address, which only exists on the accept.
+    XCTAssertTrue(
+      app.staticTexts["C509 28 Rothschild Avenue, 2018 Rosebery NSW"].waitForExistence(
+        timeout: 10),
+      "Accepted pickup should show the full address carried by the accept message")
+    XCTAssertFalse(
+      app.segmentedControls.buttons["Shipping"].waitForExistence(timeout: 2),
+      "Transfer tabs stay collapsed once an arrangement is agreed")
+    let shippingConfirmation = app.staticTexts.matching(
+      NSPredicate(format: "label BEGINSWITH %@", "Shipping confirmed")
+    ).firstMatch
+    XCTAssertFalse(
+      shippingConfirmation.waitForExistence(timeout: 2),
+      "Shipping confirmation should stay hidden for an accepted pickup request")
+
+    await emitter.disconnect()
+  }
+
+  @MainActor
+  func testSenderIsOfferedCancelAndCannotAnswerItsOwnRequest() throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    let host = apiHost
+    let selectedTimeslot = "2026-06-03T09:00:00"
+    let (itemId, _) = try awaitResult("create sender cancel item") {
+      try await emitter.connect(host: host)
+      try await emitter.login(token: "e2e-test", os: "ios")
+      return try await self.createMarketplaceItem(
+        emitter: emitter,
+        titlePrefix: "Sender cancel item",
+        pickupSelection: [selectedTimeslot]
+      )
+    }
+
+    let viewLabel = "Sender cancel \(Int(Date().timeIntervalSince1970))"
+    let homeFlowData = createHomeFlowData(
+      buttonLabel: viewLabel,
+      viewItemId: itemId,
+      includeHomeInbox: true
+    )
+    let senderFlowData = E2ETestBase.senderViewFlowData(
+      flowId: E2EFlowIds.webSocketViewFlow,
+      pageId: E2EFlowIds.webSocketViewPage
+    )
+    try awaitResult("seed sender inbox flow") {
+      try await emitter.updateSDUI(
+        flowData: homeFlowData,
+        flowId: E2EFlowIds.webSocketHomeFlow
+      )
+      try await emitter.updateSDUI(
+        flowData: senderFlowData,
+        flowId: E2EFlowIds.webSocketViewFlow
+      )
+      try await emitter.subscribe(event: "data_changed")
+    }
+
+    app.terminate()
+    try launchApp()
+    let viewButton = app.buttons[viewLabel]
+    XCTAssertTrue(
+      viewButton.waitForExistence(timeout: 20),
+      "Sender request view button should load")
+    XCTAssertTrue(
+      scrollUntilHittable(viewButton),
+      "Sender request view button should be reachable")
+    viewButton.tap()
+
+    let timeslot = app.staticTexts["09:00"].firstMatch
+    XCTAssertTrue(timeslot.waitForExistence(timeout: 15), "Pickup timeslot should be visible")
+    timeslot.tap()
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Pickup confirmation sheet should appear after selecting a timeslot")
+    tapConfirmationSheetRequestButton()
+
+    let requestId = try awaitResult("wait for sender request") {
+      try await self.waitForMessageId(
+        emitter: emitter,
+        itemId: itemId,
+        type: "pickup",
+        value: nil,
+        failureMessage: "Tapping a pickup timeslot should have created a request"
+      )
+    }
+    let backButton = app.navigationBars.buttons.firstMatch
+    XCTAssertTrue(
+      backButton.waitForExistence(timeout: 5), "The request page should have a back button")
+    backButton.tap()
+
+    let fromYouTab = app.segmentedControls.buttons["From you"]
+    XCTAssertTrue(
+      fromYouTab.waitForExistence(timeout: 10),
+      "The inbox should include a From you tab")
+    XCTAssertTrue(
+      scrollUntilHittable(fromYouTab),
+      "The From you tab should be reachable below the request picker")
+    fromYouTab.tap()
+
+    let childRowId = E2ETestBase.homeInboxFromYouChildRowId
+    let row = app.otherElements["swipeRow_\(childRowId)_\(requestId)"]
+    XCTAssertTrue(
+      row.waitForExistence(timeout: 10),
+      "The request created by this device should appear under From you")
+    XCTAssertTrue(
+      scrollUntilHittable(row),
+      "The request row should be reachable after scrolling")
+    row.swipeLeft(velocity: .slow)
+
+    let swipeButtonId = "swipeLeft_\(childRowId)_\(requestId)"
+    let swipeButton = app.buttons[swipeButtonId]
+    XCTAssertTrue(
+      swipeButton.waitForExistence(timeout: 3),
+      "The sender should be offered cancel")
+    XCTAssertEqual(swipeButton.label, "Cancel")
+    XCTAssertEqual(
+      app.buttons.matching(identifier: swipeButtonId).count,
+      1,
+      "The From you row should reveal exactly one declarative action")
+
+    XCTAssertTrue(
+      swipeButton.isHittable,
+      "The revealed Cancel action should accept taps"
+    )
+    swipeButton.tap()
+    XCTAssertTrue(
+      row.waitForNonExistence(timeout: 5),
+      "Cancel should optimistically remove the request from From you"
+    )
+
+    let cancelled = try awaitResult("wait for cancel response") {
+      try await self.waitForMessageResponse(
+        emitter: emitter,
+        messageId: requestId,
+        value: "cancel"
+      )
+    }
+    XCTAssertTrue(cancelled, "Cancel should persist a response naming the request")
+    try awaitResult("disconnect sender emitter") { await emitter.disconnect() }
+  }
+
+  @MainActor
+  func testAskToBuyCreatesShippingRequestAndValidatesEmptyPostcode() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Shipping request item",
+      pickupSelection: ["2026-06-03T09:00:00"],
+      shippingFee: "0"
+    )
+
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: "Request shipping",
+      itemId: selectedItemId,
+      buttonExistenceMessage: "Request view button should load"
+    )
+    try await emitter.subscribe(event: "data_changed")
+
+    let askToBuyButton = app.buttons["Ask to buy"]
+    XCTAssertTrue(
+      askToBuyButton.waitForExistence(timeout: 10), "Ask to buy button should be visible")
+    askToBuyButton.tap()
+
+    let missingInformationAlert = app.alerts["Missing information"]
+    XCTAssertTrue(
+      missingInformationAlert.waitForExistence(timeout: 5),
+      "An empty shipping postcode should show the missing-information alert"
+    )
+    let messagesAfterEmptyPostcode = try await emitter.getResource(
+      resource: EVYCoreResource.messages.ref
+    )
+    XCTAssertFalse(
+      Self.messagesContain(
+        messagesAfterEmptyPostcode,
+        type: "shipping",
+        itemId: selectedItemId
+      ),
+      "An empty postcode must not create a shipping request"
+    )
+    let dismissAlertButton = missingInformationAlert.buttons.firstMatch
+    XCTAssertTrue(dismissAlertButton.exists, "Missing-information alert should be dismissible")
+    dismissAlertButton.tap()
+
+    try fillShippingPostcodeAndAskToBuy()
+
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Shipping confirmation sheet should appear after Ask to buy with a postcode")
+    tapConfirmationSheetRequestButton()
+
+    let shippingRequestCreated = try await waitForMessage(
+      emitter: emitter,
+      type: "shipping",
+      itemId: selectedItemId,
+      valueKey: "postalcode",
+      value: "2018"
+    )
+    XCTAssertTrue(
+      shippingRequestCreated,
+      "Ask to buy should create a shipping request with the entered postcode"
+    )
+    await emitter.disconnect()
+  }
+
+  /// Requests shipping for a freshly created item and asserts which surcharge-aware copy
+  /// appears in the confirmation sheet.
+  @MainActor
+  private func assertShippingConfirmationCopy(
+    emitter: WSEmitter,
+    titlePrefix: String,
+    shippingFee: String,
+    viewLabelPrefix: String,
+    expectedCopy: String,
+    expectedMessage: String,
+    absentCopy: String,
+    absentMessage: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    let (itemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: titlePrefix,
+      pickupSelection: ["2026-06-03T09:00:00"],
+      shippingFee: shippingFee
+    )
+    _ = try await openViewItemPage(
+      emitter: emitter,
+      labelPrefix: viewLabelPrefix,
+      itemId: itemId
+    )
+
+    try fillShippingPostcodeAndAskToBuy()
+
+    XCTAssertTrue(
+      waitForConfirmationSheet(timeout: 5),
+      "Shipping confirmation sheet should open", file: file, line: line)
+    XCTAssertTrue(
+      app.staticTexts.containing(
+        NSPredicate(format: "label CONTAINS %@", expectedCopy)
+      ).firstMatch.waitForExistence(timeout: 5),
+      expectedMessage, file: file, line: line)
+    XCTAssertFalse(
+      app.staticTexts.containing(
+        NSPredicate(format: "label CONTAINS %@", absentCopy)
+      ).firstMatch.waitForExistence(timeout: 2),
+      absentMessage, file: file, line: line)
+  }
+
+  @MainActor
+  func testShippingConfirmationSheetShowsSurchargeAwareCopy() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+
+    let heldPaymentCopy =
+      "Your payment will be held on EVY until shipping has been confirmed (within 48 hours)."
+    let noSurchargeCopy =
+      "Shipping should be confirmed within 48 hours by the seller."
+
+    try await assertShippingConfirmationCopy(
+      emitter: emitter,
+      titlePrefix: "Surcharge shipping item",
+      shippingFee: "5",
+      viewLabelPrefix: "Surcharge shipping",
+      expectedCopy: heldPaymentCopy,
+      expectedMessage: "Surcharge item confirmation should show the held-payment notice",
+      absentCopy: noSurchargeCopy,
+      absentMessage: "Surcharge item confirmation should not show the no-surcharge notice"
+    )
+
+    dismissConfirmationSheet()
+    XCTAssertTrue(
+      waitForConfirmationSheetDismissed(timeout: 5),
+      "Shipping confirmation sheet should dismiss")
+
+    try await assertShippingConfirmationCopy(
+      emitter: emitter,
+      titlePrefix: "Free shipping item",
+      shippingFee: "0",
+      viewLabelPrefix: "Free shipping",
+      expectedCopy: noSurchargeCopy,
+      expectedMessage: "No-surcharge item confirmation should show the 48-hour notice",
+      absentCopy: heldPaymentCopy,
+      absentMessage: "No-surcharge item confirmation should not show the held-payment notice"
+    )
+    await emitter.disconnect()
+  }
+
+  @MainActor
+  func testViewItemPaymentRowsRespectVisiblePredicate() async throws {
+    let viewItemButton = app.buttons["View"]
+    XCTAssertTrue(
+      viewItemButton.waitForExistence(timeout: 20),
+      "Home screen not loaded - verify API is running and database is seeded")
+
+    let emitter = WSEmitter()
+    try await emitter.connect(host: apiHost)
+    try await emitter.login(token: "e2e-test", os: "ios")
+
+    let (selectedItemId, _) = try await createMarketplaceItem(
+      emitter: emitter,
+      titlePrefix: "Payment Item",
+      paymentMethods: ["cash": true, "app": false]
+    )
+
+    let viewButtonLabel = "View payment \(Int(Date().timeIntervalSince1970))"
+    try await emitter.updateSDUI(
+      flowData: createHomeFlowData(
+        buttonLabel: viewButtonLabel,
+        viewItemId: selectedItemId
+      ),
+      flowId: E2EFlowIds.webSocketHomeFlow
+    )
+    try await emitter.updateSDUI(
+      flowData: Self.viewItemFlowData(
+        flowId: E2EFlowIds.webSocketViewFlow,
+        pageId: E2EFlowIds.webSocketViewPage
+      ),
+      flowId: E2EFlowIds.webSocketViewFlow
+    )
+    await emitter.disconnect()
+
+    app.terminate()
+    try launchApp()
+
+    let queryButton = app.buttons[viewButtonLabel]
+    XCTAssertTrue(
+      queryButton.waitForExistence(timeout: 20),
+      "Home view button should load with query-aware label after relaunch")
+
+    queryButton.tap()
+
+    let scrollView = app.scrollViews.firstMatch
+    XCTAssertTrue(scrollView.waitForExistence(timeout: 10), "View item page should appear")
+
+    XCTAssertTrue(
+      app.staticTexts["Cash accepted"].waitForExistence(timeout: 10),
+      "Cash payment row should be visible when \(MARKETPLACE_ITEMS_RESOURCE_ID).payment_methods.cash is true"
+    )
+    XCTAssertFalse(
+      app.staticTexts["App payments accepted"].waitForExistence(timeout: 2),
+      "App payment row should be hidden when \(MARKETPLACE_ITEMS_RESOURCE_ID).payment_methods.app is false"
+    )
+  }
+
+  @MainActor
+  private func waitForCancelRequestVisible(timeout: TimeInterval) -> Bool {
+    let labels = ["pickup", "delivery", "shipping"].map { Self.cancelRequestButtonLabel(type: $0) }
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if labels.contains(where: { app.buttons[$0].exists }) {
+        return true
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+    }
+    return labels.contains { app.buttons[$0].exists }
+  }
+
+  @MainActor
+  private func waitForCancelRequestHidden(timeout: TimeInterval) -> Bool {
+    let labels = ["pickup", "delivery", "shipping"].map { Self.cancelRequestButtonLabel(type: $0) }
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if labels.allSatisfy({ !app.buttons[$0].exists }) {
+        return true
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+    }
+    return labels.allSatisfy { !app.buttons[$0].exists }
+  }
+
+  private func waitForMessage(
+    emitter: WSEmitter,
+    type: String? = nil,
+    itemId: String,
+    valueKey: String? = nil,
+    value: String? = nil
+  ) async throws -> Bool {
+    try await waitForResourceUpdate(
+      emitter: emitter, resource: EVYCoreResource.messages.ref
+    ) {
+      Self.messagesContain(
+        $0,
+        type: type,
+        itemId: itemId,
+        valueKey: valueKey,
+        value: value
+      )
+    }
+  }
+
+  private static func messagesContain(
+    _ messages: Any,
+    type: String? = nil,
+    itemId: String,
+    valueKey: String? = nil,
+    value: String? = nil
+  ) -> Bool {
+    guard let messageRows = responseDataArray(from: messages) else { return false }
+    return messageRows.contains { message in
+      guard let messageData = message as? [String: Any],
+        messageData["fk"] as? String == itemId,
+        let messageDetails = messageData["data"] as? [String: Any]
+      else {
+        return false
+      }
+      if let type, messageDetails["type"] as? String != type {
+        return false
+      }
+      guard let valueKey, let value else { return true }
+      return messageDetails[valueKey] as? String == value
+    }
+  }
+  @MainActor
+  func fillShippingPostcodeAndAskToBuy(postcode: String = "2018") throws {
+    let postcodeContainer = try XCTUnwrap(
+      findElement(identifier: "textField_{shipping_address.postcode}"),
+      "Shipping postcode input should be visible"
+    )
+    let editablePostcodeField = tapAndGetEditableField(container: postcodeContainer)
+    let postcodeField = try XCTUnwrap(editablePostcodeField)
+    clearAndType(field: postcodeField, text: postcode, placeholder: "Postcode")
+    dismissKeyboard()
+    app.buttons["Ask to buy"].tap()
+  }
+
+}

--- a/ios/evy.xcodeproj/project.pbxproj
+++ b/ios/evy.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		73F7A0012F70B00700000001 /* CoreResources.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7A0112F70B00700000001 /* CoreResources.generated.swift */; };
 		73F7A0032F70B00700000003 /* CoreResources.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7A0112F70B00700000001 /* CoreResources.generated.swift */; };
 		73F7E2012F70020100000001 /* MarketplaceE2EFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7E1022F70010100000001 /* MarketplaceE2EFixture.swift */; };
+		73F7E2052F70020100000003 /* e2eRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7E1032F70010100000003 /* e2eRequests.swift */; };
 		73F7E2032F70020100000001 /* MarketplaceTestFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7E1042F70010100000001 /* MarketplaceTestFixture.swift */; };
 		73F7E0022F70000100000001 /* EVYError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7E0012F70000100000001 /* EVYError.swift */; };
 		73F7E1012F70010100000001 /* EVYDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F7E1002F70010100000001 /* EVYDataStore.swift */; };
@@ -288,6 +289,7 @@
 		73F5D2002F50000200000001 /* forEachRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = forEachRow.swift; sourceTree = "<group>"; };
 		73F7A0112F70B00700000001 /* CoreResources.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreResources.generated.swift; sourceTree = "<group>"; };
 		73F7E1022F70010100000001 /* MarketplaceE2EFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceE2EFixture.swift; sourceTree = "<group>"; };
+		73F7E1032F70010100000003 /* e2eRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = e2eRequests.swift; sourceTree = "<group>"; };
 		73F7E1042F70010100000001 /* MarketplaceTestFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketplaceTestFixture.swift; sourceTree = "<group>"; };
 		73F7E0012F70000100000001 /* EVYError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYError.swift; sourceTree = "<group>"; };
 		73F7E1002F70010100000001 /* EVYDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EVYDataStore.swift; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 			isa = PBXGroup;
 			children = (
 				73F1A0002F30B00100000001 /* e2e.swift */,
+				73F7E1032F70010100000003 /* e2eRequests.swift */,
 				73F7E1022F70010100000001 /* MarketplaceE2EFixture.swift */,
 			);
 			path = e2e;
@@ -933,6 +936,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73F1A0012F30B00100000001 /* e2e.swift in Sources */,
+				73F7E2052F70020100000003 /* e2eRequests.swift in Sources */,
 				73F7E2012F70020100000001 /* MarketplaceE2EFixture.swift in Sources */,
 				73F7A0032F70B00700000003 /* CoreResources.generated.swift in Sources */,
 			);

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -11,10 +11,11 @@ cd "$REPO_ROOT"
 
 # Parse arguments
 SKIP_IOS=false
+SKIP_IOS_REQUESTED=false
 CI_MODE=false
 for arg in "$@"; do
     case $arg in
-        --skip-ios) SKIP_IOS=true ;;
+        --skip-ios) SKIP_IOS=true; SKIP_IOS_REQUESTED=true ;;
         --ci) CI_MODE=true ;;
         *)
             echo -e "${RED}Unknown argument: $arg${NC}"
@@ -91,6 +92,9 @@ case "${API_URL}" in
 		;;
 esac
 
+# shellcheck source=scripts/run-ios-e2e.sh
+source "$REPO_ROOT/scripts/run-ios-e2e.sh"
+
 echo -e "${YELLOW}========================================${NC}"
 echo -e "${YELLOW}EVY End-to-End Test Runner${NC}"
 echo -e "${YELLOW}========================================${NC}"
@@ -114,11 +118,7 @@ retry_until_cmd() {
 
 cleanup() {
     echo -e "\n${YELLOW}Cleaning up...${NC}"
-    if [ -n "$IOS_SIM_UDID" ]; then
-        echo "Erasing iOS simulator $IOS_SIM_UDID"
-        xcrun simctl shutdown "$IOS_SIM_UDID" 2>/dev/null || true
-        xcrun simctl erase "$IOS_SIM_UDID" 2>/dev/null || true
-    fi
+    ios_cleanup
     if [ "$CI_MODE" = true ]; then
         local pid
         for pid in "$WEB_PID" "$MARKETPLACE_PID" "$API_PID"; do
@@ -163,97 +163,6 @@ start_bun_service() {
     ( cd "$REPO_ROOT/$service_dir" && exec bun run start ) &
 }
 
-extract_ios_simulator_destination() {
-    local destination_line="$1"
-    local destination_id="${destination_line#*id:}"
-    destination_id="${destination_id%%,*}"
-
-    if [ -z "$destination_id" ] || [[ "$destination_id" == dvtdevice-*placeholder* ]]; then
-        return 1
-    fi
-
-    # Including arch prevents xcodebuild from warning about multiple matching destinations
-    # when the same simulator ID appears for both arm64 and x86_64.
-    local arch
-    arch="$(extract_ios_simulator_field "$destination_line" "arch" || true)"
-    if [ -n "$arch" ]; then
-        printf 'platform=iOS Simulator,arch=%s,id=%s' "$arch" "$destination_id"
-    else
-        printf 'platform=iOS Simulator,id=%s' "$destination_id"
-    fi
-}
-
-extract_ios_simulator_field() {
-    local destination_line="$1"
-    local field_name="$2"
-    local field_value="${destination_line#*${field_name}:}"
-
-    if [ "$field_value" = "$destination_line" ]; then
-        return 1
-    fi
-
-    field_value="${field_value%%,*}"
-    field_value="${field_value% \}}"
-    printf '%s' "$field_value"
-}
-
-find_ios_simulator_destination() {
-    local destinations_output="$1"
-    local preferred_device_name="${2:-}"
-    local preferred_os_version="${3:-}"
-    local destination_line
-    local resolved_destination
-
-    while IFS= read -r destination_line; do
-        if [[ "$destination_line" != *"platform:iOS Simulator"* ]]; then
-            continue
-        fi
-
-        if [ -n "$preferred_device_name" ] &&
-            [ "$(extract_ios_simulator_field "$destination_line" "name" || true)" != "$preferred_device_name" ]; then
-            continue
-        fi
-
-        if [ -n "$preferred_os_version" ] &&
-            [ "$(extract_ios_simulator_field "$destination_line" "OS" || true)" != "$preferred_os_version" ]; then
-            continue
-        fi
-
-        resolved_destination="$(extract_ios_simulator_destination "$destination_line" || true)"
-        if [ -n "$resolved_destination" ]; then
-            printf '%s' "$resolved_destination"
-            return 0
-        fi
-    done <<< "$destinations_output"
-
-    return 1
-}
-
-resolve_ios_simulator_destination() {
-    if [ -n "${IOS_SIMULATOR_DESTINATION:-}" ]; then
-        printf '%s' "$IOS_SIMULATOR_DESTINATION"
-        return 0
-    fi
-
-    local preferred_device_name="${IOS_SIMULATOR_DEVICE_NAME:-iPhone 17}"
-    local preferred_os_version="${IOS_SIMULATOR_OS_VERSION:-26.5}"
-    local destinations_output
-    local resolved_destination
-    if ! destinations_output="$(xcodebuild -showdestinations -project evy.xcodeproj -scheme evy 2>/dev/null)"; then
-        return 1
-    fi
-
-    resolved_destination="$(find_ios_simulator_destination "$destinations_output" "$preferred_device_name" "$preferred_os_version" ||
-        find_ios_simulator_destination "$destinations_output" "$preferred_device_name" ||
-        find_ios_simulator_destination "$destinations_output" || true)"
-    if [ -n "$resolved_destination" ]; then
-        printf '%s' "$resolved_destination"
-        return 0
-    fi
-
-    return 1
-}
-
 seed_database() {
     if ! bun db:seed; then
         echo -e "${RED}Database seeding failed${NC}"
@@ -284,6 +193,22 @@ bun install --cwd api
 bun install --cwd web
 bun install --cwd services/marketplace
 
+if [ "$SKIP_IOS" = false ]; then
+    echo -e "\n${YELLOW}Resolving iOS simulators and starting build-for-testing in background...${NC}"
+    if ! ios_resolve_simulators; then
+        echo -e "${RED}Unable to resolve an available iOS simulator destination${NC}"
+        echo "Available destinations:"
+        (cd "$REPO_ROOT/ios" && xcodebuild -showdestinations -project evy.xcodeproj -scheme evy) || true
+        IOS_RESULT=1
+        SKIP_IOS=true
+    else
+        (
+            ios_build_for_testing
+        ) >"$REPO_ROOT/ios-e2e-build.log" 2>&1 &
+        IOS_BUILD_PID=$!
+    fi
+fi
+
 if [ "$CI_MODE" = true ]; then
     echo -e "\n${YELLOW}Starting services with Bun (CI mode)...${NC}"
     wait_for_postgres
@@ -295,6 +220,8 @@ if [ "$CI_MODE" = true ]; then
     start_bun_service api
     API_PID=$!
     wait_for_service_readiness api api "health" "API"
+
+    ios_start_stack_b_background
 
     start_bun_service web
     WEB_PID=$!
@@ -356,42 +283,22 @@ fi
 cd ..
 
 if [ "$SKIP_IOS" = true ]; then
-    echo -e "\n${YELLOW}Skipping iOS e2e tests (--skip-ios flag set)${NC}"
-    IOS_SKIPPED=true
+    if [ "$SKIP_IOS_REQUESTED" = true ]; then
+        echo -e "\n${YELLOW}Skipping iOS e2e tests (--skip-ios flag set)${NC}"
+        IOS_SKIPPED=true
+    else
+        echo -e "\n${RED}Skipping iOS e2e tests due to simulator resolution failure${NC}"
+    fi
 else
     echo -e "\n${YELLOW}Running iOS e2e tests...${NC}"
     echo -e "${GREEN}GOOGLE_PLACES_MOCK=true; place search uses API fixtures (no live Google calls)${NC}"
     seed_database
-    cd ios
-    IOS_DESTINATION="$(resolve_ios_simulator_destination)"
-    if [ -z "$IOS_DESTINATION" ]; then
-        echo -e "${RED}Unable to resolve an available iOS simulator destination${NC}"
-        echo "Available destinations:"
-        xcodebuild -showdestinations -project evy.xcodeproj -scheme evy || true
-        IOS_RESULT=1
+    if ios_run_e2e; then
+        echo -e "${GREEN}iOS e2e tests passed${NC}"
     else
-        echo "Using iOS simulator destination: $IOS_DESTINATION"
-        # Clean simulator to prevent stale data (e.g. SwiftData schema) from crashing the app
-        IOS_SIM_UDID="${IOS_DESTINATION#*id=}"
-        xcrun simctl shutdown "$IOS_SIM_UDID" 2>/dev/null || true
-        xcrun simctl erase "$IOS_SIM_UDID" 2>/dev/null || true
-        # Drop the harmless "IDELaunchParametersSnapshot ... no debugger version"
-        # noise xcodebuild emits on every app launch. sed (not grep -v) so an
-        # all-noise stream isn't a failure; pipefail keeps xcodebuild's status.
-        if (set -o pipefail; xcodebuild test \
-            -project evy.xcodeproj \
-            -scheme evy \
-            -destination "$IOS_DESTINATION" \
-            -only-testing:evyUITests \
-            -parallel-testing-enabled NO \
-            -quiet 2>&1 | sed '/IDELaunchParametersSnapshot/d'); then
-            echo -e "${GREEN}iOS e2e tests passed${NC}"
-        else
-            echo -e "${RED}iOS e2e tests failed${NC}"
-            IOS_RESULT=1
-        fi
+        echo -e "${RED}iOS e2e tests failed${NC}"
+        IOS_RESULT=1
     fi
-    cd ..
 fi
 
 echo -e "\n${YELLOW}========================================${NC}"

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -375,13 +375,16 @@ else
         IOS_SIM_UDID="${IOS_DESTINATION#*id=}"
         xcrun simctl shutdown "$IOS_SIM_UDID" 2>/dev/null || true
         xcrun simctl erase "$IOS_SIM_UDID" 2>/dev/null || true
-        if xcodebuild test \
+        # Drop the harmless "IDELaunchParametersSnapshot ... no debugger version"
+        # noise xcodebuild emits on every app launch. sed (not grep -v) so an
+        # all-noise stream isn't a failure; pipefail keeps xcodebuild's status.
+        if (set -o pipefail; xcodebuild test \
             -project evy.xcodeproj \
             -scheme evy \
             -destination "$IOS_DESTINATION" \
             -only-testing:evyUITests \
             -parallel-testing-enabled NO \
-            -quiet; then
+            -quiet 2>&1 | sed '/IDELaunchParametersSnapshot/d'); then
             echo -e "${GREEN}iOS e2e tests passed${NC}"
         else
             echo -e "${RED}iOS e2e tests failed${NC}"

--- a/scripts/run-ios-e2e.sh
+++ b/scripts/run-ios-e2e.sh
@@ -224,6 +224,17 @@ ios_resolve_simulators() {
 	return 0
 }
 
+ios_locate_xctestrun() {
+	local found
+	found="$(ls "$REPO_ROOT/ios/DerivedData-e2e/Build/Products/"evy_*.xctestrun 2>/dev/null | head -n 1)"
+	if [ -z "$found" ] || [ ! -f "$found" ]; then
+		echo -e "${RED}Unable to locate evy_*.xctestrun under ios/DerivedData-e2e/Build/Products${NC}"
+		return 1
+	fi
+	# Absolute path: background builds set vars in a subshell that the parent never sees.
+	IOS_XCTESTRUN="$(cd "$(dirname "$found")" && pwd)/$(basename "$found")"
+}
+
 ios_build_for_testing() {
 	echo "Building iOS e2e tests (build-for-testing)..."
 	cd "$REPO_ROOT/ios"
@@ -236,14 +247,8 @@ ios_build_for_testing() {
 		cd "$REPO_ROOT"
 		return 1
 	fi
-
-	IOS_XCTESTRUN="$(ls DerivedData-e2e/Build/Products/evy_*.xctestrun 2>/dev/null | head -n 1)"
-	if [ -z "$IOS_XCTESTRUN" ]; then
-		echo -e "${RED}Unable to locate evy_*.xctestrun under ios/DerivedData-e2e/Build/Products${NC}"
-		cd "$REPO_ROOT"
-		return 1
-	fi
 	cd "$REPO_ROOT"
+	ios_locate_xctestrun
 }
 
 ios_start_stack_b_service() {
@@ -269,20 +274,6 @@ ios_wait_for_stack_b_readiness() {
 		ios_stack_b_env
 		cd \"$REPO_ROOT/api\" && bun run health
 	"
-}
-
-ios_start_stack_b() {
-	if [ "$CI_MODE" != true ]; then
-		return 0
-	fi
-
-	echo "Starting stack B (API :${STACK_B_API_PORT}, marketplace WS :${STACK_B_MARKETPLACE_WS_PORT})..."
-	ios_create_stack_b_databases
-	ios_start_stack_b_service services/marketplace
-	MARKETPLACE_B_PID=$!
-	ios_start_stack_b_service api
-	API_B_PID=$!
-	ios_wait_for_stack_b_readiness
 }
 
 ios_seed_stack_b() {
@@ -314,8 +305,17 @@ ios_start_stack_b_background() {
 	if [ "$CI_MODE" != true ]; then
 		return 0
 	fi
+
+	# Start services in this shell so MARKETPLACE_B_PID / API_B_PID survive for cleanup.
+	# Only readiness + seeding run in the background subshell.
+	echo "Starting stack B (API :${STACK_B_API_PORT}, marketplace WS :${STACK_B_MARKETPLACE_WS_PORT})..."
+	ios_create_stack_b_databases
+	ios_start_stack_b_service services/marketplace
+	MARKETPLACE_B_PID=$!
+	ios_start_stack_b_service api
+	API_B_PID=$!
 	(
-		ios_start_stack_b && ios_seed_stack_b
+		ios_wait_for_stack_b_readiness && ios_seed_stack_b
 	) &
 	IOS_STACK_B_READY_PID=$!
 }
@@ -447,11 +447,20 @@ ios_run_e2e() {
 			[ -f "$REPO_ROOT/ios-e2e-build.log" ] && cat "$REPO_ROOT/ios-e2e-build.log"
 			return 1
 		fi
+		# Background build ran in a subshell; locate the xctestrun in this shell.
+		if ! ios_locate_xctestrun; then
+			return 1
+		fi
 	elif ! ios_build_for_testing; then
 		return 1
 	fi
 
 	if [ "$CI_MODE" = true ]; then
+		if [ -z "$IOS_XCTESTRUN" ] || [ ! -f "$IOS_XCTESTRUN" ]; then
+			echo -e "${RED}iOS xctestrun path is missing or invalid: '${IOS_XCTESTRUN}'${NC}"
+			return 1
+		fi
+		echo "Using xctestrun: $IOS_XCTESTRUN"
 		if ! ios_wait_for_stack_b_background; then
 			return 1
 		fi

--- a/scripts/run-ios-e2e.sh
+++ b/scripts/run-ios-e2e.sh
@@ -1,0 +1,499 @@
+#!/bin/bash
+# iOS e2e helpers — sourced by run-e2e.sh (shares env, colors, cleanup traps).
+
+IOS_SIM_NAME_B="iPhone 17 E2E-B"
+STACK_B_API_PORT=8010
+STACK_B_MARKETPLACE_WS_PORT=8011
+
+IOS_SIM_UDID_A=""
+IOS_SIM_UDID_B=""
+IOS_DESTINATION_A=""
+IOS_DESTINATION_B=""
+IOS_XCTESTRUN=""
+API_B_PID=""
+MARKETPLACE_B_PID=""
+IOS_BUILD_PID=""
+IOS_STACK_B_READY_PID=""
+
+# Bucket A: WebSocketE2ETests, E2EHomeInboxTests, E2EPlaceSearchTests
+IOS_BUCKET_A_ONLY_TESTING=(
+	"evyUITests/WebSocketE2ETests"
+	"evyUITests/E2EHomeInboxTests"
+	"evyUITests/E2EPlaceSearchTests"
+)
+
+ios_stack_b_env() {
+	export API_PORT="${STACK_B_API_PORT}"
+	export API_HOST="localhost:${STACK_B_API_PORT}"
+	export API_URL="ws://localhost:${STACK_B_API_PORT}"
+	export MARKETPLACE_WS_HOST="127.0.0.1"
+	export MARKETPLACE_WS_PORT="${STACK_B_MARKETPLACE_WS_PORT}"
+	export DB_EVY_DATABASE="evy_b"
+	export DB_MARKETPLACE_DATABASE="marketplace_b"
+}
+
+extract_ios_simulator_destination() {
+	local destination_line="$1"
+	local destination_id="${destination_line#*id:}"
+	destination_id="${destination_id%%,*}"
+
+	if [ -z "$destination_id" ] || [[ "$destination_id" == dvtdevice-*placeholder* ]]; then
+		return 1
+	fi
+
+	local arch
+	arch="$(extract_ios_simulator_field "$destination_line" "arch" || true)"
+	if [ -n "$arch" ]; then
+		printf 'platform=iOS Simulator,arch=%s,id=%s' "$arch" "$destination_id"
+	else
+		printf 'platform=iOS Simulator,id=%s' "$destination_id"
+	fi
+}
+
+extract_ios_simulator_field() {
+	local destination_line="$1"
+	local field_name="$2"
+	local field_value="${destination_line#*${field_name}:}"
+
+	if [ "$field_value" = "$destination_line" ]; then
+		return 1
+	fi
+
+	field_value="${field_value%%,*}"
+	field_value="${field_value% \}}"
+	printf '%s' "$field_value"
+}
+
+find_ios_simulator_destination() {
+	local destinations_output="$1"
+	local preferred_device_name="${2:-}"
+	local preferred_os_version="${3:-}"
+	local destination_line
+	local resolved_destination
+
+	while IFS= read -r destination_line; do
+		if [[ "$destination_line" != *"platform:iOS Simulator"* ]]; then
+			continue
+		fi
+
+		if [ -n "$preferred_device_name" ] &&
+			[ "$(extract_ios_simulator_field "$destination_line" "name" || true)" != "$preferred_device_name" ]; then
+			continue
+		fi
+
+		if [ -n "$preferred_os_version" ] &&
+			[ "$(extract_ios_simulator_field "$destination_line" "OS" || true)" != "$preferred_os_version" ]; then
+			continue
+		fi
+
+		resolved_destination="$(extract_ios_simulator_destination "$destination_line" || true)"
+		if [ -n "$resolved_destination" ]; then
+			printf '%s' "$resolved_destination"
+			return 0
+		fi
+	done <<< "$destinations_output"
+
+	return 1
+}
+
+resolve_ios_simulator_destination() {
+	if [ -n "${IOS_SIMULATOR_DESTINATION:-}" ]; then
+		printf '%s' "$IOS_SIMULATOR_DESTINATION"
+		return 0
+	fi
+
+	local preferred_device_name="${IOS_SIMULATOR_DEVICE_NAME:-iPhone 17}"
+	local preferred_os_version="${IOS_SIMULATOR_OS_VERSION:-26.5}"
+	local destinations_output
+	local resolved_destination
+	if ! destinations_output="$(xcodebuild -showdestinations -project evy.xcodeproj -scheme evy 2>/dev/null)"; then
+		return 1
+	fi
+
+	resolved_destination="$(find_ios_simulator_destination "$destinations_output" "$preferred_device_name" "$preferred_os_version" ||
+		find_ios_simulator_destination "$destinations_output" "$preferred_device_name" ||
+		find_ios_simulator_destination "$destinations_output" || true)"
+	if [ -n "$resolved_destination" ]; then
+		printf '%s' "$resolved_destination"
+		return 0
+	fi
+
+	return 1
+}
+
+ios_simulator_udid_from_destination() {
+	local destination="$1"
+	printf '%s' "${destination#*id=}"
+}
+
+ios_lookup_simulator_udid_by_name() {
+	local simulator_name="$1"
+	python3 -c '
+import json, sys
+name = sys.argv[1]
+devices = json.load(sys.stdin).get("devices", {})
+for runtime_devices in devices.values():
+    for device in runtime_devices:
+        if device.get("name") == name and device.get("isAvailable", True):
+            print(device["udid"])
+            raise SystemExit(0)
+raise SystemExit(1)
+' "$simulator_name" < <(xcrun simctl list -j devices available)
+}
+
+ios_create_simulator_b() {
+	local preferred_device_name="${IOS_SIMULATOR_DEVICE_NAME:-iPhone 17}"
+	local preferred_os_version="${IOS_SIMULATOR_OS_VERSION:-26.5}"
+	local device_type_id runtime_id
+
+	device_type_id="$(python3 -c '
+import json, sys
+name = sys.argv[1]
+for device_type in json.load(sys.stdin).get("devicetypes", []):
+    if device_type.get("name") == name:
+        print(device_type["identifier"])
+        raise SystemExit(0)
+raise SystemExit(1)
+' "$preferred_device_name" < <(xcrun simctl list -j devicetypes))" || return 1
+
+	runtime_id="$(python3 -c '
+import json, sys
+version = sys.argv[1]
+for runtime in json.load(sys.stdin).get("runtimes", []):
+    if runtime.get("version") == version and runtime.get("isAvailable", True):
+        print(runtime["identifier"])
+        raise SystemExit(0)
+raise SystemExit(1)
+' "$preferred_os_version" < <(xcrun simctl list -j runtimes))" || return 1
+
+	xcrun simctl create "$IOS_SIM_NAME_B" "$device_type_id" "$runtime_id"
+}
+
+ios_destination_for_udid() {
+	local udid="$1"
+	local destinations_output
+	local destination_line
+	local resolved_destination
+
+	if ! destinations_output="$(xcodebuild -showdestinations -project evy.xcodeproj -scheme evy 2>/dev/null)"; then
+		return 1
+	fi
+
+	while IFS= read -r destination_line; do
+		if [[ "$destination_line" != *"platform:iOS Simulator"* ]] ||
+			[[ "$destination_line" != *"id:$udid"* ]]; then
+			continue
+		fi
+		resolved_destination="$(extract_ios_simulator_destination "$destination_line" || true)"
+		if [ -n "$resolved_destination" ]; then
+			printf '%s' "$resolved_destination"
+			return 0
+		fi
+	done <<< "$destinations_output"
+
+	printf 'platform=iOS Simulator,id=%s' "$udid"
+}
+
+ios_resolve_simulators() {
+	local preferred_device_name="${IOS_SIMULATOR_DEVICE_NAME:-iPhone 17}"
+
+	cd "$REPO_ROOT/ios"
+	IOS_DESTINATION_A="$(resolve_ios_simulator_destination)"
+	if [ -z "$IOS_DESTINATION_A" ]; then
+		cd "$REPO_ROOT"
+		return 1
+	fi
+	IOS_SIM_UDID_A="$(ios_simulator_udid_from_destination "$IOS_DESTINATION_A")"
+
+	if [ "$CI_MODE" != true ]; then
+		IOS_SIM_UDID="$IOS_SIM_UDID_A"
+		cd "$REPO_ROOT"
+		return 0
+	fi
+
+	if ! IOS_SIM_UDID_B="$(ios_lookup_simulator_udid_by_name "$IOS_SIM_NAME_B" 2>/dev/null)"; then
+		echo "Creating iOS simulator B: $IOS_SIM_NAME_B ($preferred_device_name)"
+		IOS_SIM_UDID_B="$(ios_create_simulator_b)" || {
+			cd "$REPO_ROOT"
+			return 1
+		}
+	fi
+
+	IOS_DESTINATION_B="$(ios_destination_for_udid "$IOS_SIM_UDID_B")"
+	cd "$REPO_ROOT"
+	return 0
+}
+
+ios_build_for_testing() {
+	echo "Building iOS e2e tests (build-for-testing)..."
+	cd "$REPO_ROOT/ios"
+	if ! xcodebuild build-for-testing \
+		-project evy.xcodeproj \
+		-scheme evy \
+		-destination "$IOS_DESTINATION_A" \
+		-derivedDataPath DerivedData-e2e \
+		-quiet; then
+		cd "$REPO_ROOT"
+		return 1
+	fi
+
+	IOS_XCTESTRUN="$(ls DerivedData-e2e/Build/Products/evy_*.xctestrun 2>/dev/null | head -n 1)"
+	if [ -z "$IOS_XCTESTRUN" ]; then
+		echo -e "${RED}Unable to locate evy_*.xctestrun under ios/DerivedData-e2e/Build/Products${NC}"
+		cd "$REPO_ROOT"
+		return 1
+	fi
+	cd "$REPO_ROOT"
+}
+
+ios_start_stack_b_service() {
+	local service_dir="$1"
+	(
+		ios_stack_b_env
+		cd "$REPO_ROOT/$service_dir"
+		exec bun run start
+	) &
+}
+
+ios_create_stack_b_databases() {
+	createdb -h "$DB_DOMAIN" -p "$DB_PORT" -U "$DB_USER" evy_b 2>/dev/null || true
+	createdb -h "$DB_DOMAIN" -p "$DB_PORT" -U "$DB_USER" marketplace_b 2>/dev/null || true
+}
+
+ios_wait_for_stack_b_readiness() {
+	retry_until_cmd "stack-B Marketplace" bash -c "
+		ios_stack_b_env
+		cd \"$REPO_ROOT/services/marketplace\" && bun run health
+	"
+	retry_until_cmd "stack-B API" bash -c "
+		ios_stack_b_env
+		cd \"$REPO_ROOT/api\" && bun run health
+	"
+}
+
+ios_start_stack_b() {
+	if [ "$CI_MODE" != true ]; then
+		return 0
+	fi
+
+	echo "Starting stack B (API :${STACK_B_API_PORT}, marketplace WS :${STACK_B_MARKETPLACE_WS_PORT})..."
+	ios_create_stack_b_databases
+	ios_start_stack_b_service services/marketplace
+	MARKETPLACE_B_PID=$!
+	ios_start_stack_b_service api
+	API_B_PID=$!
+	ios_wait_for_stack_b_readiness
+}
+
+ios_seed_stack_b() {
+	if [ "$CI_MODE" != true ]; then
+		return 0
+	fi
+
+	echo "Seeding stack B databases..."
+	if ! (
+		ios_stack_b_env
+		cd "$REPO_ROOT"
+		bun db:seed
+	); then
+		echo -e "${RED}Stack B database seeding failed${NC}"
+		return 1
+	fi
+
+	retry_until_cmd "stack-B seeded API data" bash -c "
+		ios_stack_b_env
+		cd \"$REPO_ROOT/api\" && bun run health:seeded
+	"
+	retry_until_cmd "stack-B seeded marketplace data" bash -c "
+		ios_stack_b_env
+		cd \"$REPO_ROOT/services/marketplace\" && bun run health:seeded
+	"
+}
+
+ios_start_stack_b_background() {
+	if [ "$CI_MODE" != true ]; then
+		return 0
+	fi
+	(
+		ios_start_stack_b && ios_seed_stack_b
+	) &
+	IOS_STACK_B_READY_PID=$!
+}
+
+ios_wait_for_stack_b_background() {
+	if [ "$CI_MODE" != true ] || [ -z "$IOS_STACK_B_READY_PID" ]; then
+		return 0
+	fi
+	if ! wait "$IOS_STACK_B_READY_PID"; then
+		echo -e "${RED}Stack B startup or seeding failed${NC}"
+		return 1
+	fi
+}
+
+ios_erase_simulator() {
+	local udid="$1"
+	xcrun simctl shutdown "$udid" 2>/dev/null || true
+	xcrun simctl erase "$udid" 2>/dev/null || true
+}
+
+ios_xcodebuild_test_args() {
+	local bucket_label="$1"
+	local destination="$2"
+	local api_host="$3"
+	local result_bundle="$4"
+	local log_file="$5"
+	shift 5
+	local -a test_filters=("$@")
+	local -a cmd=(
+		xcodebuild test-without-building
+		-xctestrun "$IOS_XCTESTRUN"
+		-destination "$destination"
+		-parallel-testing-enabled NO
+		-resultBundlePath "$result_bundle"
+		-quiet
+	)
+	local filter
+	for filter in "${test_filters[@]}"; do
+		cmd+=("$filter")
+	done
+	(
+		cd "$REPO_ROOT/ios"
+		TEST_RUNNER_API_HOST="$api_host" "${cmd[@]}"
+	) >"$log_file" 2>&1
+	local status=$?
+	if [ "$status" -ne 0 ]; then
+		echo -e "${RED}iOS e2e bucket ${bucket_label} failed (see ${log_file})${NC}"
+		cat "$log_file"
+	fi
+	return "$status"
+}
+
+ios_run_tests_parallel() {
+	local -a bucket_a_filters=()
+	local -a bucket_b_filters=()
+	local filter
+	for filter in "${IOS_BUCKET_A_ONLY_TESTING[@]}"; do
+		bucket_a_filters+=("-only-testing:${filter}")
+		bucket_b_filters+=("-skip-testing:${filter}")
+	done
+
+	rm -f "$REPO_ROOT/ios-e2e-A.log" "$REPO_ROOT/ios-e2e-B.log"
+	rm -rf "$REPO_ROOT/ios/TestResults-A.xcresult" "$REPO_ROOT/ios/TestResults-B.xcresult"
+
+	ios_erase_simulator "$IOS_SIM_UDID_A"
+	ios_erase_simulator "$IOS_SIM_UDID_B"
+
+	local bucket_a_status=0 bucket_b_status=0
+
+	ios_xcodebuild_test_args \
+		"A" \
+		"$IOS_DESTINATION_A" \
+		"127.0.0.1:${API_PORT}" \
+		"TestResults-A.xcresult" \
+		"$REPO_ROOT/ios-e2e-A.log" \
+		"${bucket_a_filters[@]}" &
+	local pid_a=$!
+
+	# Stagger simulator B slightly to reduce launch-timeout flakiness on CI.
+	sleep 10
+
+	ios_xcodebuild_test_args \
+		"B" \
+		"$IOS_DESTINATION_B" \
+		"127.0.0.1:${STACK_B_API_PORT}" \
+		"TestResults-B.xcresult" \
+		"$REPO_ROOT/ios-e2e-B.log" \
+		"${bucket_b_filters[@]}" &
+	local pid_b=$!
+
+	wait "$pid_a" || bucket_a_status=$?
+	wait "$pid_b" || bucket_b_status=$?
+
+	if [ "$bucket_a_status" -ne 0 ] || [ "$bucket_b_status" -ne 0 ]; then
+		return 1
+	fi
+	return 0
+}
+
+ios_run_tests_sequential() {
+	cd "$REPO_ROOT/ios"
+	ios_erase_simulator "$IOS_SIM_UDID_A"
+	if (set -o pipefail; TEST_RUNNER_API_HOST="127.0.0.1:${API_PORT}" xcodebuild test \
+		-project evy.xcodeproj \
+		-scheme evy \
+		-destination "$IOS_DESTINATION_A" \
+		-only-testing:evyUITests \
+		-parallel-testing-enabled NO \
+		-quiet 2>&1 | sed '/IDELaunchParametersSnapshot/d'); then
+		cd "$REPO_ROOT"
+		return 0
+	fi
+	cd "$REPO_ROOT"
+	return 1
+}
+
+ios_run_e2e() {
+	if ! ios_resolve_simulators; then
+		echo -e "${RED}Unable to resolve an available iOS simulator destination${NC}"
+		echo "Available destinations:"
+		(cd "$REPO_ROOT/ios" && xcodebuild -showdestinations -project evy.xcodeproj -scheme evy) || true
+		return 1
+	fi
+
+	if [ -n "$IOS_BUILD_PID" ]; then
+		echo "Waiting for background iOS build-for-testing..."
+		if ! wait "$IOS_BUILD_PID"; then
+			echo -e "${RED}iOS build-for-testing failed${NC}"
+			[ -f "$REPO_ROOT/ios-e2e-build.log" ] && cat "$REPO_ROOT/ios-e2e-build.log"
+			return 1
+		fi
+	elif ! ios_build_for_testing; then
+		return 1
+	fi
+
+	if [ "$CI_MODE" = true ]; then
+		if ! ios_wait_for_stack_b_background; then
+			return 1
+		fi
+		echo "Using iOS simulator A: $IOS_DESTINATION_A"
+		echo "Using iOS simulator B: $IOS_DESTINATION_B"
+		if ios_run_tests_parallel; then
+			return 0
+		fi
+		return 1
+	fi
+
+	echo "Using iOS simulator destination: $IOS_DESTINATION_A"
+	if ios_run_tests_sequential; then
+		return 0
+	fi
+	return 1
+}
+
+ios_cleanup() {
+	if [ -n "$IOS_BUILD_PID" ]; then
+		kill "$IOS_BUILD_PID" 2>/dev/null || true
+		wait "$IOS_BUILD_PID" 2>/dev/null || true
+	fi
+	if [ -n "$IOS_STACK_B_READY_PID" ]; then
+		kill "$IOS_STACK_B_READY_PID" 2>/dev/null || true
+		wait "$IOS_STACK_B_READY_PID" 2>/dev/null || true
+	fi
+	if [ "$CI_MODE" = true ]; then
+		local pid
+		for pid in "$MARKETPLACE_B_PID" "$API_B_PID"; do
+			[ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+		done
+		for pid in "$MARKETPLACE_B_PID" "$API_B_PID"; do
+			[ -n "$pid" ] && wait "$pid" 2>/dev/null || true
+		done
+	fi
+	if [ -n "$IOS_SIM_UDID_A" ]; then
+		echo "Erasing iOS simulator A $IOS_SIM_UDID_A"
+		ios_erase_simulator "$IOS_SIM_UDID_A"
+	fi
+	if [ -n "$IOS_SIM_UDID_B" ]; then
+		echo "Erasing iOS simulator B $IOS_SIM_UDID_B"
+		ios_erase_simulator "$IOS_SIM_UDID_B"
+	fi
+}


### PR DESCRIPTION
## Summary

Speeds up the iOS e2e suite and makes failures easier to debug. On CI the tests now run in parallel across two simulators, each backed by an isolated service stack, and the `build-for-testing` step runs in the background while the services boot. The iOS runner helpers are extracted from `run-e2e.sh` into a new sourced script, and the WebSocket request tests moved into their own file.

## Major changes

- **`scripts/run-ios-e2e.sh` (new)**: iOS e2e helpers sourced by `run-e2e.sh`. Adds a second simulator ("iPhone 17 E2E-B", auto-created when missing) and a second isolated stack (API on port 8010, marketplace WS on port 8011, separate `evy_b` / `marketplace_b` databases). CI splits the suite into two buckets (bucket A: `WebSocketE2ETests`, `E2EHomeInboxTests`, `E2EPlaceSearchTests`) and runs them concurrently via `test-without-building` with the prebuilt `.xctestrun`, staggering simulator B to reduce launch-timeout flakiness. Local runs keep the previous single-simulator sequential flow.
- **`run-e2e.sh`**: sources the new script, starts the iOS `build-for-testing` in the background while services start, distinguishes a user-requested `--skip-ios` from a simulator-resolution failure, and delegates the iOS run/cleanup to the helpers.
- **`ios/e2e/e2e.swift`**: adds reusable helpers to `E2ETestBase` (`seedIsolatedFlows`, `openViewItemPage`, `createHomeFlowData`, `viewItemNavigateAction`) and relaxes previously `private` fixtures so they can be shared across test classes.
- **`ios/e2e/e2eRequests.swift` (new)**: `WebSocketRequestE2ETests` extracted from `e2e.swift` — marketplace request flows over WebSocket (timeslot pickup requests and confirmation sheets), using `TEST_RUNNER_API_HOST` to target the correct stack.
- **`.github/workflows/e2e_tests.yml`**: triggers on changes to `scripts/run-ios-e2e.sh` and uploads `ios/TestResults-*.xcresult` plus `ios-e2e-*.log` as CI artifacts.
- **`ios/evy.xcodeproj/project.pbxproj`**: adds `e2eRequests.swift` to the `evyUITests` target.
- **`ios/.gitignore`**: ignores `DerivedData-e2e/` and `TestResults-*.xcresult`.

## Tests

- The full e2e suite (web + iOS) runs on PRs via `.github/workflows/e2e_tests.yml`, now with parallel iOS buckets and uploaded `.xcresult`/log artifacts for debugging.

## Risks / suggestions

- The parallel CI run needs a second iOS simulator and free ports 8010/8011 plus the `evy_b` / `marketplace_b` databases; failures there now fail the iOS e2e step with the build/run logs surfaced.
- Parallel runs can surface test isolation issues that the old sequential run masked — the staggered start and per-bucket logs are meant to make any such failures diagnosable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EVY-Platform/codesmith/evy/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788087958&installation_model_id=19950&pr_number=246&repository=EVY-Platform%2Fevy&return_to=https%3A%2F%2Fgithub.com%2FEVY-Platform%2Fevy%2Fpull%2F246&signature=1fde613d96acc0c1ba12debaaa2e975f947f451d349d7b480ee564f80115c85b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->